### PR TITLE
Use HTTPS instead of SSH for mobilecoin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mobilecoin"]
 	path = mobilecoin
-	url = git@github.com:mobilecoinfoundation/mobilecoin.git
+	url = https://github.com/mobilecoinfoundation/mobilecoin.git


### PR DESCRIPTION
This is generally the convention for repos that are publicly available since it allows connecting via both https basic credential auth and ssh private key auth.