### PR TITLE
WS-13 Enum strs

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -5,7 +5,10 @@
 use crate::{
     db::{
         assigned_subaddress::AssignedSubaddressModel,
-        models::{Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo},
+        models::{
+            Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo,
+            TXO_SPENT,
+        },
         transaction_log::TransactionLogModel,
     },
     error::WalletDbError,
@@ -265,7 +268,8 @@ impl AccountModel for Account {
                         account_txo_statuses.find((&self.account_id_hex, &matches[0].txo_id_hex)),
                     )
                     .set(
-                        crate::db::schema::account_txo_statuses::txo_status.eq("spent".to_string()),
+                        crate::db::schema::account_txo_statuses::txo_status
+                            .eq(TXO_SPENT.to_string()),
                     )
                     .execute(conn)?;
 

--- a/full-service/src/db/account_txo_status.rs
+++ b/full-service/src/db/account_txo_status.rs
@@ -3,7 +3,7 @@
 //! DB impl for the AccountTxoStatus model.
 
 use crate::{
-    db::models::{AccountTxoStatus, NewAccountTxoStatus},
+    db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_UNSPENT},
     error::WalletDbError,
 };
 
@@ -85,7 +85,7 @@ impl AccountTxoStatusModel for AccountTxoStatus {
         use crate::db::schema::account_txo_statuses::txo_status;
 
         diesel::update(self)
-            .set(txo_status.eq("unspent"))
+            .set(txo_status.eq(TXO_UNSPENT))
             .execute(conn)?;
         Ok(())
     }

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -9,6 +9,34 @@ use super::schema::{
 
 use serde::Serialize;
 
+// FIXME: WS-13 - Would be great to get enums to work. Run into several issues when attempting
+//        to use https://github.com/adwhit/diesel-derive-enum for sqlite
+// TxoStatus
+pub const TXO_UNSPENT: &str = "unspent";
+pub const TXO_PENDING: &str = "pending";
+pub const TXO_SPENT: &str = "spent";
+pub const TXO_SECRETED: &str = "secreted";
+pub const TXO_ORPHANED: &str = "orphaned";
+
+// TxoType
+pub const TXO_MINTED: &str = "minted";
+pub const TXO_RECEIVED: &str = "received";
+
+// TransactionStatus
+pub const TX_BUILT: &str = "built";
+pub const TX_PENDING: &str = "pending";
+pub const TX_SUCCEEDED: &str = "succeeded";
+pub const TX_FAILED: &str = "failed";
+
+// Transaction Direction
+pub const TX_DIR_SENT: &str = "sent";
+pub const TX_DIR_RECEIVED: &str = "received";
+
+// Transaction Txo Type
+pub const INPUT: &str = "input";
+pub const OUTPUT: &str = "output";
+pub const CHANGE: &str = "change";
+
 #[derive(Clone, Serialize, Identifiable, Queryable, PartialEq, Debug)]
 #[primary_key(id)]
 pub struct Account {

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -7,7 +7,8 @@ use crate::{
         b58_encode,
         models::{
             Account, NewTransactionLog, NewTransactionTxoType, TransactionLog, TransactionTxoType,
-            Txo,
+            Txo, CHANGE, INPUT, OUTPUT, TX_BUILT, TX_DIR_RECEIVED, TX_DIR_SENT, TX_FAILED,
+            TX_PENDING, TX_SUCCEEDED,
         },
         txo::{TxoID, TxoModel},
     },
@@ -170,9 +171,9 @@ impl TransactionLogModel for TransactionLog {
 
         for (_transaction, transaction_txo_type) in transaction_txos {
             match transaction_txo_type.transaction_txo_type.as_str() {
-                "input" => inputs.push(transaction_txo_type.txo_id_hex),
-                "output" => outputs.push(transaction_txo_type.txo_id_hex),
-                "change" => change.push(transaction_txo_type.txo_id_hex),
+                INPUT => inputs.push(transaction_txo_type.txo_id_hex),
+                OUTPUT => outputs.push(transaction_txo_type.txo_id_hex),
+                CHANGE => change.push(transaction_txo_type.txo_id_hex),
                 _ => {
                     return Err(WalletDbError::UnexpectedTransactionTxoType(
                         transaction_txo_type.transaction_txo_type,
@@ -254,9 +255,9 @@ impl TransactionLogModel for TransactionLog {
             }
 
             match transaction_txo_type.transaction_txo_type.as_str() {
-                "input" => entry.inputs.push(transaction_txo_type.txo_id_hex),
-                "output" => entry.outputs.push(transaction_txo_type.txo_id_hex),
-                "change" => entry.change.push(transaction_txo_type.txo_id_hex),
+                INPUT => entry.inputs.push(transaction_txo_type.txo_id_hex),
+                OUTPUT => entry.outputs.push(transaction_txo_type.txo_id_hex),
+                CHANGE => entry.change.push(transaction_txo_type.txo_id_hex),
                 _ => {
                     return Err(WalletDbError::UnexpectedTransactionTxoType(
                         transaction_txo_type.transaction_txo_type,
@@ -294,8 +295,8 @@ impl TransactionLogModel for TransactionLog {
             for transaction_log in associated_transaction_logs {
                 let associated = transaction_log.get_associated_txos(conn)?;
 
-                // Only update transaction_log status if proposed or pending
-                if transaction_log.status != "proposed" && transaction_log.status != "pending" {
+                // Only update transaction_log status if built or pending
+                if transaction_log.status != TX_BUILT && transaction_log.status != TX_PENDING {
                     continue;
                 }
 
@@ -307,7 +308,7 @@ impl TransactionLogModel for TransactionLog {
                             .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
                     )
                     .set((
-                        crate::db::schema::transaction_logs::status.eq("succeeded"),
+                        crate::db::schema::transaction_logs::status.eq(TX_SUCCEEDED),
                         crate::db::schema::transaction_logs::block_height.eq(cur_block_height),
                     ))
                     .execute(conn)?;
@@ -317,7 +318,7 @@ impl TransactionLogModel for TransactionLog {
                         transaction_logs
                             .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
                     )
-                    .set(crate::db::schema::transaction_logs::status.eq("failed"))
+                    .set(crate::db::schema::transaction_logs::status.eq(TX_FAILED))
                     .execute(conn)?;
                 }
             }
@@ -365,11 +366,11 @@ impl TransactionLogModel for TransactionLog {
                         assigned_subaddress_b58: &b58_subaddress,
                         value: txo.value,
                         fee: None, // Impossible to recover fee from received transaction
-                        status: "succeeded",
+                        status: TX_SUCCEEDED,
                         sent_time: None, // NULL for received
                         block_height: block_height as i64,
                         comment: "", // NULL for received
-                        direction: "received",
+                        direction: TX_DIR_RECEIVED,
                         tx: None, // NULL for received
                     };
 
@@ -381,7 +382,7 @@ impl TransactionLogModel for TransactionLog {
                     let new_transaction_txo = NewTransactionTxoType {
                         transaction_id_hex: &transaction_id.to_string(),
                         txo_id_hex: &txo.txo_id_hex,
-                        transaction_txo_type: "output",
+                        transaction_txo_type: OUTPUT,
                     };
                     // Note: SQLite backend does not support batch insert, so within iter is fine
                     diesel::insert_into(transaction_txo_types::table)
@@ -415,7 +416,7 @@ impl TransactionLogModel for TransactionLog {
             for utxo in tx_proposal.utxos.iter() {
                 let txo_id = TxoID::from(&utxo.tx_out);
                 Txo::update_to_pending(&txo_id, conn)?;
-                txo_ids.push((txo_id.to_string(), "input".to_string()));
+                txo_ids.push((txo_id.to_string(), INPUT.to_string()));
             }
 
             // Next, add all of our minted outputs to the Txo Table
@@ -460,13 +461,13 @@ impl TransactionLogModel for TransactionLog {
                     assigned_subaddress_b58: "", // NULL for sent
                     value: transaction_value as i64,
                     fee: Some(tx_proposal.tx.prefix.fee as i64),
-                    status: "pending",
+                    status: TX_PENDING,
                     sent_time: Some(Utc::now().timestamp()),
                     block_height: block_height as i64, // FIXME: WS-18 - is this going to do what we want? It's
                     // submitted block height, but not necessarily when it hits the ledger - would we
                     // update when we see a key_image from this transaction?
                     comment: &comment,
-                    direction: "sent",
+                    direction: TX_DIR_SENT,
                     tx: Some(mc_util_serial::encode(&tx_proposal.tx)),
                 };
 
@@ -497,7 +498,10 @@ impl TransactionLogModel for TransactionLog {
 mod tests {
     use super::*;
     use crate::{
-        db::account::{AccountID, AccountModel},
+        db::{
+            account::{AccountID, AccountModel},
+            models::{TXO_MINTED, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED},
+        },
         service::sync::SyncThread,
         test_utils::{
             builder_for_random_recipient, create_test_received_txo, get_test_ledger,
@@ -565,7 +569,7 @@ mod tests {
                     Txo::get(&account_id, txo_id, &wallet_db.get_conn().unwrap()).unwrap();
                 assert_eq!(transaction_logs[0].value, txo.value);
 
-                // Make the sure the types are correct - all received should be "output"
+                // Make the sure the types are correct - all received should be OUTPUT
                 let associated = transaction_logs[0]
                     .get_associated_txos(&wallet_db.get_conn().unwrap())
                     .unwrap();
@@ -632,11 +636,11 @@ mod tests {
         // Fee exists for submitted
         assert_eq!(tx_log.fee, Some(MINIMUM_FEE as i64));
         // Created and sent transaction is "pending" until it lands
-        assert_eq!(tx_log.status, "pending");
+        assert_eq!(tx_log.status, TX_PENDING);
         assert!(tx_log.sent_time.unwrap() > 0);
         assert_eq!(tx_log.block_height, ledger_db.num_blocks().unwrap() as i64);
         assert_eq!(tx_log.comment, "");
-        assert_eq!(tx_log.direction, "sent");
+        assert_eq!(tx_log.direction, TX_DIR_SENT);
         let tx: Tx = mc_util_serial::decode(&tx_log.clone().tx.unwrap()).unwrap();
         assert_eq!(tx, tx_proposal.tx);
 
@@ -654,8 +658,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(input.value, 70 * MOB);
-        assert_eq!(input_status.txo_status, "pending"); // Should now be pending
-        assert_eq!(input_status.txo_type, "received");
+        assert_eq!(input_status.txo_status, TXO_PENDING); // Should now be pending
+        assert_eq!(input_status.txo_type, TXO_RECEIVED);
         assert_eq!(opt_input_assigned_subaddress.unwrap().subaddress_index, 0);
 
         // Assert outputs are as expected
@@ -667,8 +671,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(output.value, 50 * MOB);
-        assert_eq!(output_status.txo_status, "secreted");
-        assert_eq!(output_status.txo_type, "minted");
+        assert_eq!(output_status.txo_status, TXO_SECRETED);
+        assert_eq!(output_status.txo_type, TXO_MINTED);
         assert!(opt_output_assigned_subaddress.is_none());
 
         // Assert change is as expected
@@ -680,8 +684,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(change.value, 19990000000000); // 19.99 * MOB
-        assert_eq!(change_status.txo_status, "secreted"); // Note, change becomes "unspent" once scanned
-        assert_eq!(change_status.txo_type, "minted"); // Note, becomes "received" once scanned
+        assert_eq!(change_status.txo_status, TXO_SECRETED); // Note, change becomes "unspent" once scanned
+        assert_eq!(change_status.txo_type, TXO_MINTED); // Note, becomes "received" once scanned
         assert!(opt_change_assigned_subaddress.is_none()); // Note, gets filled in once scanned
 
         // FIXME: add the change txo above to the ledger, and then scan and verify the above statements
@@ -744,11 +748,11 @@ mod tests {
         // Fee exists for submitted
         assert_eq!(tx_log.fee, Some(MINIMUM_FEE as i64));
         // Created and sent transaction is "pending" until it lands
-        assert_eq!(tx_log.status, "pending");
+        assert_eq!(tx_log.status, TX_PENDING);
         assert!(tx_log.sent_time.unwrap() > 0);
         assert_eq!(tx_log.block_height, ledger_db.num_blocks().unwrap() as i64);
         assert_eq!(tx_log.comment, "");
-        assert_eq!(tx_log.direction, "sent");
+        assert_eq!(tx_log.direction, TX_DIR_SENT);
         let tx: Tx = mc_util_serial::decode(&tx_log.clone().tx.unwrap()).unwrap();
         assert_eq!(tx, tx_proposal.tx);
 

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     db::{
-        models::{Account, Txo},
+        models::{Account, Txo, TXO_UNSPENT},
         WalletDb,
         {
             account::{AccountID, AccountModel},
@@ -85,7 +85,7 @@ impl<FPR: FogPubkeyResolver + Send + Sync + 'static> WalletTransactionBuilder<FP
         let txos = Txo::select_by_id(&input_txo_ids.to_vec(), &self.wallet_db.get_conn()?)?;
         let unspent: Vec<Txo> = txos
             .iter()
-            .filter(|(_txo, status)| status.txo_status == "unspent")
+            .filter(|(_txo, status)| status.txo_status == TXO_UNSPENT)
             .map(|(t, _s)| t.clone())
             .collect();
         if unspent.iter().map(|t| t.value as u128).sum::<u128>() > u64::MAX as u128 {
@@ -619,7 +619,7 @@ mod tests {
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
-        let balance: u128 = txo_lists["unspent"]
+        let balance: u128 = txo_lists[TXO_UNSPENT]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -430,6 +430,7 @@ pub fn rocket(
 mod tests {
     use super::*;
     use crate::{
+        db::models::{TXO_RECEIVED, TXO_UNSPENT},
         service::wallet_impl::b58_decode,
         test_utils::{
             add_block_to_ledger_db, get_test_ledger, setup_grpc_peer_manager, WalletDbTestContext,
@@ -673,9 +674,9 @@ mod tests {
         assert_eq!(txos.len(), 1);
         let txo = &txos[0];
         let txo_status = txo.get("txo_status").unwrap().as_str().unwrap();
-        assert_eq!(txo_status, "unspent");
+        assert_eq!(txo_status, TXO_UNSPENT);
         let txo_type = txo.get("txo_type").unwrap().as_str().unwrap();
-        assert_eq!(txo_type, "received");
+        assert_eq!(txo_type, TXO_RECEIVED);
         let value = txo.get("value").unwrap().as_str().unwrap();
         assert_eq!(value, "100");
 
@@ -688,7 +689,7 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
         assert_eq!(unspent, "100");
     }
 
@@ -864,9 +865,9 @@ mod tests {
         assert_eq!(txos.len(), 1);
         let txo = &txos[0];
         let txo_status = txo.get("txo_status").unwrap().as_str().unwrap();
-        assert_eq!(txo_status, "unspent");
+        assert_eq!(txo_status, TXO_UNSPENT);
         let txo_type = txo.get("txo_type").unwrap().as_str().unwrap();
-        assert_eq!(txo_type, "received");
+        assert_eq!(txo_type, TXO_RECEIVED);
         let value = txo.get("value").unwrap().as_str().unwrap();
         assert_eq!(value, "42000000000000");
     }

--- a/full-service/src/service/wallet_impl.rs
+++ b/full-service/src/service/wallet_impl.rs
@@ -3,7 +3,10 @@
 //! The implementation of the wallet service methods.
 
 use crate::{
-    db::models::{Account, AssignedSubaddress, TransactionLog, Txo},
+    db::models::{
+        Account, AssignedSubaddress, TransactionLog, Txo, TXO_ORPHANED, TXO_PENDING, TXO_SECRETED,
+        TXO_SPENT, TXO_UNSPENT,
+    },
     db::WalletDb,
     db::{
         account::{AccountID, AccountModel},
@@ -255,23 +258,23 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         let conn = self.wallet_db.get_conn()?;
 
         let status_map = Txo::list_by_status(account_id_hex, &conn)?;
-        let unspent: u128 = status_map["unspent"]
+        let unspent: u128 = status_map[TXO_UNSPENT]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let pending: u128 = status_map["pending"]
+        let pending: u128 = status_map[TXO_PENDING]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let spent: u128 = status_map["spent"]
+        let spent: u128 = status_map[TXO_SPENT]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let secreted: u128 = status_map["secreted"]
+        let secreted: u128 = status_map[TXO_SECRETED]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let orphaned: u128 = status_map["orphaned"]
+        let orphaned: u128 = status_map[TXO_ORPHANED]
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
@@ -532,8 +535,11 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{
-        add_block_to_ledger_db, get_test_ledger, setup_peer_manager, WalletDbTestContext,
+    use crate::{
+        db::models::{TXO_MINTED, TXO_RECEIVED},
+        test_utils::{
+            add_block_to_ledger_db, get_test_ledger, setup_peer_manager, WalletDbTestContext,
+        },
     };
     use mc_account_keys::PublicAddress;
     use mc_common::logger::{test_with_logger, Logger};
@@ -596,7 +602,7 @@ mod tests {
         // Verify that we have 1 txo
         let txos = service.list_txos(&alice.account_id).unwrap();
         assert_eq!(txos.len(), 1);
-        assert_eq!(txos[0].txo_status, "unspent");
+        assert_eq!(txos[0].txo_status, TXO_UNSPENT);
 
         // Add another account
         let bob = service
@@ -626,20 +632,20 @@ mod tests {
         let pending: Vec<JsonListTxosResponse> = txos
             .iter()
             .cloned()
-            .filter(|t| t.txo_status == "pending")
+            .filter(|t| t.txo_status == TXO_PENDING)
             .collect();
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].txo_type, "received");
+        assert_eq!(pending[0].txo_type, TXO_RECEIVED);
         assert_eq!(pending[0].value, "100000000000000");
         // The Minted have Status "secreted"
         let minted: Vec<JsonListTxosResponse> = txos
             .iter()
             .cloned()
-            .filter(|t| t.txo_status == "secreted")
+            .filter(|t| t.txo_status == TXO_SECRETED)
             .collect();
         assert_eq!(minted.len(), 2);
-        assert_eq!(minted[0].txo_type, "minted");
-        assert_eq!(minted[1].txo_type, "minted");
+        assert_eq!(minted[0].txo_type, TXO_MINTED);
+        assert_eq!(minted[1].txo_type, TXO_MINTED);
         let minted_value_set = HashSet::from_iter(minted.iter().map(|m| m.value.clone()));
         assert!(minted_value_set.contains("57990000000000"));
         assert!(minted_value_set.contains("42000000000000"));


### PR DESCRIPTION
### Motivation

The proof of concept littered string literals throughout the codebase. We would like to move to enums, even though SQLite's enums are a [bit of a workaround](https://github.com/adwhit/diesel-derive-enum). I experimented on [this branch](https://github.com/sugargoat/wallet-service/tree/ws-13/enums), but rather than rabbit holing, this is a reasonable interim solution.

### In this PR
* Moves string literals to a single place of definition in models.rs and refers to those consts whereever the "enums" are being used.

First step in [WS-13](https://mobilecoin.atlassian.net/browse/WS-13)

### Future Work
* Re-explore the diesel-derive-enum approach: [WS-13](https://mobilecoin.atlassian.net/browse/WS-13)

