### PR TITLE
Get Proofs and Proof Documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -375,6 +375,36 @@ Txo Spent from One Account to Another in the Same Wallet
 * [get_all_txos_by_account](./README.md#get-all-txos-for-a-given-account)
 * [get_txo](./README.md#get-txo-details)
 
+### The Proof Object
+
+#### Attributes
+
+| *Name* | *Type* | *Description*
+| :--- | :--- | :---
+| txo_id | string | Unique identifier for the Txo.
+| proof | string | A string with a proof that can be verified to confirm that another party constructed or had knowledge of the construction of the associated Txo.
+
+#### More attributes
+
+| *Name* | *Type* | *Description*
+| :--- | :--- | :---
+| object | string, value is "proof" | String representing the object's type. Objects of the same type share the same value.
+
+#### Example Object
+
+```
+{
+  "object": "proof",
+  "txo_id": "873dfb8c...",
+  "propf": "984eacd...",
+}
+```
+
+#### API Methods Returning Transaction Log Objects
+
+* [get_proofs](./README.md#get-proofs)
+* [verify_proof](./README.md#verify-proof)
+
 ## Future API Objects
 
 ### The Recipient Address object

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1141,12 +1141,6 @@ checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "hashbrown"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
-
-[[package]]
-name = "hashbrown"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
@@ -1213,11 +1207,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.9.1",
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -1583,15 +1577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8f669d42c72d18514dfca8115689c5f6370a17d980cb5bd777a67f404594c8"
-dependencies = [
- "hashbrown 0.5.0",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,8 +1630,6 @@ version = "1.0.0"
 dependencies = [
  "blake2",
  "curve25519-dalek",
- "digest",
- "displaydoc",
  "hkdf",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
@@ -1670,7 +1653,6 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "mc-account-keys",
- "mc-common",
  "mc-crypto-keys",
  "mc-transaction-core",
  "mc-util-build-grpc",
@@ -1690,7 +1672,6 @@ dependencies = [
  "digest",
  "displaydoc",
  "mc-attest-core",
- "mc-common",
  "mc-crypto-keys",
  "mc-crypto-noise",
  "mc-util-build-script",
@@ -1716,7 +1697,6 @@ dependencies = [
  "mc-util-build-grpc",
  "mc-util-build-script",
  "protobuf",
- "serde",
 ]
 
 [[package]]
@@ -1730,7 +1710,6 @@ dependencies = [
  "digest",
  "displaydoc",
  "failure",
- "generic-array",
  "hex_fmt",
  "mbedtls",
  "mbedtls-sys-auto",
@@ -1769,7 +1748,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "chrono",
  "failure",
- "generic-array",
  "hashbrown 0.6.3",
  "hex_fmt",
  "hostname 0.1.5",
@@ -1814,12 +1792,10 @@ dependencies = [
  "mc-crypto-rand",
  "mc-transaction-core",
  "mc-util-grpc",
- "mc-util-host-cert",
  "mc-util-serial",
  "mc-util-uri",
  "retry",
  "secrecy",
- "serde",
  "sha2",
 ]
 
@@ -1849,26 +1825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-consensus-enclave-api"
-version = "1.0.0"
-dependencies = [
- "cfg-if 0.1.10",
- "failure",
- "mc-attest-ake",
- "mc-attest-core",
- "mc-attest-enclave-api",
- "mc-common",
- "mc-crypto-keys",
- "mc-crypto-message-cipher",
- "mc-crypto-noise",
- "mc-sgx-compat",
- "mc-sgx-report-cache-api",
- "mc-transaction-core",
- "mc-util-serial",
- "serde",
-]
-
-[[package]]
 name = "mc-consensus-enclave-measurement"
 version = "1.0.0"
 dependencies = [
@@ -1890,14 +1846,12 @@ dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-util-from-random",
- "mc-util-metrics",
  "mc-util-serial",
  "mockall",
  "rand 0.7.3",
  "rand_hc 0.2.0",
  "serde",
  "serde_json",
- "sha3",
 ]
 
 [[package]]
@@ -1961,7 +1915,6 @@ name = "mc-crypto-keys"
 version = "1.0.0"
 dependencies = [
  "binascii",
- "cfg-if 0.1.10",
  "curve25519-dalek",
  "digest",
  "ed25519",
@@ -1971,27 +1924,12 @@ dependencies = [
  "mc-crypto-digestible",
  "mc-util-from-random",
  "mc-util-repr-bytes",
- "mc-util-serial",
- "prost",
  "rand_core 0.5.1",
  "serde",
  "sha2",
  "signature",
  "x25519-dalek",
  "zeroize 1.1.1",
-]
-
-[[package]]
-name = "mc-crypto-message-cipher"
-version = "1.0.0"
-dependencies = [
- "aes-gcm",
- "failure",
- "generic-array",
- "mc-util-serial",
- "rand_core 0.5.1",
- "serde",
- "subtle",
 ]
 
 [[package]]
@@ -2006,7 +1944,6 @@ dependencies = [
  "hkdf",
  "mc-crypto-keys",
  "mc-util-from-random",
- "mc-util-repr-bytes",
  "rand_core 0.5.1",
  "secrecy",
  "serde",
@@ -2030,7 +1967,6 @@ dependencies = [
 name = "mc-crypto-sig"
 version = "1.0.0"
 dependencies = [
- "mc-crypto-hashes",
  "mc-crypto-keys",
  "merlin",
  "rand_core 0.5.1",
@@ -2047,7 +1983,6 @@ dependencies = [
  "grpcio",
  "mc-api",
  "mc-attest-api",
- "mc-common",
  "mc-consensus-api",
  "mc-util-build-grpc",
  "mc-util-build-script",
@@ -2063,7 +1998,6 @@ dependencies = [
  "mc-account-keys",
  "mc-attest-core",
  "mc-common",
- "mc-crypto-keys",
  "mc-fog-api",
  "mc-fog-report-validation",
  "mc-util-grpc",
@@ -2080,7 +2014,6 @@ dependencies = [
  "mc-attest-core",
  "mc-crypto-keys",
  "mc-util-encodings",
- "mc-util-serial",
  "mockall",
 ]
 
@@ -2157,7 +2090,6 @@ dependencies = [
  "prost",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde",
 ]
 
 [[package]]
@@ -2167,7 +2099,6 @@ dependencies = [
  "crossbeam-channel",
  "failure",
  "grpcio",
- "lazy_static",
  "mc-account-keys",
  "mc-api",
  "mc-attest-core",
@@ -2175,12 +2106,9 @@ dependencies = [
  "mc-connection",
  "mc-consensus-enclave-measurement",
  "mc-consensus-scp",
- "mc-crypto-keys",
  "mc-ledger-db",
- "mc-peers",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-util-metrics",
  "mc-util-uri",
  "mockall",
  "protobuf",
@@ -2201,12 +2129,10 @@ dependencies = [
  "crossbeam-channel",
  "displaydoc",
  "failure",
- "futures",
  "grpcio",
  "hex_fmt",
  "libz-sys",
  "lmdb-rkv",
- "lru",
  "mc-account-keys",
  "mc-api",
  "mc-attest-core",
@@ -2236,11 +2162,9 @@ dependencies = [
  "prost",
  "protobuf",
  "rand 0.7.3",
- "rand_core 0.5.1",
  "reqwest",
  "retry",
  "serde_json",
- "sha3",
  "structopt",
  "tempdir",
 ]
@@ -2253,9 +2177,6 @@ dependencies = [
  "futures",
  "grpcio",
  "mc-api",
- "mc-common",
- "mc-crypto-keys",
- "mc-transaction-core",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
@@ -2278,36 +2199,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "structopt",
-]
-
-[[package]]
-name = "mc-peers"
-version = "1.0.0"
-dependencies = [
- "crossbeam-channel",
- "ed25519",
- "failure",
- "grpcio",
- "mc-attest-api",
- "mc-attest-enclave-api",
- "mc-common",
- "mc-connection",
- "mc-consensus-api",
- "mc-consensus-enclave-api",
- "mc-consensus-scp",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-ledger-db",
- "mc-transaction-core",
- "mc-util-grpc",
- "mc-util-serial",
- "mc-util-uri",
- "mockall",
- "protobuf",
- "retry",
- "serde",
- "sha2",
- "url 2.2.0",
 ]
 
 [[package]]
@@ -2337,17 +2228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-sgx-report-cache-api"
-version = "1.0.0"
-dependencies = [
- "displaydoc",
- "mc-attest-core",
- "mc-attest-enclave-api",
- "mc-util-serial",
- "serde",
-]
-
-[[package]]
 name = "mc-sgx-types"
 version = "1.0.0"
 
@@ -2358,7 +2238,6 @@ dependencies = [
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
- "digest",
  "displaydoc",
  "generic-array",
  "hex_fmt",
@@ -2377,7 +2256,6 @@ dependencies = [
  "prost",
  "rand_core 0.5.1",
  "serde",
- "sha2",
  "subtle",
  "zeroize 1.1.1",
 ]
@@ -2404,10 +2282,7 @@ dependencies = [
  "blake2",
  "curve25519-dalek",
  "failure",
- "hkdf",
  "mc-account-keys",
- "mc-common",
- "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-transaction-core",
  "mc-util-from-random",
@@ -2415,7 +2290,6 @@ dependencies = [
  "prost",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde",
  "zeroize 1.1.1",
 ]
 
@@ -2465,7 +2339,6 @@ dependencies = [
  "cargo-emit",
  "cc",
  "displaydoc",
- "lazy_static",
  "mc-util-build-script",
  "pkg-config",
 ]
@@ -2495,13 +2368,12 @@ version = "1.0.0"
 dependencies = [
  "base64 0.12.3",
  "cookie 0.14.3",
- "digest",
  "displaydoc",
  "futures",
  "grpcio",
  "hex",
  "hex_fmt",
- "hmac 0.9.0",
+ "hmac 0.10.1",
  "lazy_static",
  "mc-common",
  "mc-util-build-grpc",
@@ -2510,7 +2382,6 @@ dependencies = [
  "mc-util-serial",
  "mc-util-uri",
  "prometheus",
- "prost",
  "protobuf",
  "rand 0.6.5",
  "sha2",
@@ -2546,13 +2417,11 @@ name = "mc-util-metrics"
 version = "1.0.0"
 dependencies = [
  "chrono",
- "crossbeam-channel",
  "grpcio",
  "lazy_static",
  "mc-common",
  "prometheus",
  "protobuf",
- "reqwest",
  "serde_json",
 ]
 
@@ -2739,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01458f8a19b10cb28195290942e3149161c75acf67ebc8fbf714ab67a2b943bc"
+checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
 dependencies = [
  "cfg-if 0.1.10",
  "downcast",
@@ -2754,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
+checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
 dependencies = [
  "cfg-if 0.1.10",
  "proc-macro2 1.0.24",
@@ -3474,11 +3343,11 @@ dependencies = [
 
 [[package]]
 name = "retry"
-version = "0.5.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
+checksum = "c15ef4789108d066d7fd85dcec330eab9b8e51244275922a9b7161afc4f46dda"
 dependencies = [
- "rand 0.6.5",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,14 @@ curl -s localhost:9090/wallet \
 }
 ```
 
+### Transaction Output Proofs
+
+When constructing a transaction, the wallet produces a "proof" for each Txo minted by the transaction. This proof can be delivered to the recipient to confirm that they received the Txo from the sender.
+
+#### Verify Proof
+
+
+
 ## Contributing
 
 See [CONTRIBUTING](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ curl -s localhost:9090/wallet \
 
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
-| `tarnsaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
+| `transaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
 
 ### Transaction Output Proofs
 
@@ -1139,7 +1139,7 @@ curl -s localhost:9090/wallet \
 
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
-| `tarnsaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
+| `transaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
 
 #### Verify Proof
 

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,8 @@ curl -s localhost:9090/wallet \
 curl -s localhost:9090/wallet \
   -d '{
         "method": "get_transaction",
-        "params": {"transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d"
+        "params": {
+          "transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d"
         }
       }' \
   -X POST -H 'Content-type: application/json' | jq
@@ -1101,13 +1102,74 @@ curl -s localhost:9090/wallet \
 }
 ```
 
+| Required Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `tarnsaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
+
 ### Transaction Output Proofs
 
 When constructing a transaction, the wallet produces a "proof" for each Txo minted by the transaction. This proof can be delivered to the recipient to confirm that they received the Txo from the sender.
 
+#### Get Proofs
+
+A Txo constructed by this wallet will contain a proof, which can be shared with the recipient to verify the association between the sender and this Txo. When calling `get_proofs` for a transaction, only the proofs for the "output_txo_ids" are returned.
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "get_proofs",
+        "params": {
+          "transaction_log_id": "0db5ac892ed796bb11e52d3842f83c05f4993f2f9d7da5fc9f40c8628c7859a4"
+        }
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+{
+  "method": "get_proofs",
+  "result": {
+    "proofs": [
+      {
+        "object": "proof",
+        "txo_id": "bbee8b70e80837fc3e10bde47f63de41768ee036263907325ef9a8d45d851f15",
+        "proof": "0a2005ba1d9d871c7fb0d5ba7df17391a1e14aad1b4aa2319c997538f8e338a670bb"
+      }
+    ]
+  }
+}
+```
+
+| Required Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `tarnsaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
+
 #### Verify Proof
 
+A sender can provide the proofs from a transaction to the recipient, who then verifies for a specific txo_id (note that txo_id is specific to the txo, and is consistent across wallets. Therefore the sender and receiver will have the same txo_id for the same Txo which was minted by the sender, and received by the receiver) with the following:
 
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "verify_proof",
+        "params": {
+          "account_id": "4b4fd11738c03bf5179781aeb27d725002fb67d8a99992920d3654ac00ee1a2c",
+          "txo_id": "bbee8b70e80837fc3e10bde47f63de41768ee036263907325ef9a8d45d851f15",
+          "proof": "0a2005ba1d9d871c7fb0d5ba7df17391a1e14aad1b4aa2319c997538f8e338a670bb"
+        }
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+
+{
+  "method": "verify_proof",
+  "result": {
+    "verified": true
+  }
+}
+```
+
+| Required Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `account_id`   | The account on which to perform this action  | Account must exist in the wallet  |
+| `txo_id`   | The ID of the Txo for which to verify the proof  | Txo must be a received Txo  |
+| `proof`   | The proof to verify  | The proof should be delivered by the sender of the Txo in question |
 
 ## Contributing
 

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -44,7 +44,7 @@ hex = {version = "0.4", default-features = false }
 num_cpus = "1.12"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", default-features = false }
-retry = "0.5"
+retry = "1.2"
 rocket = { version = "0.4.5", default-features = false }
 rocket_contrib = { version = "0.4.5", default-features = false, features = ["json", "diesel_sqlite_pool"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/full-service/src/error.rs
+++ b/full-service/src/error.rs
@@ -50,6 +50,9 @@ pub enum WalletServiceError {
 
     /// Diesel Error: {0}
     Diesel(diesel::result::Error),
+
+    /// Txo should contain proof: {0}
+    MissingProof(String),
 }
 
 impl From<WalletDbError> for WalletServiceError {

--- a/full-service/src/service/decorated_types.rs
+++ b/full-service/src/service/decorated_types.rs
@@ -277,3 +277,10 @@ impl JsonBlockContents {
         }
     }
 }
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+pub struct JsonProof {
+    pub object: String,
+    pub txo_id: String,
+    pub proof: String,
+}

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -4,7 +4,7 @@ use crate::{
     db::account::AccountID,
     service::{
         decorated_types::{
-            JsonAccount, JsonAddress, JsonBalanceResponse, JsonBlock, JsonBlockContents,
+            JsonAccount, JsonAddress, JsonBalanceResponse, JsonBlock, JsonBlockContents, JsonProof,
             JsonSubmitResponse, JsonTransactionLog, JsonTxo, JsonWalletStatus,
         },
         wallet_impl::WalletService,
@@ -109,6 +109,9 @@ pub enum JsonCommandRequest {
     get_block_object {
         block_index: String,
     },
+    get_proofs {
+        transaction_log_id: String,
+    },
     verify_proof {
         account_id: String,
         txo_id: String,
@@ -184,6 +187,9 @@ pub enum JsonCommandResponse {
     get_block_object {
         block: JsonBlock,
         block_contents: JsonBlockContents,
+    },
+    get_proofs {
+        proofs: Vec<JsonProof>,
     },
     verify_proof {
         verified: bool,
@@ -448,6 +454,11 @@ where
                 block_contents,
             }
         }
+        JsonCommandRequest::get_proofs { transaction_log_id } => JsonCommandResponse::get_proofs {
+            proofs: service
+                .get_proofs(&transaction_log_id)
+                .map_err(|e| format!("{{\"error\": \"{:?}\"}}", e))?,
+        },
         JsonCommandRequest::verify_proof {
             account_id,
             txo_id,

--- a/full-service/src/service/wallet_impl.rs
+++ b/full-service/src/service/wallet_impl.rs
@@ -604,18 +604,17 @@ impl<
             .output_txo_ids
             .iter()
             .map(|txo_id| {
-                let proof = self
-                    .get_txo(txo_id)
-                    .expect("Could not get Txo")
-                    .proof
-                    .unwrap();
-                JsonProof {
-                    object: "proof".to_string(),
-                    txo_id: txo_id.clone(),
-                    proof,
-                }
+                self.get_txo(txo_id).and_then(|txo| {
+                    txo.proof
+                        .map(|proof| JsonProof {
+                            object: "proof".to_string(),
+                            txo_id: txo_id.clone(),
+                            proof,
+                        })
+                        .ok_or(WalletServiceError::MissingProof(txo_id.to_string()))
+                })
             })
-            .collect();
+            .collect::<Result<Vec<JsonProof>, WalletServiceError>>()?;
         Ok(proofs)
     }
 

--- a/full-service/src/service/wallet_impl.rs
+++ b/full-service/src/service/wallet_impl.rs
@@ -611,7 +611,7 @@ impl<
                             txo_id: txo_id.clone(),
                             proof,
                         })
-                        .ok_or(WalletServiceError::MissingProof(txo_id.to_string()))
+                        .ok_or_else(|| WalletServiceError::MissingProof(txo_id.to_string()))
                 })
             })
             .collect::<Result<Vec<JsonProof>, WalletServiceError>>()?;


### PR DESCRIPTION
### Motivation

We needed to document the `verify_proofs` endpoint, and in the process, I realized we needed a convenience call to `get_proofs` for a transaction.

### In this PR
* Uprevs mobilecoin
* Adds `get_proofs`
* Documents the proof object in the API doc, as well as the proof service methods in the README.

[WS-52](https://mobilecoin.atlassian.net/browse/WS-52)


