### PR TITLE
WS-78: TxProposal Stringify

### DIFF
--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -172,24 +172,7 @@ impl APIConfig {
                 .build(),
         );
 
-        let conn = GrpcFogReportConnection::new(env, logger);
-
-        let verifier = self.get_fog_ingest_verifier();
-
-        Arc::new(move |fog_uris| -> Result<FogResolver, String> {
-            if fog_uris.is_empty() {
-                Ok(Default::default())
-            } else if let Some(verifier) = verifier.as_ref() {
-                let report_responses = conn
-                    .fetch_fog_reports(fog_uris.iter().cloned())
-                    .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
-                Ok(FogResolver::new(report_responses, verifier))
-            } else {
-                Err(
-                    "Some recipients have fog, but no fog ingest report verifier was configured"
-                        .to_string(),
-                )
-            }
+            GrpcFogPubkeyResolver::new(&report_verifier, env, logger)
         })
     }
 

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -172,7 +172,24 @@ impl APIConfig {
                 .build(),
         );
 
-            GrpcFogPubkeyResolver::new(&report_verifier, env, logger)
+        let conn = GrpcFogReportConnection::new(env, logger);
+
+        let verifier = self.get_fog_ingest_verifier();
+
+        Arc::new(move |fog_uris| -> Result<FogResolver, String> {
+            if fog_uris.is_empty() {
+                Ok(Default::default())
+            } else if let Some(verifier) = verifier.as_ref() {
+                let report_responses = conn
+                    .fetch_fog_reports(fog_uris.iter().cloned())
+                    .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
+                Ok(FogResolver::new(report_responses, verifier))
+            } else {
+                Err(
+                    "Some recipients have fog, but no fog ingest report verifier was configured"
+                        .to_string(),
+                )
+            }
         })
     }
 

--- a/full-service/src/service/decorated_types.rs
+++ b/full-service/src/service/decorated_types.rs
@@ -361,10 +361,10 @@ impl From<&JsonTxProposal> for StringifiedJsonTxProposal {
 
 impl From<&StringifiedJsonTxProposal> for JsonTxProposal {
     fn from(src: &StringifiedJsonTxProposal) -> Self {
-        let outlay_map: Vec<(u64, u64)> = src
+        let outlay_map: Vec<(usize, usize)> = src
             .outlay_index_to_tx_out_index
             .iter()
-            .map(|(key, val)| (key.parse::<u64>().unwrap(), val.parse::<u64>().unwrap()))
+            .map(|(key, val)| (key.parse::<usize>().unwrap(), val.parse::<usize>().unwrap()))
             .collect();
         Self {
             input_list: src.input_list.iter().map(JsonUnspentTxOut::from).collect(),

--- a/full-service/src/service/decorated_types.rs
+++ b/full-service/src/service/decorated_types.rs
@@ -377,6 +377,7 @@ impl From<&JsonTxProposal> for StringifiedJsonTxProposal {
 impl TryFrom<&StringifiedJsonTxProposal> for JsonTxProposal {
     type Error = String;
 
+    #[allow(clippy::bind_instead_of_map)]
     fn try_from(src: &StringifiedJsonTxProposal) -> Result<JsonTxProposal, String> {
         let outlay_map: Vec<(usize, usize)> = src
             .outlay_index_to_tx_out_index

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -508,7 +508,7 @@ mod tests {
     use crate::{
         db::{
             b58_decode,
-            models::{TXO_RECEIVED, TXO_UNSPENT},
+            models::{TXO_PENDING, TXO_RECEIVED, TXO_SECRETED, TXO_SPENT, TXO_UNSPENT},
         },
         test_utils::{
             add_block_to_ledger_db, get_resolver_factory, get_test_ledger,
@@ -734,6 +734,8 @@ mod tests {
         let public_address = account_obj.get("main_address").unwrap().as_str().unwrap();
         assert_eq!(public_address, "8JtpPPh9mV2PTLrrDz4f2j4PtUpNWnrRg8HKpnuwkZbj5j8bGqtNMNLC9E3zjzcw456215yMjkCVYK4FPZTX4gijYHiuDT31biNHrHmQmsU");
         let account_id = account_obj.get("account_id").unwrap().as_str().unwrap();
+        // Catches if a change results in changed accounts_ids, which should always be
+        // made to be backward compatible.
         assert_eq!(
             account_id,
             "f9957a9d050ef8dff9d8ef6f66daa608081e631b2d918988311613343827b779"
@@ -875,7 +877,7 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn test_build_transaction(logger: Logger) {
+    fn test_build_and_submit_transaction(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
         let (client, mut ledger_db) = setup(&mut rng, logger.clone());
 
@@ -992,6 +994,113 @@ mod tests {
         // tombstone)
         let prefix_tombstone = tx_prefix.get("tombstone_block").unwrap();
         assert_eq!(prefix_tombstone, "64");
+
+        // Get current balance
+        let body = json!({
+            "method": "get_balance",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let result = dispatch(&client, body, &logger);
+        let balance_status = result.get("status").unwrap();
+        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        assert_eq!(unspent, "100000000000100");
+
+        // Submit the tx_proposal
+        let body = json!({
+            "method": "submit_transaction",
+            "params": {
+                "tx_proposal": tx_proposal,
+            }
+        });
+        let result = dispatch(&client, body, &logger);
+        let transaction_id = result
+            .get("transaction")
+            .unwrap()
+            .get("transaction_id")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        // Note - we cannot test here that the transaction ID is consistent, because
+        // there is randomness in the transaction creation.
+
+        // Wait for the transaction to hit the ledger
+        std::thread::sleep(Duration::from_secs(4));
+
+        // Get balance after submission
+        let body = json!({
+            "method": "get_balance",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let result = dispatch(&client, body, &logger);
+        let balance_status = result.get("status").unwrap();
+        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
+        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
+        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
+        assert_eq!(unspent, "0");
+        assert_eq!(pending, "100000000000100");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+
+        // FIXME: FS-93 Increment ledger manually so tx lands.
+
+        // Get the transaction_id and verify it contains what we expect
+        let body = json!({
+            "method": "get_transaction",
+            "params": {
+                "transaction_log_id": transaction_id,
+            }
+        });
+        let result = dispatch(&client, body, &logger);
+        let transaction_log = result.get("transaction").unwrap();
+        assert_eq!(
+            transaction_log.get("direction").unwrap().as_str().unwrap(),
+            "sent"
+        );
+        assert_eq!(
+            transaction_log.get("value_pmob").unwrap().as_str().unwrap(),
+            "42000000000000"
+        );
+        assert_eq!(
+            transaction_log
+                .get("recipient_address_id")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            b58_public_address
+        );
+        assert_eq!(
+            transaction_log.get("account_id").unwrap().as_str().unwrap(),
+            ""
+        );
+        assert_eq!(
+            transaction_log.get("fee_pmob").unwrap().as_str().unwrap(),
+            "10000000000"
+        );
+        assert_eq!(
+            transaction_log.get("status").unwrap().as_str().unwrap(),
+            "pending"
+        );
+        assert_eq!(
+            transaction_log
+                .get("submitted_block_height")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "14"
+        );
+        assert_eq!(
+            transaction_log
+                .get("transaction_log_id")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            transaction_id
+        );
     }
 
     #[test_with_logger]

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -18,7 +18,7 @@ use rocket::{get, post, routes};
 use rocket_contrib::json::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use std::iter::FromIterator;
+use std::{convert::TryFrom, iter::FromIterator};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -398,7 +398,7 @@ where
             account_id,
         } => JsonCommandResponse::submit_transaction {
             transaction: service
-                .submit_transaction(JsonTxProposal::from(&tx_proposal), comment, account_id)
+                .submit_transaction(JsonTxProposal::try_from(&tx_proposal)?, comment, account_id)
                 .map_err(|e| format!("{{\"error\": \"{:?}\"}}", e))?,
         },
         JsonCommandRequest::get_all_transactions_by_account { account_id } => {


### PR DESCRIPTION
Soundtrack of this PR: [Undone](https://www.youtube.com/watch?v=LHQqqM5sr7g)

### Motivation

The JsonTxProposal object has several u64s in various objects contained therein. This change introduces a StringifiedJsonTxProposal which has all internal u64s represented as strings.

### In this PR
* StringifiedJsonTxProposal and StringifiedUnspentTxOut

[WS-78](https://mobilecoin.atlassian.net/browse/WS-78)

### TODO for this PR
- [ ] Update mobilecoin submodule once [upstream PR](https://github.com/mobilecoinfoundation/mobilecoin/pull/719) is merged

