### PR TITLE
FS-98: New models take &[u8] rather than &Vec

### DIFF
--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -58,7 +58,7 @@ pub struct Account {
 #[table_name = "accounts"]
 pub struct NewAccount<'a> {
     pub account_id_hex: &'a str,
-    pub account_key: &'a Vec<u8>,
+    pub account_key: &'a [u8],
     pub main_subaddress_index: i64,
     pub change_subaddress_index: i64,
     pub next_subaddress_index: i64,
@@ -91,16 +91,16 @@ pub struct Txo {
 pub struct NewTxo<'a> {
     pub txo_id_hex: &'a str,
     pub value: i64,
-    pub target_key: &'a Vec<u8>,
-    pub public_key: &'a Vec<u8>,
-    pub e_fog_hint: &'a Vec<u8>,
-    pub txo: &'a Vec<u8>,
+    pub target_key: &'a [u8],
+    pub public_key: &'a [u8],
+    pub e_fog_hint: &'a [u8],
+    pub txo: &'a [u8],
     pub subaddress_index: Option<i64>,
-    pub key_image: Option<&'a Vec<u8>>,
+    pub key_image: Option<&'a [u8]>,
     pub received_block_count: Option<i64>,
     pub pending_tombstone_block_count: Option<i64>,
     pub spent_block_count: Option<i64>,
-    pub proof: Option<&'a Vec<u8>>,
+    pub proof: Option<&'a [u8]>,
 }
 
 #[derive(Clone, Serialize, Associations, Identifiable, Queryable, PartialEq, Debug)]
@@ -147,10 +147,10 @@ pub struct NewAssignedSubaddress<'a> {
     pub assigned_subaddress_b58: &'a str,
     pub account_id_hex: &'a str,
     pub address_book_entry: Option<i64>,
-    pub public_address: &'a Vec<u8>,
+    pub public_address: &'a [u8],
     pub subaddress_index: i64,
     pub comment: &'a str,
-    pub subaddress_spend_key: &'a Vec<u8>,
+    pub subaddress_spend_key: &'a [u8],
 }
 
 #[derive(Clone, Serialize, Associations, Identifiable, Queryable, PartialEq, Debug)]
@@ -192,7 +192,7 @@ pub struct NewTransactionLog<'a> {
     pub finalized_block_count: Option<i64>,
     pub comment: &'a str,
     pub direction: &'a str,
-    pub tx: Option<Vec<u8>>,
+    pub tx: Option<&'a [u8]>,
 }
 
 #[derive(Clone, Serialize, Associations, Identifiable, Queryable, PartialEq, Debug)]

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -457,6 +457,7 @@ impl TransactionLogModel for TransactionLog {
 
             if let Some(recipient) = recipient_address {
                 let transaction_id = TransactionID::from(&tx_proposal.tx);
+                let tx = mc_util_serial::encode(&tx_proposal.tx);
                 // Create a TransactionLogs entry
                 let new_transaction_log = NewTransactionLog {
                     transaction_id_hex: &transaction_id.to_string(),
@@ -473,7 +474,7 @@ impl TransactionLogModel for TransactionLog {
                     finalized_block_count: None,
                     comment: &comment,
                     direction: TX_DIR_SENT,
-                    tx: Some(mc_util_serial::encode(&tx_proposal.tx)),
+                    tx: Some(&tx),
                 };
 
                 diesel::insert_into(crate::db::schema::transaction_logs::table)

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -245,7 +245,7 @@ impl TxoModel for Txo {
                         e_fog_hint: &mc_util_serial::encode(&txo.e_fog_hint),
                         txo: &mc_util_serial::encode(&txo),
                         subaddress_index,
-                        key_image: key_image_bytes.as_ref(),
+                        key_image: key_image_bytes.as_deref(),
                         received_block_count: Some(received_block_count as i64),
                         pending_tombstone_block_count: None,
                         spent_block_count: None,
@@ -340,7 +340,7 @@ impl TxoModel for Txo {
                 received_block_count: None,
                 pending_tombstone_block_count: Some(tx_proposal.tx.prefix.tombstone_block as i64),
                 spent_block_count: None,
-                proof: encoded_proof.as_ref(),
+                proof: encoded_proof.as_deref(),
             };
 
             diesel::insert_into(txos::table)


### PR DESCRIPTION
### Motivation

New model types should take &[u8] rather than &Vec.

### In this PR
* Modifies new models specification to take &[u8] rather than &Vec

[FS-98](https://mobilecoin.atlassian.net/browse/FS-98)