### PR TITLE
Uprev mobilecoin and Add Credentials Provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-util-from-random",
+ "mc-util-grpc",
  "mc-util-lmdb",
  "mc-util-repr-bytes",
  "mc-util-serial",

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -7,7 +7,7 @@ use mc_common::{
     logger::{log, Logger},
     ResponderId,
 };
-use mc_connection::{ConnectionManager, ThickClient};
+use mc_connection::{ConnectionManager, HardcodedCredentialsProvider, ThickClient};
 use mc_consensus_scp::QuorumSet;
 use mc_fog_report_connection::GrpcFogReportConnection;
 use mc_fog_report_validation::FogResolver;
@@ -318,7 +318,7 @@ impl PeersConfig {
         verifier: Verifier,
         grpc_env: Arc<grpcio::Environment>,
         logger: Logger,
-    ) -> Vec<ThickClient> {
+    ) -> Vec<ThickClient<HardcodedCredentialsProvider>> {
         self.peers
             .clone()
             .unwrap_or_default()
@@ -328,6 +328,7 @@ impl PeersConfig {
                     client_uri.clone(),
                     verifier.clone(),
                     grpc_env.clone(),
+                    HardcodedCredentialsProvider::from(client_uri),
                     logger.clone(),
                 )
                 .expect("Could not create thick client.")
@@ -339,7 +340,7 @@ impl PeersConfig {
         &self,
         verifier: Verifier,
         logger: &Logger,
-    ) -> ConnectionManager<ThickClient> {
+    ) -> ConnectionManager<ThickClient<HardcodedCredentialsProvider>> {
         let grpc_env = Arc::new(
             grpcio::EnvBuilder::new()
                 .cq_count(1)

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -11,7 +11,9 @@ use crate::{
         wallet_impl::WalletService,
     },
 };
-use mc_connection::{BlockchainConnection, ThickClient, UserTxConnection};
+use mc_connection::{
+    BlockchainConnection, HardcodedCredentialsProvider, ThickClient, UserTxConnection,
+};
 use mc_fog_report_validation::{FogPubkeyResolver, FogResolver};
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut, JsonTxProposal};
 use rocket::{get, post, routes};
@@ -463,7 +465,7 @@ where
 
 #[post("/wallet", format = "json", data = "<command>")]
 fn wallet_api(
-    state: rocket::State<WalletState<ThickClient, FogResolver>>,
+    state: rocket::State<WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>>,
     command: Json<JsonCommandRequest>,
 ) -> Result<Json<JsonCommandResponse>, String> {
     wallet_api_inner(&state.service, command)
@@ -480,7 +482,7 @@ fn wallet_help() -> Result<String, String> {
 
 pub fn rocket(
     rocket_config: rocket::Config,
-    state: WalletState<ThickClient, FogResolver>,
+    state: WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>,
 ) -> rocket::Rocket {
     rocket::custom(rocket_config)
         .mount("/", routes![wallet_api, wallet_help])

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -14,7 +14,7 @@ use diesel_migrations::embed_migrations;
 use mc_account_keys::{AccountKey, PublicAddress};
 use mc_attest_core::Verifier;
 use mc_common::logger::Logger;
-use mc_connection::{Connection, ConnectionManager, ThickClient};
+use mc_connection::{Connection, ConnectionManager, HardcodedCredentialsProvider, ThickClient};
 use mc_connection_test_utils::{test_client_uri, MockBlockchainConnection};
 use mc_consensus_scp::QuorumSet;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
@@ -257,8 +257,8 @@ pub fn setup_peer_manager_and_network_state(
 pub fn setup_grpc_peer_manager_and_network_state(
     logger: Logger,
 ) -> (
-    ConnectionManager<ThickClient>,
-    Arc<RwLock<PollingNetworkState<ThickClient>>>,
+    ConnectionManager<ThickClient<HardcodedCredentialsProvider>>,
+    Arc<RwLock<PollingNetworkState<ThickClient<HardcodedCredentialsProvider>>>>,
 ) {
     let peer1 = test_client_uri(1);
     let peer2 = test_client_uri(2);
@@ -280,6 +280,7 @@ pub fn setup_grpc_peer_manager_and_network_state(
                 client_uri.clone(),
                 verifier.clone(),
                 grpc_env.clone(),
+                HardcodedCredentialsProvider::from(client_uri),
                 logger.clone(),
             )
             .expect("Could not create thick client.")


### PR DESCRIPTION
### Motivation

A previous oversight left the submodule at a revision from my fork, rather than from mobilecoin's master. This PR uprevs mobilecoin submodule to latest, which includes adding the new credentials provider to the ThickClient.

### In this PR
* uprevs mobilecoin
* adds HardcodedCredentialsProvider to ThickClient usage