### PR TITLE
Moves b58 encoding to a separate file, and stubs out a few unit tests

### DIFF
--- a/full-service/src/db/b58.rs
+++ b/full-service/src/db/b58.rs
@@ -1,0 +1,81 @@
+//! Public Address base58 encoding and decoding.
+
+use crate::db::WalletDbError;
+use mc_account_keys::PublicAddress;
+use std::convert::TryFrom;
+
+pub fn b58_encode(public_address: &PublicAddress) -> Result<String, WalletDbError> {
+    let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+    wrapper.set_public_address(public_address.into());
+    Ok(wrapper.b58_encode()?)
+}
+
+pub fn b58_decode(b58_public_address: &str) -> Result<PublicAddress, WalletDbError> {
+    let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
+        b58_public_address.to_string(),
+    )?;
+
+    let pubaddr_proto: &mc_api::external::PublicAddress = if wrapper.has_payment_request() {
+        let payment_request = wrapper.get_payment_request();
+        payment_request.get_public_address()
+    } else if wrapper.has_public_address() {
+        wrapper.get_public_address()
+    } else {
+        return Err(WalletDbError::B58Decode);
+    };
+
+    let public_address =
+        PublicAddress::try_from(pubaddr_proto).map_err(|_e| WalletDbError::B58Decode)?;
+    Ok(public_address)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::{b58_decode, b58_encode};
+    use mc_account_keys::{AccountKey, PublicAddress};
+    use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
+
+    fn get_public_address<T: RngCore + CryptoRng>(rng: &mut T) -> PublicAddress {
+        let account_key = AccountKey::random(rng);
+        account_key.default_subaddress()
+    }
+
+    #[test]
+    /// Encoding a valid PublicAddress should return Ok.
+    fn encoding_does_not_panic() {
+        // TODO: this should use property-based testing to generate random
+        // public_addresses.
+        let mut rng: StdRng = SeedableRng::from_seed([91u8; 32]);
+        let public_address = get_public_address(&mut rng);
+
+        let _encoded = b58_encode(&public_address).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    /// Encoded string should be valid b58.
+    fn encoding_produces_b58() {
+        // TODO
+        unimplemented!()
+    }
+
+    #[test]
+    /// Decoding a valid b58 string should return the correct PublicAddress.
+    fn decoding_succeeds() {
+        // TODO: this should use property-based testing to generate random
+        // public_addresses.
+        let mut rng: StdRng = SeedableRng::from_seed([91u8; 32]);
+        let public_address = get_public_address(&mut rng);
+        let encoded = b58_encode(&public_address).unwrap();
+        let decoded = b58_decode(&encoded).unwrap();
+        assert_eq!(public_address, decoded);
+    }
+
+    #[test]
+    #[ignore]
+    /// Attempting to decode invalid data should return a reasonable Error.
+    fn decoding_invalid_string_should_not_panic() {
+        // TODO
+        unimplemented!()
+    }
+}

--- a/full-service/src/db/mod.rs
+++ b/full-service/src/db/mod.rs
@@ -5,43 +5,19 @@
 pub mod account;
 pub mod account_txo_status;
 pub mod assigned_subaddress;
+mod b58;
 pub mod models;
 pub mod schema;
 pub mod transaction_log;
 pub mod txo;
 
-use mc_account_keys::PublicAddress;
-use mc_common::logger::Logger;
-
+use crate::error::WalletDbError;
+pub use b58::{b58_decode, b58_encode};
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, Pool, PooledConnection},
 };
-
-use crate::error::WalletDbError;
-use std::convert::TryFrom;
-
-// Helper method to use our PrintableWrapper to b58 encode the PublicAddress
-pub fn b58_encode(public_address: &PublicAddress) -> Result<String, WalletDbError> {
-    let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
-    wrapper.set_public_address(public_address.into());
-    Ok(wrapper.b58_encode()?)
-}
-
-pub fn b58_decode(b58_public_address: &str) -> Result<PublicAddress, WalletDbError> {
-    let wrapper =
-        mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(b58_public_address.to_string())
-            .unwrap();
-    let pubaddr_proto: &mc_api::external::PublicAddress = if wrapper.has_payment_request() {
-        let payment_request = wrapper.get_payment_request();
-        payment_request.get_public_address()
-    } else if wrapper.has_public_address() {
-        wrapper.get_public_address()
-    } else {
-        return Err(WalletDbError::B58Decode);
-    };
-    Ok(PublicAddress::try_from(pubaddr_proto).unwrap())
-}
+use mc_common::logger::Logger;
 
 #[derive(Clone)]
 pub struct WalletDb {


### PR DESCRIPTION
This is an extract of https://github.com/mobilecoinofficial/full-service/pull/24. I am breaking that into smaller independent PRs so that they are easier to review and merge.

- Handles a few errors instead of calling `unwrap()`,
- Moves b58 encoding into a separate file. That just feels nicer to me than cluttering up mod.rs,
- Stubs out a few unit tests. I'd like to work on those later.