### PR TITLE
Moves WalletDb and WalletDbError to separate files under db

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -13,7 +13,6 @@ use crate::{
         transaction_log::TransactionLogModel,
         txo::TxoModel,
     },
-    error::WalletDbError,
     service::decorated_types::JsonAccount,
 };
 
@@ -21,6 +20,7 @@ use mc_account_keys::{AccountKey, DEFAULT_SUBADDRESS_INDEX};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_transaction_core::ring_signature::KeyImage;
 
+use crate::db::WalletDbError;
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},

--- a/full-service/src/db/account_txo_status.rs
+++ b/full-service/src/db/account_txo_status.rs
@@ -2,11 +2,9 @@
 
 //! DB impl for the AccountTxoStatus model.
 
-use crate::{
-    db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_UNSPENT},
-    error::WalletDbError,
-};
+use crate::db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_UNSPENT};
 
+use crate::db::WalletDbError;
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -2,18 +2,16 @@
 
 //! DB impl for the AssignedSubaddress model
 
-use crate::{
-    db::{
-        account::{AccountID, AccountModel},
-        b58_encode,
-        models::{Account, AssignedSubaddress, NewAssignedSubaddress},
-    },
-    error::WalletDbError,
+use crate::db::{
+    account::{AccountID, AccountModel},
+    b58_encode,
+    models::{Account, AssignedSubaddress, NewAssignedSubaddress},
 };
 
 use mc_account_keys::AccountKey;
 use mc_crypto_keys::RistrettoPublic;
 
+use crate::db::WalletDbError;
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},

--- a/full-service/src/db/mod.rs
+++ b/full-service/src/db/mod.rs
@@ -12,7 +12,6 @@ pub mod txo;
 mod wallet_db;
 mod wallet_db_error;
 
-
 pub use b58::{b58_decode, b58_encode};
 pub use wallet_db::WalletDb;
 pub use wallet_db_error::WalletDbError;

--- a/full-service/src/db/mod.rs
+++ b/full-service/src/db/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
 //! Implementations of DB and DB models.
-
 pub mod account;
 pub mod account_txo_status;
 pub mod assigned_subaddress;
@@ -10,38 +9,10 @@ pub mod models;
 pub mod schema;
 pub mod transaction_log;
 pub mod txo;
+mod wallet_db;
+mod wallet_db_error;
 
-use crate::error::WalletDbError;
+
 pub use b58::{b58_decode, b58_encode};
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, Pool, PooledConnection},
-};
-use mc_common::logger::Logger;
-
-#[derive(Clone)]
-pub struct WalletDb {
-    pool: Pool<ConnectionManager<SqliteConnection>>,
-    logger: Logger,
-}
-
-impl WalletDb {
-    pub fn new(pool: Pool<ConnectionManager<SqliteConnection>>, logger: Logger) -> Self {
-        Self { pool, logger }
-    }
-
-    pub fn new_from_url(database_url: &str, logger: Logger) -> Result<Self, WalletDbError> {
-        let manager = ConnectionManager::<SqliteConnection>::new(database_url);
-        let pool = Pool::builder()
-            .max_size(1)
-            .test_on_check_out(true)
-            .build(manager)?;
-        Ok(Self::new(pool, logger))
-    }
-
-    pub fn get_conn(
-        &self,
-    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, WalletDbError> {
-        Ok(self.pool.get()?)
-    }
-}
+pub use wallet_db::WalletDb;
+pub use wallet_db_error::WalletDbError;

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2,17 +2,14 @@
 
 //! DB impl for the Transaction model.
 
-use crate::{
-    db::{
-        b58_encode,
-        models::{
-            Account, NewTransactionLog, NewTransactionTxoType, TransactionLog, TransactionTxoType,
-            Txo, TXO_CHANGE, TXO_INPUT, TXO_OUTPUT, TX_BUILT, TX_DIR_RECEIVED, TX_DIR_SENT,
-            TX_FAILED, TX_PENDING, TX_SUCCEEDED,
-        },
-        txo::{TxoID, TxoModel},
+use crate::db::{
+    b58_encode,
+    models::{
+        Account, NewTransactionLog, NewTransactionTxoType, TransactionLog, TransactionTxoType, Txo,
+        TXO_CHANGE, TXO_INPUT, TXO_OUTPUT, TX_BUILT, TX_DIR_RECEIVED, TX_DIR_SENT, TX_FAILED,
+        TX_PENDING, TX_SUCCEEDED,
     },
-    error::WalletDbError,
+    txo::{TxoID, TxoModel},
 };
 
 use mc_account_keys::AccountKey;
@@ -21,6 +18,7 @@ use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_mobilecoind::payments::TxProposal;
 use mc_transaction_core::tx::Tx;
 
+use crate::db::WalletDbError;
 use chrono::Utc;
 use diesel::{
     prelude::*,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2,19 +2,16 @@
 
 //! DB impl for the Txo model.
 
-use crate::{
-    db::{
-        account::{AccountID, AccountModel},
-        account_txo_status::AccountTxoStatusModel,
-        assigned_subaddress::AssignedSubaddressModel,
-        b58_encode,
-        models::{
-            Account, AccountTxoStatus, AssignedSubaddress, NewAccountTxoStatus, NewTxo, Txo,
-            TXO_CHANGE, TXO_MINTED, TXO_ORPHANED, TXO_OUTPUT, TXO_PENDING, TXO_RECEIVED,
-            TXO_SECRETED, TXO_SPENT, TXO_UNSPENT,
-        },
+use crate::db::{
+    account::{AccountID, AccountModel},
+    account_txo_status::AccountTxoStatusModel,
+    assigned_subaddress::AssignedSubaddressModel,
+    b58_encode,
+    models::{
+        Account, AccountTxoStatus, AssignedSubaddress, NewAccountTxoStatus, NewTxo, Txo,
+        TXO_CHANGE, TXO_MINTED, TXO_ORPHANED, TXO_OUTPUT, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED,
+        TXO_SPENT, TXO_UNSPENT,
     },
-    error::WalletDbError,
 };
 
 use mc_account_keys::{AccountKey, PublicAddress};
@@ -27,6 +24,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber},
 };
 
+use crate::db::WalletDbError;
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -1,0 +1,33 @@
+use crate::db::WalletDbError;
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool, PooledConnection},
+};
+use mc_common::logger::Logger;
+
+#[derive(Clone)]
+pub struct WalletDb {
+    pool: Pool<ConnectionManager<SqliteConnection>>,
+    logger: Logger,
+}
+
+impl WalletDb {
+    pub fn new(pool: Pool<ConnectionManager<SqliteConnection>>, logger: Logger) -> Self {
+        Self { pool, logger }
+    }
+
+    pub fn new_from_url(database_url: &str, logger: Logger) -> Result<Self, WalletDbError> {
+        let manager = ConnectionManager::<SqliteConnection>::new(database_url);
+        let pool = Pool::builder()
+            .max_size(1)
+            .test_on_check_out(true)
+            .build(manager)?;
+        Ok(Self::new(pool, logger))
+    }
+
+    pub fn get_conn(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, WalletDbError> {
+        Ok(self.pool.get()?)
+    }
+}

--- a/full-service/src/db/wallet_db_error.rs
+++ b/full-service/src/db/wallet_db_error.rs
@@ -1,0 +1,121 @@
+use displaydoc::Display;
+
+#[derive(Display, Debug)]
+pub enum WalletDbError {
+    /// Diesel Error: {0}
+    Diesel(diesel::result::Error),
+
+    /// Error with rocket databases: {0}
+    RocketDB(rocket_contrib::databases::r2d2::Error),
+
+    /// Duplicate entries with the same ID: {0}
+    DuplicateEntries(String),
+
+    /// Error encoding b58: {0}
+    B58Encode(mc_api::display::Error),
+
+    /// Error decoding b58: No public address in wrapper.
+    B58Decode,
+
+    /// Constructed a malformed transaction with multiple account IDs
+    MultipleAccountIDsInTransaction,
+
+    /// Constructed a transaction with multiple recipients (not currently
+    /// supported for transaction logs)
+    MultipleRecipientsInTransaction,
+
+    /// Constructed a transaction with no recipient
+    TransactionLacksRecipient,
+
+    /// Constructed a transaction that is not linked to any account in the
+    /// wallet
+    TransactionLacksAccount,
+
+    /// Error decoding prost: {0}
+    ProstDecode(prost::DecodeError),
+
+    /// We expect one change output per TxProposal
+    UnexpectedNumberOfChangeOutputs,
+
+    /// Key Image missing when recovering orphaned Txo
+    MissingKeyImage,
+
+    /// Subaddress on received transaction is null
+    NullSubaddressOnReceived,
+
+    /// No unspent Txos in the wallet
+    NoSpendableTxos,
+
+    /// Txos are too fragmented to construct a transaction with MAX_INPUTS.
+    /// Please combine txos.
+    InsufficientFundsFragmentedTxos,
+
+    /// Insufficient Funds: {0}
+    InsufficientFunds(String),
+
+    /// Insufficient funds from Txos under max_spendable_value: {0}
+    InsufficientFundsUnderMaxSpendable(String),
+
+    /// Multiple AccountTxoStatus entries for Txo
+    MultipleStatusesForTxo,
+
+    /// Unexpected TXO Type: {0}
+    UnexpectedTransactionTxoType(String),
+
+    /// Unexpected AccountTxoStatus: {0}
+    UnexpectedAccountTxoStatus(String),
+
+    /// Transaction mismatch when retrieving associated Txos
+    TransactionMismatch,
+
+    /// Account Not Found: {0}
+    AccountNotFound(String),
+
+    /// AssignedSubaddress Not Found: {0}
+    AssignedSubaddressNotFound(String),
+
+    /// Txo Not Found: {0}
+    TxoNotFound(String),
+
+    /// TransactionLog Not Found: {0}
+    TransactionLogNotFound(String),
+
+    /// AccountTxoStatus not found: {0}
+    AccountTxoStatusNotFound(String),
+
+    /// Cannot log a transaction with a value > i64::MAX
+    TransactionValueExceedsMax,
+
+    /// The Txo Exists, but for another account: {0}
+    TxoExistsForAnotherAccount(String),
+
+    /// The Txo is associated with too many Accounts: {0}
+    TxoAssociatedWithTooManyAccounts(String),
+
+    /// The Txo has neither received_to nor spent_from specified.
+    MalformedTxoDatabaseEntry,
+}
+
+impl From<diesel::result::Error> for WalletDbError {
+    fn from(src: diesel::result::Error) -> Self {
+        Self::Diesel(src)
+    }
+}
+
+impl From<rocket_contrib::databases::r2d2::Error> for WalletDbError {
+    fn from(src: rocket_contrib::databases::r2d2::Error) -> Self {
+        Self::RocketDB(src)
+    }
+}
+
+impl From<mc_api::display::Error> for WalletDbError {
+    fn from(src: mc_api::display::Error) -> Self {
+        Self::B58Encode(src)
+    }
+}
+
+impl From<prost::DecodeError> for WalletDbError {
+    fn from(src: prost::DecodeError) -> Self {
+        Self::ProstDecode(src)
+    }
+}

--- a/full-service/src/error.rs
+++ b/full-service/src/error.rs
@@ -2,6 +2,7 @@
 
 //! Errors for the wallet service.
 
+use crate::db::WalletDbError;
 use displaydoc::Display;
 
 #[derive(Display, Debug)]
@@ -117,126 +118,6 @@ impl From<serde_json::Error> for WalletServiceError {
 impl From<diesel::result::Error> for WalletServiceError {
     fn from(src: diesel::result::Error) -> Self {
         Self::Diesel(src)
-    }
-}
-
-#[derive(Display, Debug)]
-pub enum WalletDbError {
-    /// Diesel Error: {0}
-    Diesel(diesel::result::Error),
-
-    /// Error with rocket databases: {0}
-    RocketDB(rocket_contrib::databases::r2d2::Error),
-
-    /// Duplicate entries with the same ID: {0}
-    DuplicateEntries(String),
-
-    /// Error encoding b58: {0}
-    B58Encode(mc_api::display::Error),
-
-    /// Error decoding b58: No public address in wrapper.
-    B58Decode,
-
-    /// Constructed a malformed transaction with multiple account IDs
-    MultipleAccountIDsInTransaction,
-
-    /// Constructed a transaction with multiple recipients (not currently
-    /// supported for transaction logs)
-    MultipleRecipientsInTransaction,
-
-    /// Constructed a transaction with no recipient
-    TransactionLacksRecipient,
-
-    /// Constructed a transaction that is not linked to any account in the
-    /// wallet
-    TransactionLacksAccount,
-
-    /// Error decoding prost: {0}
-    ProstDecode(prost::DecodeError),
-
-    /// We expect one change output per TxProposal
-    UnexpectedNumberOfChangeOutputs,
-
-    /// Key Image missing when recovering orphaned Txo
-    MissingKeyImage,
-
-    /// Subaddress on received transaction is null
-    NullSubaddressOnReceived,
-
-    /// No unspent Txos in the wallet
-    NoSpendableTxos,
-
-    /// Txos are too fragmented to construct a transaction with MAX_INPUTS.
-    /// Please combine txos.
-    InsufficientFundsFragmentedTxos,
-
-    /// Insufficient Funds: {0}
-    InsufficientFunds(String),
-
-    /// Insufficient funds from Txos under max_spendable_value: {0}
-    InsufficientFundsUnderMaxSpendable(String),
-
-    /// Multiple AccountTxoStatus entries for Txo
-    MultipleStatusesForTxo,
-
-    /// Unexpected TXO Type: {0}
-    UnexpectedTransactionTxoType(String),
-
-    /// Unexpected AccountTxoStatus: {0}
-    UnexpectedAccountTxoStatus(String),
-
-    /// Transaction mismatch when retrieving associated Txos
-    TransactionMismatch,
-
-    /// Account Not Found: {0}
-    AccountNotFound(String),
-
-    /// AssignedSubaddress Not Found: {0}
-    AssignedSubaddressNotFound(String),
-
-    /// Txo Not Found: {0}
-    TxoNotFound(String),
-
-    /// TransactionLog Not Found: {0}
-    TransactionLogNotFound(String),
-
-    /// AccountTxoStatus not found: {0}
-    AccountTxoStatusNotFound(String),
-
-    /// Cannot log a transaction with a value > i64::MAX
-    TransactionValueExceedsMax,
-
-    /// The Txo Exists, but for another account: {0}
-    TxoExistsForAnotherAccount(String),
-
-    /// The Txo is associated with too many Accounts: {0}
-    TxoAssociatedWithTooManyAccounts(String),
-
-    /// The Txo has neither received_to nor spent_from specified.
-    MalformedTxoDatabaseEntry,
-}
-
-impl From<diesel::result::Error> for WalletDbError {
-    fn from(src: diesel::result::Error) -> Self {
-        Self::Diesel(src)
-    }
-}
-
-impl From<rocket_contrib::databases::r2d2::Error> for WalletDbError {
-    fn from(src: rocket_contrib::databases::r2d2::Error) -> Self {
-        Self::RocketDB(src)
-    }
-}
-
-impl From<mc_api::display::Error> for WalletDbError {
-    fn from(src: mc_api::display::Error) -> Self {
-        Self::B58Encode(src)
-    }
-}
-
-impl From<prost::DecodeError> for WalletDbError {
-    fn from(src: prost::DecodeError) -> Self {
-        Self::ProstDecode(src)
     }
 }
 

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -31,9 +31,9 @@ use crate::{
         models::{Account, AssignedSubaddress, TransactionLog, Txo},
         transaction_log::TransactionLogModel,
         txo::TxoModel,
-        WalletDb,
+        WalletDb, WalletDbError,
     },
-    error::{SyncError, WalletDbError},
+    error::SyncError,
 };
 use mc_account_keys::AccountKey;
 use mc_common::{

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -540,7 +540,7 @@ fn extract_fog_uri(addr: &PublicAddress) -> Result<Option<FogUri>, WalletTransac
 mod tests {
     use super::*;
     use crate::{
-        error::WalletDbError,
+        db::WalletDbError,
         service::sync::SyncThread,
         test_utils::{
             builder_for_random_recipient, get_test_ledger, random_account_with_seed_values,


### PR DESCRIPTION
This change is pulled from https://github.com/mobilecoinofficial/full-service/pull/24

- Moves WalletDb out of mod.rs. That feels clean to me, and ought to help with organization if we do things like use a trait and/or mocks for this.
- Moves WalletDbError out of the top-level errors.rs, into a separate file under `db`. Small files feel better to me, and I like keeping error types close to the code that generates those errors.