### PR TITLE
TXO status constants

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -8,7 +8,7 @@ use crate::{
         b58_encode,
         models::{
             Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo,
-            TXO_PENDING, TXO_SPENT, TXO_UNSPENT,
+            TXO_STATUS_PENDING, TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
         },
         transaction_log::TransactionLogModel,
         txo::TxoModel,
@@ -244,14 +244,16 @@ impl AccountModel for Account {
         Ok(conn.transaction::<JsonAccount, WalletDbError, _>(|| {
             let account = Account::get(account_id_hex, conn)?;
 
-            let unspent = Txo::list_by_status(&account_id_hex.to_string(), TXO_UNSPENT, conn)?
-                .iter()
-                .map(|t| t.value as u128)
-                .sum::<u128>();
-            let pending = Txo::list_by_status(&account_id_hex.to_string(), TXO_PENDING, conn)?
-                .iter()
-                .map(|t| t.value as u128)
-                .sum::<u128>();
+            let unspent =
+                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_UNSPENT, conn)?
+                    .iter()
+                    .map(|t| t.value as u128)
+                    .sum::<u128>();
+            let pending =
+                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_PENDING, conn)?
+                    .iter()
+                    .map(|t| t.value as u128)
+                    .sum::<u128>();
 
             let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
             let main_subaddress_b58 =
@@ -357,7 +359,7 @@ impl AccountModel for Account {
                     )
                     .set(
                         crate::db::schema::account_txo_statuses::txo_status
-                            .eq(TXO_SPENT.to_string()),
+                            .eq(TXO_STATUS_SPENT.to_string()),
                     )
                     .execute(conn)?;
 

--- a/full-service/src/db/account_txo_status.rs
+++ b/full-service/src/db/account_txo_status.rs
@@ -2,7 +2,7 @@
 
 //! DB impl for the AccountTxoStatus model.
 
-use crate::db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_UNSPENT};
+use crate::db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_STATUS_UNSPENT};
 
 use crate::db::WalletDbError;
 use diesel::{
@@ -104,7 +104,7 @@ impl AccountTxoStatusModel for AccountTxoStatus {
         use crate::db::schema::account_txo_statuses::txo_status;
 
         diesel::update(self)
-            .set(txo_status.eq(TXO_UNSPENT))
+            .set(txo_status.eq(TXO_STATUS_UNSPENT))
             .execute(conn)?;
         Ok(())
     }

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -9,14 +9,21 @@ use super::schema::{
 
 use serde::Serialize;
 
-// FIXME: WS-13 - Would be great to get enums to work. Run into several issues
-// when attempting        to use https://github.com/adwhit/diesel-derive-enum for sqlite
-// TxoStatus
-pub const TXO_UNSPENT: &str = "unspent";
-pub const TXO_PENDING: &str = "pending";
-pub const TXO_SPENT: &str = "spent";
-pub const TXO_SECRETED: &str = "secreted";
-pub const TXO_ORPHANED: &str = "orphaned";
+/// A TXO owned by this wallet that has not yet been spent.
+pub const TXO_STATUS_UNSPENT: &str = "txo_status_unspent";
+
+/// A TXO owned by this wallet that is used by a pending transaction.
+pub const TXO_STATUS_PENDING: &str = "txo_status_pending";
+
+/// A TXO owned by this wallet that has been spent.
+pub const TXO_STATUS_SPENT: &str = "txo_status_spent";
+
+/// TODO: ???
+pub const TXO_STATUS_SECRETED: &str = "txo_status_secreted";
+
+/// The TXO is owned by this wallet, but not yet spendable (i.e., receiving
+/// subaddress is unknown).
+pub const TXO_STATUS_ORPHANED: &str = "txo_status_orphaned";
 
 // TxoType
 pub const TXO_MINTED: &str = "minted";

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -507,7 +507,7 @@ mod tests {
     use crate::{
         db::{
             account::{AccountID, AccountModel},
-            models::{TXO_MINTED, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED},
+            models::{TXO_MINTED, TXO_RECEIVED, TXO_STATUS_PENDING, TXO_STATUS_SECRETED},
         },
         service::sync::SyncThread,
         test_utils::{
@@ -666,7 +666,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_PENDING
+            TXO_STATUS_PENDING
         ); // Should now be pending
         assert_eq!(
             input_details.received_to_account.clone().unwrap().txo_type,
@@ -692,7 +692,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_SECRETED
+            TXO_STATUS_SECRETED
         );
         assert_eq!(
             output_details
@@ -716,7 +716,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_SECRETED
+            TXO_STATUS_SECRETED
         ); // Note, change becomes "unspent" once scanned
         assert_eq!(
             change_details

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -11,7 +11,7 @@
 use crate::{
     db::{
         account::{AccountID, AccountModel},
-        models::{Account, Txo, TXO_UNSPENT},
+        models::{Account, Txo, TXO_STATUS_UNSPENT},
         txo::TxoModel,
         WalletDb,
     },
@@ -110,7 +110,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
         let txos = Txo::select_by_id(&input_txo_ids.to_vec(), &self.wallet_db.get_conn()?)?;
         let unspent: Vec<Txo> = txos
             .iter()
-            .filter(|(_txo, status)| status.txo_status == TXO_UNSPENT)
+            .filter(|(_txo, status)| status.txo_status == TXO_STATUS_UNSPENT)
             .map(|(t, _s)| t.clone())
             .collect();
         if unspent.iter().map(|t| t.value as u128).sum::<u128>() > u64::MAX as u128 {
@@ -626,7 +626,7 @@ mod tests {
         // Check balance
         let unspent = Txo::list_by_status(
             &AccountID::from(&account_key).to_string(),
-            TXO_UNSPENT,
+            TXO_STATUS_UNSPENT,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -495,9 +495,7 @@ mod tests {
     use crate::{
         db::{
             b58_decode,
-            models::{
-                TXO_ORPHANED, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED, TXO_SPENT, TXO_UNSPENT,
-            },
+            models::{TXO_RECEIVED, TXO_STATUS_UNSPENT},
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, get_resolver_factory,
@@ -922,7 +920,7 @@ mod tests {
             .unwrap()
             .as_str()
             .unwrap();
-        assert_eq!(txo_status, TXO_UNSPENT);
+        assert_eq!(txo_status, TXO_STATUS_UNSPENT);
         let txo_type = account_status_map
             .get("txo_type")
             .unwrap()
@@ -941,7 +939,7 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent, "100");
     }
 
@@ -1066,7 +1064,7 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent, "100000000000100");
 
         // Submit the tx_proposal
@@ -1099,11 +1097,11 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
-        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
-        let orphaned = balance_status.get(TXO_ORPHANED).unwrap().as_str().unwrap();
-        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let pending = balance_status.get("pending").unwrap().as_str().unwrap();
+        let spent = balance_status.get("spent").unwrap().as_str().unwrap();
+        let orphaned = balance_status.get("orphaned").unwrap().as_str().unwrap();
+        let secreted = balance_status.get("secreted").unwrap().as_str().unwrap();
         assert_eq!(unspent, "0");
         assert_eq!(pending, "100000000000100");
         assert_eq!(spent, "0");
@@ -1241,7 +1239,7 @@ mod tests {
             .get(account_id)
             .unwrap();
         let txo_status = status_map.get("txo_status").unwrap().as_str().unwrap();
-        assert_eq!(txo_status, TXO_UNSPENT);
+        assert_eq!(txo_status, TXO_STATUS_UNSPENT);
         let txo_type = status_map.get("txo_type").unwrap().as_str().unwrap();
         assert_eq!(txo_type, TXO_RECEIVED);
         let value = txo.get("value_pmob").unwrap().as_str().unwrap();
@@ -1362,7 +1360,7 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
 
         // Build a transaction
@@ -1414,11 +1412,11 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
-        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
-        let orphaned = balance_status.get(TXO_ORPHANED).unwrap().as_str().unwrap();
-        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let pending = balance_status.get("pending").unwrap().as_str().unwrap();
+        let spent = balance_status.get("spent").unwrap().as_str().unwrap();
+        let orphaned = balance_status.get("orphaned").unwrap().as_str().unwrap();
+        let secreted = balance_status.get("secreted").unwrap().as_str().unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
         assert_eq!(pending.parse::<i64>().unwrap(), 0);
         assert_eq!(spent.parse::<i64>().unwrap(), 0);

--- a/full-service/src/service/wallet_impl.rs
+++ b/full-service/src/service/wallet_impl.rs
@@ -8,8 +8,8 @@ use crate::{
         assigned_subaddress::AssignedSubaddressModel,
         b58_decode,
         models::{
-            Account, AssignedSubaddress, TransactionLog, Txo, TXO_ORPHANED, TXO_PENDING,
-            TXO_SECRETED, TXO_SPENT, TXO_UNSPENT,
+            Account, AssignedSubaddress, TransactionLog, Txo, TXO_STATUS_ORPHANED,
+            TXO_STATUS_PENDING, TXO_STATUS_SECRETED, TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
         },
         transaction_log::TransactionLogModel,
         txo::TxoModel,
@@ -342,23 +342,23 @@ impl<
     ) -> Result<JsonBalanceResponse, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
 
-        let unspent = Txo::list_by_status(account_id_hex, TXO_UNSPENT, &conn)?
+        let unspent = Txo::list_by_status(account_id_hex, TXO_STATUS_UNSPENT, &conn)?
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let spent = Txo::list_by_status(account_id_hex, TXO_SPENT, &conn)?
+        let spent = Txo::list_by_status(account_id_hex, TXO_STATUS_SPENT, &conn)?
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let secreted = Txo::list_by_status(account_id_hex, TXO_SECRETED, &conn)?
+        let secreted = Txo::list_by_status(account_id_hex, TXO_STATUS_SECRETED, &conn)?
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let orphaned = Txo::list_by_status(account_id_hex, TXO_ORPHANED, &conn)?
+        let orphaned = Txo::list_by_status(account_id_hex, TXO_STATUS_ORPHANED, &conn)?
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        let pending = Txo::list_by_status(account_id_hex, TXO_PENDING, &conn)?
+        let pending = Txo::list_by_status(account_id_hex, TXO_STATUS_PENDING, &conn)?
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
@@ -733,7 +733,7 @@ mod tests {
             txos[0].account_status_map[&alice.account.account_id]
                 .get("txo_status")
                 .unwrap(),
-            TXO_UNSPENT
+            TXO_STATUS_UNSPENT
         );
 
         // Add another account
@@ -766,7 +766,7 @@ mod tests {
             .iter()
             .cloned()
             .filter(|t| {
-                t.account_status_map[&alice.account.account_id]["txo_status"] == TXO_PENDING
+                t.account_status_map[&alice.account.account_id]["txo_status"] == TXO_STATUS_PENDING
             })
             .collect();
         assert_eq!(pending.len(), 1);


### PR DESCRIPTION
Txos in the database have both a "status" and a "type", and both status and type have associated constants. However, the constants don't contain the word "status" or "type" in their names or values, which causes ambiguity and invites hard-to-see bugs.

### In this PR
* Gives the DB-level TXO status constants more descriptive names and unambiguous values.
* Fixes unit tests that referred to the DB-level constants, instead of the API-level JSON response fields.

This is a breaking database change, which I'm assuming is OK at this point?