### PR TITLE
Db constants

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -8,7 +8,7 @@ use crate::{
         b58_encode,
         models::{
             Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo,
-            TXO_PENDING, TXO_SPENT, TXO_UNSPENT,
+            TXO_STATUS_PENDING, TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
         },
         transaction_log::TransactionLogModel,
         txo::TxoModel,
@@ -244,14 +244,16 @@ impl AccountModel for Account {
         Ok(conn.transaction::<JsonAccount, WalletDbError, _>(|| {
             let account = Account::get(account_id_hex, conn)?;
 
-            let unspent = Txo::list_by_status(&account_id_hex.to_string(), TXO_UNSPENT, conn)?
-                .iter()
-                .map(|t| t.value as u128)
-                .sum::<u128>();
-            let pending = Txo::list_by_status(&account_id_hex.to_string(), TXO_PENDING, conn)?
-                .iter()
-                .map(|t| t.value as u128)
-                .sum::<u128>();
+            let unspent =
+                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_UNSPENT, conn)?
+                    .iter()
+                    .map(|t| t.value as u128)
+                    .sum::<u128>();
+            let pending =
+                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_PENDING, conn)?
+                    .iter()
+                    .map(|t| t.value as u128)
+                    .sum::<u128>();
 
             let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
             let main_subaddress_b58 =
@@ -352,7 +354,7 @@ impl AccountModel for Account {
                     )
                     .set(
                         crate::db::schema::account_txo_statuses::txo_status
-                            .eq(TXO_SPENT.to_string()),
+                            .eq(TXO_STATUS_SPENT.to_string()),
                     )
                     .execute(conn)?;
 

--- a/full-service/src/db/account_txo_status.rs
+++ b/full-service/src/db/account_txo_status.rs
@@ -2,7 +2,9 @@
 
 //! DB impl for the AccountTxoStatus model.
 
-use crate::db::models::{AccountTxoStatus, NewAccountTxoStatus, TXO_ORPHANED, TXO_UNSPENT};
+use crate::db::models::{
+    AccountTxoStatus, NewAccountTxoStatus, TXO_STATUS_ORPHANED, TXO_STATUS_UNSPENT,
+};
 
 use crate::db::WalletDbError;
 use diesel::{
@@ -109,7 +111,7 @@ impl AccountTxoStatusModel for AccountTxoStatus {
         use crate::db::schema::account_txo_statuses::txo_status;
 
         diesel::update(self)
-            .set(txo_status.eq(TXO_UNSPENT))
+            .set(txo_status.eq(TXO_STATUS_UNSPENT))
             .execute(conn)?;
         Ok(())
     }
@@ -121,7 +123,7 @@ impl AccountTxoStatusModel for AccountTxoStatus {
         use crate::db::schema::account_txo_statuses::txo_status;
 
         diesel::update(self)
-            .set(txo_status.eq(TXO_ORPHANED))
+            .set(txo_status.eq(TXO_STATUS_ORPHANED))
             .execute(conn)?;
         Ok(())
     }

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -9,33 +9,57 @@ use super::schema::{
 
 use serde::Serialize;
 
-// FIXME: WS-13 - Would be great to get enums to work. Run into several issues
-// when attempting        to use https://github.com/adwhit/diesel-derive-enum for sqlite
-// TxoStatus
-pub const TXO_UNSPENT: &str = "unspent";
-pub const TXO_PENDING: &str = "pending";
-pub const TXO_SPENT: &str = "spent";
-pub const TXO_SECRETED: &str = "secreted";
-pub const TXO_ORPHANED: &str = "orphaned";
+/// A TXO owned by an account in this wallet that has not yet been spent.
+pub const TXO_STATUS_UNSPENT: &str = "unspent";
 
-// TxoType
-pub const TXO_MINTED: &str = "minted";
-pub const TXO_RECEIVED: &str = "received";
+/// A TXO owned by an account in this wallet that is used by a pending
+/// transaction.
+pub const TXO_STATUS_PENDING: &str = "pending";
 
-// TransactionStatus
-pub const TX_BUILT: &str = "built";
-pub const TX_PENDING: &str = "pending";
-pub const TX_SUCCEEDED: &str = "succeeded";
-pub const TX_FAILED: &str = "failed";
+/// A TXO owned by an account in this wallet that has been spent.
+pub const TXO_STATUS_SPENT: &str = "spent";
 
-// Transaction Direction
+/// A TXO created by an account in this wallet for use as an output in an
+/// outgoing transaction.
+pub const TXO_STATUS_SECRETED: &str = "secreted";
+
+/// The TXO is owned by this wallet, but not yet spendable (i.e., receiving
+/// subaddress is unknown).
+pub const TXO_STATUS_ORPHANED: &str = "orphaned";
+
+/// A Txo that has been created locally, but is not yet in the ledger.
+pub const TXO_TYPE_MINTED: &str = "minted";
+
+/// A Txo in the ledger that belongs to an account in this wallet.
+pub const TXO_TYPE_RECEIVED: &str = "received";
+
+/// A transaction that has been built locally.
+pub const TX_STATUS_BUILT: &str = "built";
+
+/// A transaction that has been submitted to the MobileCoin network.
+pub const TX_STATUS_PENDING: &str = "pending";
+
+/// A transaction that appears to have been processed by the MobileCoin network.
+pub const TX_STATUS_SUCCEEDED: &str = "succeeded";
+
+/// A transaction that was rejected by the MobileCoin network, or that expired
+/// before it could be processed.
+pub const TX_STATUS_FAILED: &str = "failed";
+
+/// A transaction created by an account in this wallet.
 pub const TX_DIR_SENT: &str = "sent";
+
+/// A TxOut received by an account in this wallet.
 pub const TX_DIR_RECEIVED: &str = "received";
 
-// Transaction Txo Type
-pub const TXO_INPUT: &str = "input";
-pub const TXO_OUTPUT: &str = "output";
-pub const TXO_CHANGE: &str = "change";
+/// A transaction output that is used as an input to a new transaction.
+pub const TXO_USED_AS_INPUT: &str = "input";
+
+/// A transaction output that is used as an output of a new transaction.
+pub const TXO_USED_AS_OUTPUT: &str = "output";
+
+/// A transaction output used as a change output of a new transaction.
+pub const TXO_USED_AS_CHANGE: &str = "change";
 
 /// An Account entity.
 ///

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -47,10 +47,10 @@ pub const TX_STATUS_SUCCEEDED: &str = "tx_status_succeeded";
 pub const TX_STATUS_FAILED: &str = "tx_status_failed";
 
 /// A transaction created by an account in this wallet.
-pub const TX_DIR_SENT: &str = "sent";
+pub const TX_DIRECTION_SENT: &str = "tx_direction_sent";
 
 /// A TxOut received by an account in this wallet.
-pub const TX_DIR_RECEIVED: &str = "received";
+pub const TX_DIRECTION_RECEIVED: &str = "tx_direction_received";
 
 /// A transaction output that is used as an input to a new transaction.
 pub const TXO_USED_AS_INPUT: &str = "input";

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -53,13 +53,13 @@ pub const TX_DIRECTION_SENT: &str = "tx_direction_sent";
 pub const TX_DIRECTION_RECEIVED: &str = "tx_direction_received";
 
 /// A transaction output that is used as an input to a new transaction.
-pub const TXO_USED_AS_INPUT: &str = "input";
+pub const TXO_USED_AS_INPUT: &str = "txo_used_as_input";
 
 /// A transaction output that is used as an output of a new transaction.
-pub const TXO_USED_AS_OUTPUT: &str = "output";
+pub const TXO_USED_AS_OUTPUT: &str = "txo_used_as_output";
 
 /// A transaction output used as a change output of a new transaction.
-pub const TXO_USED_AS_CHANGE: &str = "change";
+pub const TXO_USED_AS_CHANGE: &str = "txo_used_as_change";
 
 /// An Account entity.
 ///

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -34,17 +34,17 @@ pub const TXO_TYPE_MINTED: &str = "txo_type_minted";
 pub const TXO_TYPE_RECEIVED: &str = "txo_type_received";
 
 /// A transaction that has been built locally.
-pub const TX_STATUS_BUILT: &str = "built";
+pub const TX_STATUS_BUILT: &str = "tx_status_built";
 
 /// A transaction that has been submitted to the MobileCoin network.
-pub const TX_STATUS_PENDING: &str = "pending";
+pub const TX_STATUS_PENDING: &str = "tx_status_pending";
 
 /// A transaction that appears to have been processed by the MobileCoin network.
-pub const TX_STATUS_SUCCEEDED: &str = "succeeded";
+pub const TX_STATUS_SUCCEEDED: &str = "tx_status_succeeded";
 
 /// A transaction that was rejected by the MobileCoin network, or that expired
 /// before it could be processed.
-pub const TX_STATUS_FAILED: &str = "failed";
+pub const TX_STATUS_FAILED: &str = "tx_status_failed";
 
 /// A transaction created by an account in this wallet.
 pub const TX_DIR_SENT: &str = "sent";

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -28,10 +28,10 @@ pub const TXO_STATUS_SECRETED: &str = "txo_status_secreted";
 pub const TXO_STATUS_ORPHANED: &str = "txo_status_orphaned";
 
 /// A Txo that has been created locally, but is not yet in the ledger.
-pub const TXO_TYPE_MINTED: &str = "minted";
+pub const TXO_TYPE_MINTED: &str = "txo_type_minted";
 
 /// A Txo in the ledger that belongs to an account in this wallet.
-pub const TXO_TYPE_RECEIVED: &str = "received";
+pub const TXO_TYPE_RECEIVED: &str = "txo_type_received";
 
 /// A transaction that has been built locally.
 pub const TX_STATUS_BUILT: &str = "built";

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -10,22 +10,22 @@ use super::schema::{
 use serde::Serialize;
 
 /// A TXO owned by an account in this wallet that has not yet been spent.
-pub const TXO_STATUS_UNSPENT: &str = "unspent";
+pub const TXO_STATUS_UNSPENT: &str = "txo_status_unspent";
 
 /// A TXO owned by an account in this wallet that is used by a pending
 /// transaction.
-pub const TXO_STATUS_PENDING: &str = "pending";
+pub const TXO_STATUS_PENDING: &str = "txo_status_pending";
 
 /// A TXO owned by an account in this wallet that has been spent.
-pub const TXO_STATUS_SPENT: &str = "spent";
+pub const TXO_STATUS_SPENT: &str = "txo_status_spent";
 
 /// A TXO created by an account in this wallet for use as an output in an
 /// outgoing transaction.
-pub const TXO_STATUS_SECRETED: &str = "secreted";
+pub const TXO_STATUS_SECRETED: &str = "txo_status_secreted";
 
 /// The TXO is owned by this wallet, but not yet spendable (i.e., receiving
 /// subaddress is unknown).
-pub const TXO_STATUS_ORPHANED: &str = "orphaned";
+pub const TXO_STATUS_ORPHANED: &str = "txo_status_orphaned";
 
 /// A Txo that has been created locally, but is not yet in the ledger.
 pub const TXO_TYPE_MINTED: &str = "minted";

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -6,8 +6,8 @@ use crate::db::{
     b58_encode,
     models::{
         Account, NewTransactionLog, NewTransactionTxoType, TransactionLog, TransactionTxoType, Txo,
-        TXO_CHANGE, TXO_INPUT, TXO_OUTPUT, TX_BUILT, TX_DIR_RECEIVED, TX_DIR_SENT, TX_FAILED,
-        TX_PENDING, TX_SUCCEEDED,
+        TXO_USED_AS_CHANGE, TXO_USED_AS_INPUT, TXO_USED_AS_OUTPUT, TX_DIR_RECEIVED, TX_DIR_SENT,
+        TX_STATUS_BUILT, TX_STATUS_FAILED, TX_STATUS_PENDING, TX_STATUS_SUCCEEDED,
     },
     txo::{TxoID, TxoModel},
 };
@@ -171,9 +171,9 @@ impl TransactionLogModel for TransactionLog {
 
         for (_transaction, transaction_txo_type) in transaction_txos {
             match transaction_txo_type.transaction_txo_type.as_str() {
-                TXO_INPUT => inputs.push(transaction_txo_type.txo_id_hex),
-                TXO_OUTPUT => outputs.push(transaction_txo_type.txo_id_hex),
-                TXO_CHANGE => change.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_INPUT => inputs.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_OUTPUT => outputs.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_CHANGE => change.push(transaction_txo_type.txo_id_hex),
                 _ => {
                     return Err(WalletDbError::UnexpectedTransactionTxoType(
                         transaction_txo_type.transaction_txo_type,
@@ -253,9 +253,9 @@ impl TransactionLogModel for TransactionLog {
             }
 
             match transaction_txo_type.transaction_txo_type.as_str() {
-                TXO_INPUT => entry.inputs.push(transaction_txo_type.txo_id_hex),
-                TXO_OUTPUT => entry.outputs.push(transaction_txo_type.txo_id_hex),
-                TXO_CHANGE => entry.change.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_INPUT => entry.inputs.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_OUTPUT => entry.outputs.push(transaction_txo_type.txo_id_hex),
+                TXO_USED_AS_CHANGE => entry.change.push(transaction_txo_type.txo_id_hex),
                 _ => {
                     return Err(WalletDbError::UnexpectedTransactionTxoType(
                         transaction_txo_type.transaction_txo_type,
@@ -294,7 +294,9 @@ impl TransactionLogModel for TransactionLog {
                 let associated = transaction_log.get_associated_txos(conn)?;
 
                 // Only update transaction_log status if built or pending
-                if transaction_log.status != TX_BUILT && transaction_log.status != TX_PENDING {
+                if transaction_log.status != TX_STATUS_BUILT
+                    && transaction_log.status != TX_STATUS_PENDING
+                {
                     continue;
                 }
 
@@ -308,7 +310,7 @@ impl TransactionLogModel for TransactionLog {
                             .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
                     )
                     .set((
-                        crate::db::schema::transaction_logs::status.eq(TX_SUCCEEDED),
+                        crate::db::schema::transaction_logs::status.eq(TX_STATUS_SUCCEEDED),
                         crate::db::schema::transaction_logs::finalized_block_count
                             .eq(Some(cur_block_count)),
                     ))
@@ -320,7 +322,7 @@ impl TransactionLogModel for TransactionLog {
                         transaction_logs
                             .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
                     )
-                    .set(crate::db::schema::transaction_logs::status.eq(TX_FAILED))
+                    .set(crate::db::schema::transaction_logs::status.eq(TX_STATUS_FAILED))
                     .execute(conn)?;
                 }
             }
@@ -367,7 +369,7 @@ impl TransactionLogModel for TransactionLog {
                         assigned_subaddress_b58: &b58_subaddress,
                         value: txo.value,
                         fee: None, // Impossible to recover fee from received transaction
-                        status: TX_SUCCEEDED,
+                        status: TX_STATUS_SUCCEEDED,
                         sent_time: None, // NULL for received
                         submitted_block_count: None,
                         finalized_block_count: Some(block_count as i64),
@@ -384,7 +386,7 @@ impl TransactionLogModel for TransactionLog {
                     let new_transaction_txo = NewTransactionTxoType {
                         transaction_id_hex: &transaction_id.to_string(),
                         txo_id_hex: &txo.txo_id_hex,
-                        transaction_txo_type: TXO_OUTPUT,
+                        transaction_txo_type: TXO_USED_AS_OUTPUT,
                     };
                     // Note: SQLite backend does not support batch insert, so within iter is fine
                     diesel::insert_into(transaction_txo_types::table)
@@ -418,7 +420,7 @@ impl TransactionLogModel for TransactionLog {
             for utxo in tx_proposal.utxos.iter() {
                 let txo_id = TxoID::from(&utxo.tx_out);
                 Txo::update_to_pending(&txo_id, conn)?;
-                txo_ids.push((txo_id.to_string(), TXO_INPUT.to_string()));
+                txo_ids.push((txo_id.to_string(), TXO_USED_AS_INPUT.to_string()));
             }
 
             // Next, add all of our minted outputs to the Txo Table
@@ -469,7 +471,7 @@ impl TransactionLogModel for TransactionLog {
                     assigned_subaddress_b58: "", // NULL for sent
                     value: transaction_value as i64,
                     fee: Some(tx_proposal.tx.prefix.fee as i64),
-                    status: TX_PENDING,
+                    status: TX_STATUS_PENDING,
                     sent_time: Some(Utc::now().timestamp()),
                     submitted_block_count: Some(block_count as i64),
                     finalized_block_count: None,
@@ -507,7 +509,7 @@ mod tests {
     use crate::{
         db::{
             account::{AccountID, AccountModel},
-            models::{TXO_MINTED, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED},
+            models::{TXO_STATUS_PENDING, TXO_STATUS_SECRETED, TXO_TYPE_MINTED, TXO_TYPE_RECEIVED},
         },
         service::sync::SyncThread,
         test_utils::{
@@ -639,7 +641,7 @@ mod tests {
         // Fee exists for submitted
         assert_eq!(tx_log.fee, Some(MINIMUM_FEE as i64));
         // Created and sent transaction is "pending" until it lands
-        assert_eq!(tx_log.status, TX_PENDING);
+        assert_eq!(tx_log.status, TX_STATUS_PENDING);
         assert!(tx_log.sent_time.unwrap() > 0);
         assert_eq!(
             tx_log.submitted_block_count,
@@ -666,11 +668,11 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_PENDING
+            TXO_STATUS_PENDING
         ); // Should now be pending
         assert_eq!(
             input_details.received_to_account.clone().unwrap().txo_type,
-            TXO_RECEIVED
+            TXO_TYPE_RECEIVED
         );
         assert_eq!(
             input_details
@@ -692,7 +694,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_SECRETED
+            TXO_STATUS_SECRETED
         );
         assert_eq!(
             output_details
@@ -700,7 +702,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_type,
-            TXO_MINTED
+            TXO_TYPE_MINTED
         );
         assert!(output_details.received_to_account.is_none());
         assert!(output_details.received_to_assigned_subaddress.is_none());
@@ -716,7 +718,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_status,
-            TXO_SECRETED
+            TXO_STATUS_SECRETED
         ); // Note, change becomes "unspent" once scanned
         assert_eq!(
             change_details
@@ -724,7 +726,7 @@ mod tests {
                 .clone()
                 .unwrap()
                 .txo_type,
-            TXO_MINTED
+            TXO_TYPE_MINTED
         ); // Note, becomes "received" once scanned
         assert!(change_details.received_to_account.is_none()); // Note, gets filled in once scanned
         assert!(change_details.received_to_assigned_subaddress.is_none()); // Note, gets filled in once scanned
@@ -790,7 +792,7 @@ mod tests {
         // Fee exists for submitted
         assert_eq!(tx_log.fee, Some(MINIMUM_FEE as i64));
         // Created and sent transaction is "pending" until it lands
-        assert_eq!(tx_log.status, TX_PENDING);
+        assert_eq!(tx_log.status, TX_STATUS_PENDING);
         assert!(tx_log.sent_time.unwrap() > 0);
         assert_eq!(
             tx_log.submitted_block_count,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -6,8 +6,9 @@ use crate::db::{
     b58_encode,
     models::{
         Account, NewTransactionLog, NewTransactionTxoType, TransactionLog, TransactionTxoType, Txo,
-        TXO_USED_AS_CHANGE, TXO_USED_AS_INPUT, TXO_USED_AS_OUTPUT, TX_DIR_RECEIVED, TX_DIR_SENT,
-        TX_STATUS_BUILT, TX_STATUS_FAILED, TX_STATUS_PENDING, TX_STATUS_SUCCEEDED,
+        TXO_USED_AS_CHANGE, TXO_USED_AS_INPUT, TXO_USED_AS_OUTPUT, TX_DIRECTION_RECEIVED,
+        TX_DIRECTION_SENT, TX_STATUS_BUILT, TX_STATUS_FAILED, TX_STATUS_PENDING,
+        TX_STATUS_SUCCEEDED,
     },
     txo::{TxoID, TxoModel},
 };
@@ -374,7 +375,7 @@ impl TransactionLogModel for TransactionLog {
                         submitted_block_count: None,
                         finalized_block_count: Some(block_count as i64),
                         comment: "", // NULL for received
-                        direction: TX_DIR_RECEIVED,
+                        direction: TX_DIRECTION_RECEIVED,
                         tx: None, // NULL for received
                     };
 
@@ -476,7 +477,7 @@ impl TransactionLogModel for TransactionLog {
                     submitted_block_count: Some(block_count as i64),
                     finalized_block_count: None,
                     comment: &comment,
-                    direction: TX_DIR_SENT,
+                    direction: TX_DIRECTION_SENT,
                     tx: Some(&tx),
                 };
 
@@ -648,7 +649,7 @@ mod tests {
             Some(ledger_db.num_blocks().unwrap() as i64)
         );
         assert_eq!(tx_log.comment, "");
-        assert_eq!(tx_log.direction, TX_DIR_SENT);
+        assert_eq!(tx_log.direction, TX_DIRECTION_SENT);
         let tx: Tx = mc_util_serial::decode(&tx_log.clone().tx.unwrap()).unwrap();
         assert_eq!(tx, tx_proposal.tx);
 
@@ -799,7 +800,7 @@ mod tests {
             Some(ledger_db.num_blocks().unwrap() as i64)
         );
         assert_eq!(tx_log.comment, "");
-        assert_eq!(tx_log.direction, TX_DIR_SENT);
+        assert_eq!(tx_log.direction, TX_DIRECTION_SENT);
         let tx: Tx = mc_util_serial::decode(&tx_log.clone().tx.unwrap()).unwrap();
         assert_eq!(tx, tx_proposal.tx);
 

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -11,7 +11,7 @@
 use crate::{
     db::{
         account::{AccountID, AccountModel},
-        models::{Account, Txo, TXO_UNSPENT},
+        models::{Account, Txo, TXO_STATUS_UNSPENT},
         txo::TxoModel,
         WalletDb,
     },
@@ -110,7 +110,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
         let txos = Txo::select_by_id(&input_txo_ids.to_vec(), &self.wallet_db.get_conn()?)?;
         let unspent: Vec<Txo> = txos
             .iter()
-            .filter(|(_txo, status)| status.txo_status == TXO_UNSPENT)
+            .filter(|(_txo, status)| status.txo_status == TXO_STATUS_UNSPENT)
             .map(|(t, _s)| t.clone())
             .collect();
         if unspent.iter().map(|t| t.value as u128).sum::<u128>() > u64::MAX as u128 {
@@ -626,7 +626,7 @@ mod tests {
         // Check balance
         let unspent = Txo::list_by_status(
             &AccountID::from(&account_key).to_string(),
-            TXO_UNSPENT,
+            TXO_STATUS_UNSPENT,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -495,7 +495,7 @@ mod tests {
     use crate::{
         db::{
             b58_decode,
-            models::{TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED, TX_STATUS_PENDING},
+            models::{TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED, TX_DIRECTION_SENT, TX_STATUS_PENDING},
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, get_resolver_factory,
@@ -1121,7 +1121,7 @@ mod tests {
         let transaction_log = result.get("transaction").unwrap();
         assert_eq!(
             transaction_log.get("direction").unwrap().as_str().unwrap(),
-            "sent"
+            TX_DIRECTION_SENT
         );
         assert_eq!(
             transaction_log.get("value_pmob").unwrap().as_str().unwrap(),

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -496,7 +496,8 @@ mod tests {
         db::{
             b58_decode,
             models::{
-                TXO_ORPHANED, TXO_PENDING, TXO_RECEIVED, TXO_SECRETED, TXO_SPENT, TXO_UNSPENT,
+                TXO_STATUS_ORPHANED, TXO_STATUS_PENDING, TXO_STATUS_SECRETED, TXO_STATUS_SPENT,
+                TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED,
             },
         },
         test_utils::{
@@ -922,13 +923,13 @@ mod tests {
             .unwrap()
             .as_str()
             .unwrap();
-        assert_eq!(txo_status, TXO_UNSPENT);
+        assert_eq!(txo_status, TXO_STATUS_UNSPENT);
         let txo_type = account_status_map
             .get("txo_type")
             .unwrap()
             .as_str()
             .unwrap();
-        assert_eq!(txo_type, TXO_RECEIVED);
+        assert_eq!(txo_type, TXO_TYPE_RECEIVED);
         let value = txo.get("value_pmob").unwrap().as_str().unwrap();
         assert_eq!(value, "100");
 
@@ -941,7 +942,11 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status
+            .get(TXO_STATUS_UNSPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "100");
     }
 
@@ -1066,7 +1071,11 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status
+            .get(TXO_STATUS_UNSPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "100000000000100");
 
         // Submit the tx_proposal
@@ -1099,11 +1108,31 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
-        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
-        let orphaned = balance_status.get(TXO_ORPHANED).unwrap().as_str().unwrap();
-        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
+        let unspent = balance_status
+            .get(TXO_STATUS_UNSPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let pending = balance_status
+            .get(TXO_STATUS_PENDING)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let spent = balance_status
+            .get(TXO_STATUS_SPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let orphaned = balance_status
+            .get(TXO_STATUS_ORPHANED)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let secreted = balance_status
+            .get(TXO_STATUS_SECRETED)
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "0");
         assert_eq!(pending, "100000000000100");
         assert_eq!(spent, "0");
@@ -1241,9 +1270,9 @@ mod tests {
             .get(account_id)
             .unwrap();
         let txo_status = status_map.get("txo_status").unwrap().as_str().unwrap();
-        assert_eq!(txo_status, TXO_UNSPENT);
+        assert_eq!(txo_status, TXO_STATUS_UNSPENT);
         let txo_type = status_map.get("txo_type").unwrap().as_str().unwrap();
-        assert_eq!(txo_type, TXO_RECEIVED);
+        assert_eq!(txo_type, TXO_TYPE_RECEIVED);
         let value = txo.get("value_pmob").unwrap().as_str().unwrap();
         assert_eq!(value, "42000000000000");
     }
@@ -1362,7 +1391,11 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
+        let unspent = balance_status
+            .get(TXO_STATUS_UNSPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
 
         // Build a transaction
@@ -1414,11 +1447,31 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
-        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
-        let orphaned = balance_status.get(TXO_ORPHANED).unwrap().as_str().unwrap();
-        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
+        let unspent = balance_status
+            .get(TXO_STATUS_UNSPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let pending = balance_status
+            .get(TXO_STATUS_PENDING)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let spent = balance_status
+            .get(TXO_STATUS_SPENT)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let orphaned = balance_status
+            .get(TXO_STATUS_ORPHANED)
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let secreted = balance_status
+            .get(TXO_STATUS_SECRETED)
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
         assert_eq!(pending.parse::<i64>().unwrap(), 0);
         assert_eq!(spent.parse::<i64>().unwrap(), 0);

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -495,10 +495,7 @@ mod tests {
     use crate::{
         db::{
             b58_decode,
-            models::{
-                TXO_STATUS_ORPHANED, TXO_STATUS_PENDING, TXO_STATUS_SECRETED, TXO_STATUS_SPENT,
-                TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED,
-            },
+            models::{TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED},
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, get_resolver_factory,
@@ -942,11 +939,7 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status
-            .get(TXO_STATUS_UNSPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent, "100");
     }
 
@@ -1071,11 +1064,7 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status
-            .get(TXO_STATUS_UNSPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent, "100000000000100");
 
         // Submit the tx_proposal
@@ -1108,31 +1097,11 @@ mod tests {
         });
         let result = dispatch(&client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status
-            .get(TXO_STATUS_UNSPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let pending = balance_status
-            .get(TXO_STATUS_PENDING)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let spent = balance_status
-            .get(TXO_STATUS_SPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let orphaned = balance_status
-            .get(TXO_STATUS_ORPHANED)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let secreted = balance_status
-            .get(TXO_STATUS_SECRETED)
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let pending = balance_status.get("pending").unwrap().as_str().unwrap();
+        let spent = balance_status.get("spent").unwrap().as_str().unwrap();
+        let orphaned = balance_status.get("orphaned").unwrap().as_str().unwrap();
+        let secreted = balance_status.get("secreted").unwrap().as_str().unwrap();
         assert_eq!(unspent, "0");
         assert_eq!(pending, "100000000000100");
         assert_eq!(spent, "0");
@@ -1392,7 +1361,7 @@ mod tests {
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
         let unspent = balance_status
-            .get(TXO_STATUS_UNSPENT)
+            .get("unspent")
             .unwrap()
             .as_str()
             .unwrap();
@@ -1447,31 +1416,11 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status
-            .get(TXO_STATUS_UNSPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let pending = balance_status
-            .get(TXO_STATUS_PENDING)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let spent = balance_status
-            .get(TXO_STATUS_SPENT)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let orphaned = balance_status
-            .get(TXO_STATUS_ORPHANED)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let secreted = balance_status
-            .get(TXO_STATUS_SECRETED)
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let pending = balance_status.get("pending").unwrap().as_str().unwrap();
+        let spent = balance_status.get("spent").unwrap().as_str().unwrap();
+        let orphaned = balance_status.get("orphaned").unwrap().as_str().unwrap();
+        let secreted = balance_status.get("secreted").unwrap().as_str().unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
         assert_eq!(pending.parse::<i64>().unwrap(), 0);
         assert_eq!(spent.parse::<i64>().unwrap(), 0);

--- a/full-service/src/service/wallet.rs
+++ b/full-service/src/service/wallet.rs
@@ -495,7 +495,7 @@ mod tests {
     use crate::{
         db::{
             b58_decode,
-            models::{TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED},
+            models::{TXO_STATUS_UNSPENT, TXO_TYPE_RECEIVED, TX_STATUS_PENDING},
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, get_resolver_factory,
@@ -1150,7 +1150,7 @@ mod tests {
         );
         assert_eq!(
             transaction_log.get("status").unwrap().as_str().unwrap(),
-            "pending"
+            TX_STATUS_PENDING
         );
         assert_eq!(
             transaction_log
@@ -1360,11 +1360,7 @@ mod tests {
         });
         let result = dispatch(&offline_client, body, &logger);
         let balance_status = result.get("status").unwrap();
-        let unspent = balance_status
-            .get("unspent")
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
         assert_eq!(unspent.parse::<i64>().unwrap(), 42 * MOB);
 
         // Build a transaction

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -3,7 +3,7 @@
 use crate::{
     db::{
         account::{AccountID, AccountModel},
-        models::{Account, TransactionLog, Txo, TXO_CHANGE, TXO_OUTPUT},
+        models::{Account, TransactionLog, Txo, TXO_USED_AS_CHANGE, TXO_USED_AS_OUTPUT},
         transaction_log::TransactionLogModel,
         txo::TxoModel,
         WalletDb,
@@ -482,7 +482,7 @@ pub fn create_test_minted_and_change_txos(
     )
     .unwrap();
     assert!(processed_output.recipient.is_some());
-    assert_eq!(processed_output.txo_type, TXO_OUTPUT);
+    assert_eq!(processed_output.txo_type, TXO_USED_AS_OUTPUT);
 
     // Create minted for the change output.
     let change_txo_index = if outlay_txo_index == 0 { 1 } else { 0 };
@@ -497,7 +497,7 @@ pub fn create_test_minted_and_change_txos(
     .unwrap();
     assert_eq!(processed_change.recipient, None,);
     // Change starts as an output, and is updated to change when scanned.
-    assert_eq!(processed_change.txo_type, TXO_CHANGE);
+    assert_eq!(processed_change.txo_type, TXO_USED_AS_CHANGE);
     (
         (processed_output.txo_id, processed_output.value),
         (processed_change.txo_id, processed_change.value),


### PR DESCRIPTION
This folds together the previous PRs that updated the DB constants' names and values. Those were small PRs, so it seemed easier to review them as a bunch instead of rebasing each of them on top of the latest changes.

### In this PR
* Updates names of constants to more clearly indicate what they are used for ("foo_status", "foo_type", etc)
* Updates values of constants to match the constant names. 
* Fixes a few unit tests that accidentally referred to DB constants instead of JSON response fields.
