### PR TITLE
FS-114: Transactions by Block

### DIFF
--- a/API_v2.md
+++ b/API_v2.md
@@ -22,8 +22,8 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 * [build_and_submit_transaction](#build-and-submit-transaction)
 * [build_transaction](#build-transaction)
 * [submit_transaction](#submit-transaction)
-* [get_all_transactions_by_account](#get-all-transactions)
-* [get_transaction](#get-transaction)
+* [get_all_transaction_logs_for_account](#get-all-transaction-logs-for-account)
+* [get_transaction_log](#get-transaction-log)
 * [get_proofs](#get-proofs)
 * [verify_proof](#verify-proof)
 * [get_txo_object](#get-txo-object)
@@ -1381,12 +1381,12 @@ curl -s localhost:9090/wallet \
 | `account_id` | Account ID for which to log the transaction. If omitted, the transaction is not logged.   | |
 | `comment` | Comment to annotate this transaction in the transaction log   | |
 
-#### Get All Transactions
+#### Get All Transaction Logs For Account
 
 ```sh
 curl -s localhost:9090/wallet \
   -d '{
-        "method": "get_all_transactions_by_account",
+        "method": "get_all_transaction_logs_for_account",
         "params": {
           "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10"
         },
@@ -1399,68 +1399,72 @@ curl -s localhost:9090/wallet \
 
 ```json
 {
-  "method": "get_all_transactions_by_account",
+  "method": "get_all_transaction_logs_for_account",
   "result": {
     "transaction_log_ids": [
-      "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c",
-      "fcd2979f737f213fc327cd79d10c490a9bd4cb163084d4a154585c5e93e8c075"
+      "49da8168e26331fc9bc109d1e59f7ed572b453f232591de4196f9cefb381c3f4",
+      "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1"
     ],
     "transaction_log_map": {
-      "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c": {
-        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
-        "assigned_address_id": "7BeDc5jpZu72AuNavumc8qo8CRJijtQ7QJXyPo9dpnqULaPhe6GdaDNF7cjxkTrDfTcfMgWVgDzKzbvTTwp32KQ78qpx7bUnPYxAgy92caJ",
-        "change_txo_ids": [],
-        "comment": "",
-        "direction": "received",
-        "failure_code": null,
-        "failure_message": null,
-        "fee_pmob": null,
-        "finalized_block_height": "144965",
-        "input_txo_ids": [],
-        "is_sent_recovered": null,
+      "49da8168e26331fc9bc109d1e59f7ed572b453f232591de4196f9cefb381c3f4": {
         "object": "transaction_log",
-        "offset_count": 296,
-        "output_txo_ids": [
-          "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c"
-        ],
+        "transaction_log_id": "49da8168e26331fc9bc109d1e59f7ed572b453f232591de4196f9cefb381c3f4",
+        "direction": "tx_direction_received",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
         "recipient_address_id": null,
-        "sent_time": null,
-        "status": "succeeded",
-        "submitted_block_height": null,
-        "transaction_log_id": "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c",
-        "value_pmob": "443990000000000"
-      },
-      "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c": {
-        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
-        "assigned_address_id": null,
-        "change_txo_ids": [
-          "e992e718e1f28b67b0cf200e213af560fc7d5a236b3fec590f225b230f88257f"
+        "assigned_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "value_pmob": "8199980000000000",
+        "fee_pmob": null,
+        "submitted_block_index": null,
+        "finalized_block_index": "130689",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [],
+        "output_txo_ids": [
+          "49da8168e26331fc9bc109d1e59f7ed572b453f232591de4196f9cefb381c3f4"
         ],
+        "change_txo_ids": [],
+        "sent_time": null,
         "comment": "",
-        "direction": "sent",
-        "fee_pmob": "10000000000",
         "failure_code": null,
         "failure_message": null,
-        "finalized_block_height": "152826",
-        "input_txo_ids": [
-          "3de563a16d2da9656ce6c8aa9b12380b682c2e6aad0011fa8d6528c084078827",
-          "fa242e21e2155e8f257cd75d2d2939000d0926946c2b7b812946e093165acadb"
-        ],
-        "is_sent_recovered": null,
+        "offset_count": 4
+      },
+      "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1": {
         "object": "transaction_log",
-        "offset_count": 496,
-        "output_txo_ids": [
-          "badf415972dfc2dc6203ed90be132831ff29f394f65b0be5c35c79048d86af5b"
+        "transaction_log_id": "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1",
+        "direction": "tx_direction_sent",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "assigned_address_id": null,
+        "value_pmob": "8000000000008",
+        "fee_pmob": "10000000000",
+        "submitted_block_index": "152951",
+        "finalized_block_index": "152951",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [
+          "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb",
+          "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815"
         ],
-        "recipient_address_id": "7BeDc5jpZu72AuNavumc8qo8CRJijtQ7QJXyPo9dpnqULaPhe6GdaDNF7cjxkTrDfTcfMgWVgDzKzbvTTwp32KQ78qpx7bUnPYxAgy92caJ",
-        "sent_time": "2020-12-15 09:30:04 UTC",
-        "status": "succeeded",
-        "submitted_block_height": "152826",
-        "transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d",
-        "value_pmob": "1000000000000"
+        "output_txo_ids": [
+          "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab"
+        ],
+        "change_txo_ids": [
+          "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc"
+        ],
+        "sent_time": "2021-02-28 03:05:11 UTC",
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 53
       }
     }
-  }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
 }
 ```
 
@@ -1468,14 +1472,14 @@ curl -s localhost:9090/wallet \
 | :------------- | :----------------------- | :------------------------ |
 | `account_id`   | The account on which to perform this action  | Account must exist in the wallet  |
 
-#### Get Transaction
+#### Get Transaction Log
 
 ```sh
 curl -s localhost:9090/wallet \
   -d '{
-        "method": "get_transaction",
+        "method": "get_transaction_log",
         "params": {
-          "transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d"
+          "transaction_log_id": "914e703b5b7bc44b61bb3657b4ee8a184d00e87a728e2fe6754a77a38598a800"
         },
         "jsonrpc": "2.0",
         "api_version": "2",
@@ -1486,38 +1490,37 @@ curl -s localhost:9090/wallet \
 
 ```json
 {
-  "method": "get_transaction",
+  "method": "get_transaction_log",
   "result": {
-    "transaction": {
+    "transaction_log": {
       "object": "transaction_log",
-      "transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d",
-      "direction": "sent",
+      "transaction_log_id": "914e703b5b7bc44b61bb3657b4ee8a184d00e87a728e2fe6754a77a38598a800",
+      "direction": "tx_direction_received",
       "is_sent_recovered": null,
-      "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
-      "recipient_address_id": "7BeDc5jpZu72AuNavumc8qo8CRJijtQ7QJXyPo9dpnqULaPhe6GdaDNF7cjxkTrDfTcfMgWVgDzKzbvTTwp32KQ78qpx7bUnPYxAgy92caJ",
+      "account_id": "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17",
+      "recipient_address_id": null,
       "assigned_address_id": null,
-      "value_pmob": "1000000000000",
-      "fee_pmob": "10000000000",
-      "submitted_block_height": "152826",
-      "finalized_block_height": "152826",
-      "status": "succeeded",
-      "input_txo_ids": [
-        "3de563a16d2da9656ce6c8aa9b12380b682c2e6aad0011fa8d6528c084078827",
-        "fa242e21e2155e8f257cd75d2d2939000d0926946c2b7b812946e093165acadb"
-      ],
+      "value_pmob": "51068338999989068",
+      "fee_pmob": null,
+      "submitted_block_index": null,
+      "finalized_block_index": "152905",
+      "status": "tx_status_succeeded",
+      "input_txo_ids": [],
       "output_txo_ids": [
-        "badf415972dfc2dc6203ed90be132831ff29f394f65b0be5c35c79048d86af5b"
+        "914e703b5b7bc44b61bb3657b4ee8a184d00e87a728e2fe6754a77a38598a800"
       ],
-      "change_txo_ids": [
-        "e992e718e1f28b67b0cf200e213af560fc7d5a236b3fec590f225b230f88257f"
-      ],
-      "sent_time": "2020-12-15 09:30:04 UTC",
+      "change_txo_ids": [],
+      "sent_time": null,
       "comment": "",
       "failure_code": null,
       "failure_message": null,
-      "offset_count": 496
+      "offset_count": 37
     }
-  }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
 }
 ```
 
@@ -1913,6 +1916,7 @@ The balance for an account, as well as some information about syncing status nee
 
 | *Name* | *Type* | *Description*
 | :--- | :--- | :---
+| object | string, value is "transaction_log" | String representing the object's type. Objects of the same type share the same value.
 | transaction_log_id | int | Unique identifier for the transaction log. This value is not associated to the ledger.
 | direction | string | A string that identifies if this transaction log was sent or received. Valid values are "sent" or "received".
 | is_sent_recovered | boolean | Flag that indicates if the sent transaction log was recovered from the ledger. This value is null for "received" transaction logs. If true, some information may not be available on the transaction log and its txos without user input. If true, the fee receipient_address_id, fee, and sent_time will be null without user input.
@@ -1923,13 +1927,7 @@ The balance for an account, as well as some information about syncing status nee
 | fee_pmob | string (uint64) | Fee in pico MOB associated to this transaction log. Only on outgoing transaction logs. Only available if direction is "sent".
 | submitted_block_index | string (uint64) | The block index of the highest block on the network at the time the transaction was submitted.
 | finalized_block_index | string (uint64) | The scanned block block index in which this transaction occurred.
-| status | string | String representing the transaction log status. On "sent", valid statuses are "built", "pending", "succeeded", "failed".  On "received", the status is "succeded".
-
-#### More attributes
-
-| *Name* | *Type* | *Description*
-| :--- | :--- | :---
-| object | string, value is "transaction_log" | String representing the object's type. Objects of the same type share the same value.
+| status | string | String representing the transaction log status. On "sent", valid statuses are "built", "pending", "succeeded", "failed".  On "received", the status is "succeeded".
 | input_txo_ids | list | A list of the IDs of the Txos which were inputs to this transaction.
 | output_txo_ids | list | A list of the IDs of the Txos which were outputs of this transaction.
 | change_txo_ids | list | A list of the IDs of the Txos which were change in this transaction.
@@ -2042,8 +2040,8 @@ Sent - Success, Recovered:
 
 #### API Methods Returning Transaction Log Objects
 
-* [get_all_transactions_by_account](#get-all-transactions)
-* [get_transaction](#get-transaction)
+* [get_all_transaction_logs_for_account](#get-all-transaction-logs-for-account)
+* [get_transaction_log](#get-transaction-log)
 * [build_and_submit_transaction](#build-and-submit-transaction)
 * [submit_transaction](#submit-transaction)
 

--- a/API_v2.md
+++ b/API_v2.md
@@ -24,6 +24,8 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 * [submit_transaction](#submit-transaction)
 * [get_all_transaction_logs_for_account](#get-all-transaction-logs-for-account)
 * [get_transaction_log](#get-transaction-log)
+* [get_all_transaction_logs_for_block](#get-all-transaction-logs-for-block)
+* [get_all_transaction_logs_ordered_by_block](#get-all-transaction-logs-ordered-by-block)
 * [get_proofs](#get-proofs)
 * [verify_proof](#verify-proof)
 * [get_txo_object](#get-txo-object)
@@ -1497,7 +1499,7 @@ curl -s localhost:9090/wallet \
       "transaction_log_id": "914e703b5b7bc44b61bb3657b4ee8a184d00e87a728e2fe6754a77a38598a800",
       "direction": "tx_direction_received",
       "is_sent_recovered": null,
-      "account_id": "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17",
+      "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
       "recipient_address_id": null,
       "assigned_address_id": null,
       "value_pmob": "51068338999989068",
@@ -1527,6 +1529,223 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `transaction_log_id`   | The transaction log ID for which to get proofs.  | Transaction log must exist in the wallet  |
+
+#### Get All Transaction Logs for Block
+
+Get the transaction logs in a given block. In the below example, the account in the wallet sent a transaction to itself. Therefore, there is one sent transaction_log in the block, and two received (one for the change, and one for the output txo sent to the same account that constructed the transaction).
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "get_all_transaction_logs_for_block",
+        "params": {
+          "block_index": "152951"
+        },
+        "jsonrpc": "2.0",
+        "api_version": "2",
+        "id": 1
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+
+{
+  "method": "get_all_transaction_logs_for_block",
+  "result": {
+    "transaction_log_ids": [
+      "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1",
+      "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc",
+      "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab"
+    ],
+    "transaction_log_map": {
+      "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1": {
+        "object": "transaction_log",
+        "transaction_log_id": "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1",
+        "direction": "tx_direction_sent",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "assigned_address_id": null,
+        "value_pmob": "8000000000008",
+        "fee_pmob": "10000000000",
+        "submitted_block_index": "152951",
+        "finalized_block_index": "152951",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [
+          "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb",
+          "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815"
+        ],
+        "output_txo_ids": [
+          "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab"
+        ],
+        "change_txo_ids": [
+          "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc"
+        ],
+        "sent_time": "2021-02-28 03:05:11 UTC",
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 53
+      },
+      "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc": {
+        "object": "transaction_log",
+        "transaction_log_id": "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc",
+        "direction": "tx_direction_received",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": null,
+        "assigned_address_id": "2pW3CcHUmg4cafp9ePCpPg72mowC6NJZ1iHQxpkiAuPJuWDVUC9WEGRxychqFmKXx68VqerFKiHeEATwM5hZcf9SKC9Cub2GyMsztSqYdjY",
+        "value_pmob": "11891402222024",
+        "fee_pmob": null,
+        "submitted_block_index": null,
+        "finalized_block_index": "152951",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [],
+        "output_txo_ids": [
+          "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc"
+        ],
+        "change_txo_ids": [],
+        "sent_time": null,
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 54
+      },
+      "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab": {
+        "object": "transaction_log",
+        "transaction_log_id": "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab",
+        "direction": "tx_direction_received",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": null,
+        "assigned_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "value_pmob": "8000000000008",
+        "fee_pmob": null,
+        "submitted_block_index": null,
+        "finalized_block_index": "152951",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [],
+        "output_txo_ids": [
+          "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab"
+        ],
+        "change_txo_ids": [],
+        "sent_time": null,
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 55
+      }
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
+}
+```
+
+#### Get All Transaction Logs Ordered By Block
+
+Get the transaction logs, grouped by the `finalized_block_index`, in ascending order.
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "get_all_transaction_logs_ordered_by_block",
+        "jsonrpc": "2.0",
+        "api_version": "2",
+        "id": 1
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+
+{
+  "method": "get_all_transaction_logs_ordered_by_block",
+  "result": {
+    "transaction_log_map": {
+      "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815": {
+        "object": "transaction_log",
+        "transaction_log_id": "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815",
+        "direction": "tx_direction_received",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": null,
+        "assigned_address_id": "2pW3CcHUmg4cafp9ePCpPg72mowC6NJZ1iHQxpkiAuPJuWDVUC9WEGRxychqFmKXx68VqerFKiHeEATwM5hZcf9SKC9Cub2GyMsztSqYdjY",
+        "value_pmob": "11901402222024",
+        "fee_pmob": null,
+        "submitted_block_index": null,
+        "finalized_block_index": "152923",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [],
+        "output_txo_ids": [
+          "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815"
+        ],
+        "change_txo_ids": [],
+        "sent_time": null,
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 51
+      },
+      "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb": {
+        "object": "transaction_log",
+        "transaction_log_id": "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb",
+        "direction": "tx_direction_received",
+        "is_sent_recovered": null,
+        "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+        "recipient_address_id": null,
+        "assigned_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "value_pmob": "8000000000008",
+        "fee_pmob": null,
+        "submitted_block_index": null,
+        "finalized_block_index": "152948",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [],
+        "output_txo_ids": [
+          "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb"
+        ],
+        "change_txo_ids": [],
+        "sent_time": null,
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 52
+      },
+      "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1": {
+        "object": "transaction_log",
+        "transaction_log_id": "ff1c85e7a488c2821110597ba75db30d913bb1595de549f83c6e8c56b06d70d1",
+        "direction": "tx_direction_sent",
+        "is_sent_recovered": null,
+        "account_id": "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17",
+        "recipient_address_id": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
+        "assigned_address_id": null,
+        "value_pmob": "8000000000008",
+        "fee_pmob": "10000000000",
+        "submitted_block_index": "152951",
+        "finalized_block_index": "152951",
+        "status": "tx_status_succeeded",
+        "input_txo_ids": [
+          "135c3861be4034fccb8d0b329f86124cb6e2404cd4debf52a3c3a10cb4a7bdfb",
+          "c91b5f27e28460ef6c4f33229e70c4cfe6dc4bc1517a22122a86df9fb8e40815"
+        ],
+        "output_txo_ids": [
+          "243494a0030bcbac40e87670b9288834047ef0727bcc6630a2fe2799439879ab"
+        ],
+        "change_txo_ids": [
+          "58729797de0929eed37acb45225d3631235933b709c00015f46bfc002d5754fc"
+        ],
+        "sent_time": "2021-02-28 03:05:11 UTC",
+        "comment": "",
+        "failure_code": null,
+        "failure_message": null,
+        "offset_count": 53
+      }
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
+}
+
+```
 
 ### Transaction Output Proofs
 
@@ -2042,6 +2261,8 @@ Sent - Success, Recovered:
 
 * [get_all_transaction_logs_for_account](#get-all-transaction-logs-for-account)
 * [get_transaction_log](#get-transaction-log)
+* [get_all_transaction_logs_for_block](#get-all-transaction-logs-for-block)
+* [get_all_transaction_logs_ordered_by_block](#get-all-transaction-logs-ordered-by-block)
 * [build_and_submit_transaction](#build-and-submit-transaction)
 * [submit_transaction](#submit-transaction)
 

--- a/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
+++ b/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
@@ -76,6 +76,7 @@ CREATE TABLE transaction_logs (
 );
 
 CREATE UNIQUE INDEX idx_transaction_logs__transaction_id_hex ON transaction_logs (transaction_id_hex);
+CREATE UNIQUE INDEX idx_transaction_logs__finzlied_block_index ON transaction_logs (finalized_block_index);
 
 CREATE TABLE transaction_txo_types (
     transaction_id_hex VARCHAR NOT NULL,

--- a/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
+++ b/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
@@ -76,7 +76,7 @@ CREATE TABLE transaction_logs (
 );
 
 CREATE UNIQUE INDEX idx_transaction_logs__transaction_id_hex ON transaction_logs (transaction_id_hex);
-CREATE UNIQUE INDEX idx_transaction_logs__finzlied_block_index ON transaction_logs (finalized_block_index);
+CREATE INDEX idx_transaction_logs__finzlied_block_index ON transaction_logs (finalized_block_index);
 
 CREATE TABLE transaction_txo_types (
     transaction_id_hex VARCHAR NOT NULL,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -181,7 +181,6 @@ impl TransactionLogModel for TransactionLog {
         };
 
         let matches = transaction_logs
-            .group_by(finalized_block_index)
             .select(all_columns)
             .order_by(finalized_block_index.asc())
             .load(conn)?;

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -65,6 +65,17 @@ pub trait TransactionLogModel {
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<TransactionLog, WalletDbError>;
 
+    /// Get all transaction logs for the given block index.
+    fn get_all_for_block_index(
+        block_index: u64,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<TransactionLog>, WalletDbError>;
+
+    /// Get all transaction logs ordered by finalized_block_index.
+    fn get_all_ordered_by_block_index(
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<TransactionLog>, WalletDbError>;
+
     /// Get the Txos associated with a given TransactionId, grouped according to
     /// their type.
     ///
@@ -144,6 +155,38 @@ impl TransactionLogModel for TransactionLog {
             )),
             Err(e) => Err(e.into()),
         }
+    }
+
+    fn get_all_for_block_index(
+        block_index: u64,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<TransactionLog>, WalletDbError> {
+        use crate::db::schema::transaction_logs::{
+            all_columns, dsl::transaction_logs, finalized_block_index,
+        };
+
+        let matches: Vec<TransactionLog> = transaction_logs
+            .select(all_columns)
+            .filter(finalized_block_index.eq(block_index as i64))
+            .load::<TransactionLog>(conn)?;
+
+        Ok(matches)
+    }
+
+    fn get_all_ordered_by_block_index(
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<TransactionLog>, WalletDbError> {
+        use crate::db::schema::transaction_logs::{
+            all_columns, dsl::transaction_logs, finalized_block_index,
+        };
+
+        let matches = transaction_logs
+            .group_by(finalized_block_index)
+            .select(all_columns)
+            .order_by(finalized_block_index.asc())
+            .load(conn)?;
+
+        Ok(matches)
     }
 
     fn get_associated_txos(
@@ -304,8 +347,6 @@ impl TransactionLogModel for TransactionLog {
                 // Check whether all the inputs have been spent or if any failed, and update
                 // accordingly
                 if Txo::are_all_spent(&associated.inputs, conn)? {
-                    // FIXME: WS-18 - do we want to store "submitted_block_index" to disambiguate
-                    // block_count?
                     diesel::update(
                         transaction_logs
                             .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
@@ -313,7 +354,7 @@ impl TransactionLogModel for TransactionLog {
                     .set((
                         crate::db::schema::transaction_logs::status.eq(TX_STATUS_SUCCEEDED),
                         crate::db::schema::transaction_logs::finalized_block_index
-                            .eq(Some(cur_block_count)),
+                            .eq(Some(cur_block_count - 1)),
                     ))
                     .execute(conn)?;
                 } else if Txo::any_failed(&associated.inputs, cur_block_count, conn)? {
@@ -373,7 +414,7 @@ impl TransactionLogModel for TransactionLog {
                         status: TX_STATUS_SUCCEEDED,
                         sent_time: None, // NULL for received
                         submitted_block_index: None,
-                        finalized_block_index: Some(block_count as i64),
+                        finalized_block_index: Some((block_count - 1) as i64),
                         comment: "", // NULL for received
                         direction: TX_DIRECTION_RECEIVED,
                         tx: None, // NULL for received
@@ -474,7 +515,7 @@ impl TransactionLogModel for TransactionLog {
                     fee: Some(tx_proposal.tx.prefix.fee as i64),
                     status: TX_STATUS_PENDING,
                     sent_time: Some(Utc::now().timestamp()),
-                    submitted_block_index: Some(block_count as i64),
+                    submitted_block_index: Some((block_count - 1) as i64),
                     finalized_block_index: None,
                     comment: &comment,
                     direction: TX_DIRECTION_SENT,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -354,7 +354,7 @@ impl TransactionLogModel for TransactionLog {
                     .set((
                         crate::db::schema::transaction_logs::status.eq(TX_STATUS_SUCCEEDED),
                         crate::db::schema::transaction_logs::finalized_block_index
-                            .eq(Some(cur_block_count - 1)),
+                            .eq(Some(cur_block_count)),
                     ))
                     .execute(conn)?;
                 } else if Txo::any_failed(&associated.inputs, cur_block_count, conn)? {
@@ -414,7 +414,7 @@ impl TransactionLogModel for TransactionLog {
                         status: TX_STATUS_SUCCEEDED,
                         sent_time: None, // NULL for received
                         submitted_block_index: None,
-                        finalized_block_index: Some((block_count - 1) as i64),
+                        finalized_block_index: Some(block_count as i64),
                         comment: "", // NULL for received
                         direction: TX_DIRECTION_RECEIVED,
                         tx: None, // NULL for received
@@ -515,7 +515,7 @@ impl TransactionLogModel for TransactionLog {
                     fee: Some(tx_proposal.tx.prefix.fee as i64),
                     status: TX_STATUS_PENDING,
                     sent_time: Some(Utc::now().timestamp()),
-                    submitted_block_index: Some((block_count - 1) as i64),
+                    submitted_block_index: Some(block_count as i64),
                     finalized_block_index: None,
                     comment: &comment,
                     direction: TX_DIRECTION_SENT,

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -184,6 +184,8 @@ pub fn wait_for_sync(
 ) {
     let mut count = 0;
     loop {
+        // FIXME: FS-122: Use async primitives so that we don't have to sleep for these
+        // tests.
         // Sleep to let the sync thread process the txos
         std::thread::sleep(Duration::from_secs(1));
 
@@ -218,6 +220,7 @@ pub fn wait_for_sync(
             );
             break;
         }
+
         // Have to manually call poll() on network state to get it to update for these
         // tests
         network_state.write().unwrap().poll();

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -187,10 +187,6 @@ pub fn wait_for_sync(
         // Sleep to let the sync thread process the txos
         std::thread::sleep(Duration::from_secs(1));
 
-        // Have to manually call poll() on network state to get it to update for these
-        // tests
-        network_state.write().unwrap().poll();
-
         // Check that syncing is working
         let body = json!({
             "jsonrpc": "2.0",
@@ -222,6 +218,9 @@ pub fn wait_for_sync(
             );
             break;
         }
+        // Have to manually call poll() on network state to get it to update for these
+        // tests
+        network_state.write().unwrap().poll();
 
         count += 1;
         if count > 10 {

--- a/full-service/src/json_rpc/api_v1/decorated_types.rs
+++ b/full-service/src/json_rpc/api_v1/decorated_types.rs
@@ -3,12 +3,7 @@
 //! Decorated types for the service to return, with constructors from the
 //! database types.
 
-use crate::db::{
-    models::{AssignedSubaddress, TransactionLog},
-    transaction_log::AssociatedTxos,
-    txo::TxoDetails,
-};
-use chrono::{TimeZone, Utc};
+use crate::db::{models::AssignedSubaddress, txo::TxoDetails};
 use mc_mobilecoind_json::data_types::{JsonTxOut, JsonTxOutMembershipElement};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Map;
@@ -116,69 +111,6 @@ impl JsonAddress {
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct JsonSubmitResponse {
     pub transaction_id: Option<String>,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct JsonTransactionLog {
-    pub object: String,
-    pub transaction_log_id: String,
-    pub direction: String,
-    pub is_sent_recovered: Option<bool>,
-    pub account_id: String,
-    pub recipient_address_id: Option<String>,
-    pub assigned_address_id: Option<String>,
-    pub value_pmob: String,
-    pub fee_pmob: Option<String>,
-    pub submitted_block_index: Option<String>,
-    pub finalized_block_index: Option<String>,
-    pub status: String,
-    pub input_txo_ids: Vec<String>,
-    pub output_txo_ids: Vec<String>,
-    pub change_txo_ids: Vec<String>,
-    pub sent_time: Option<String>,
-    pub comment: String,
-    pub failure_code: Option<i32>,
-    pub failure_message: Option<String>,
-    pub offset_count: i32,
-}
-
-impl JsonTransactionLog {
-    pub fn new(transaction_log: &TransactionLog, associated_txos: &AssociatedTxos) -> Self {
-        let recipient_address_id = transaction_log.recipient_public_address_b58.clone();
-        let assigned_address_id = transaction_log.assigned_subaddress_b58.clone();
-        Self {
-            object: "transaction_log".to_string(),
-            transaction_log_id: transaction_log.transaction_id_hex.clone(),
-            direction: transaction_log.direction.clone(),
-            is_sent_recovered: None, // FIXME: WS-16 "Is Sent Recovered"
-            account_id: transaction_log.account_id_hex.clone(),
-            recipient_address_id: if recipient_address_id == "" {
-                None
-            } else {
-                Some(recipient_address_id)
-            },
-            assigned_address_id: if assigned_address_id == "" {
-                None
-            } else {
-                Some(assigned_address_id)
-            },
-            value_pmob: transaction_log.value.to_string(),
-            fee_pmob: transaction_log.fee.map(|x| x.to_string()),
-            submitted_block_index: transaction_log.submitted_block_index.map(|b| b.to_string()),
-            finalized_block_index: transaction_log.finalized_block_index.map(|b| b.to_string()),
-            status: transaction_log.status.clone(),
-            input_txo_ids: associated_txos.inputs.clone(),
-            output_txo_ids: associated_txos.outputs.clone(),
-            change_txo_ids: associated_txos.change.clone(),
-            sent_time: transaction_log
-                .sent_time
-                .map(|t| Utc.timestamp(t, 0).to_string()),
-            comment: transaction_log.comment.clone(),
-            failure_code: None,    // FIXME: WS-17 Failiure code
-            failure_message: None, // FIXME: WS-17 Failure message
-            offset_count: transaction_log.id,
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]

--- a/full-service/src/json_rpc/api_v1/wallet_api.rs
+++ b/full-service/src/json_rpc/api_v1/wallet_api.rs
@@ -61,6 +61,7 @@ pub enum JsonCommandRequestV1 {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(tag = "method", content = "result")]
 #[allow(non_camel_case_types)]
+#[allow(clippy::large_enum_variant)]
 pub enum JsonCommandResponseV1 {
     get_all_txos_by_account {
         txo_ids: Vec<String>,

--- a/full-service/src/json_rpc/api_v1/wallet_api.rs
+++ b/full-service/src/json_rpc/api_v1/wallet_api.rs
@@ -4,8 +4,7 @@
 
 use crate::{
     json_rpc::api_v1::decorated_types::{
-        JsonAccount, JsonAddress, JsonBalanceResponse, JsonBlock, JsonBlockContents, JsonProof,
-        JsonTransactionLog, JsonTxo, JsonWalletStatus,
+        JsonAddress, JsonBlock, JsonBlockContents, JsonProof, JsonTxo,
     },
     service::WalletService,
 };
@@ -16,8 +15,7 @@ use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut};
 use rocket_contrib::json::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use std::{convert::TryFrom, iter::FromIterator};
-use strum::IntoEnumIterator;
+use std::iter::FromIterator;
 use strum_macros::EnumIter;
 
 // Helper method to format displaydoc errors in json.

--- a/full-service/src/json_rpc/api_v1/wallet_api.rs
+++ b/full-service/src/json_rpc/api_v1/wallet_api.rs
@@ -16,21 +16,13 @@ use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut};
 use rocket_contrib::json::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use std::iter::FromIterator;
+use std::{convert::TryFrom, iter::FromIterator};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 // Helper method to format displaydoc errors in json.
 fn format_error<T: std::fmt::Display + std::fmt::Debug>(e: T) -> String {
     json!({"error": format!("{:?}", e), "details": e.to_string()}).to_string()
-}
-
-pub fn help_str_v1() -> String {
-    let mut help_str = "Please use json data to choose wallet commands. For example, \n\ncurl -s localhost:9090/wallet -d '{\"method\": \"create_account\", \"params\": {\"name\": \"Alice\"}}' -X POST -H 'Content-type: application/json'\n\nAvailable commands are:\n\n".to_owned();
-    for e in JsonCommandRequestV1::iter() {
-        help_str.push_str(&format!("{:?}\n\n", e));
-    }
-    help_str
 }
 
 #[derive(Deserialize, Serialize, EnumIter, Debug)]

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -352,8 +352,6 @@ mod e2e {
         // Should have deleted the correct account
         assert_eq!(result["account"]["account_id"], account_id);
 
-        println!("\x1b[1;31m Account key {:?}\x1b[0m", account_key);
-
         let body = json!({
             "jsonrpc": "2.0",
             "api_version": "2",

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -750,14 +750,17 @@ mod e2e {
 
         // Get the transaction_id and verify it contains what we expect
         let body = json!({
-            "method": "get_transaction",
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1,
+            "method": "get_transaction_log",
             "params": {
                 "transaction_log_id": transaction_id,
             }
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        let transaction_log = result.get("transaction").unwrap();
+        let transaction_log = result.get("transaction_log").unwrap();
         assert_eq!(
             transaction_log.get("direction").unwrap().as_str().unwrap(),
             "tx_direction_sent"
@@ -799,6 +802,20 @@ mod e2e {
                 .unwrap(),
             transaction_id
         );
+
+        // Get All Transaction Logs
+        let body = json!({
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1,
+            "method": "get_all_transaction_logs_for_account",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let transaction_log_ids = result.get("transaction_log_ids").unwrap();
     }
 
     /*
@@ -882,231 +899,6 @@ mod e2e {
         let balance_status = result.get("status").unwrap();
         let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
         assert_eq!(unspent, "100");
-    }
-
-    #[test_with_logger]
-    fn test_build_and_submit_transaction(logger: Logger) {
-        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, mut ledger_db, _db_ctx, network_state) = setup(&mut rng, logger.clone());
-
-        // Add an account
-        let body = json!({
-            "method": "create_account",
-            "params": {
-                "name": "Alice Main Account",
-                "first_block": "0",
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let account_obj = result.get("account").unwrap();
-        let account_id = account_obj.get("account_id").unwrap().as_str().unwrap();
-        let b58_public_address = account_obj.get("main_address").unwrap().as_str().unwrap();
-        let public_address = b58_decode(b58_public_address).unwrap();
-
-        // Add a block with a txo for this address (note that value is smaller than
-        // MINIMUM_FEE)
-        add_block_to_ledger_db(
-            &mut ledger_db,
-            &vec![public_address.clone()],
-            100,
-            &vec![KeyImage::from(rng.next_u64())],
-            &mut rng,
-        );
-
-        wait_for_sync(&client, &ledger_db, &network_state, &logger);
-
-        // Create a tx proposal to ourselves
-        let body = json!({
-            "method": "build_transaction",
-            "params": {
-                "account_id": account_id,
-                "recipient_public_address": b58_public_address,
-                "value": "42",
-            }
-        });
-        // We will fail because we cannot afford the fee, which is 100000000000 pMOB
-        // (.01 MOB)
-        dispatch_expect_error(&client, body, &logger, "{\"details\":\"Error building transaction: Wallet DB Error: Insufficient funds from Txos under max_spendable_value: Max spendable value in wallet: 100, but target value: 10000000042\",\"error\":\"TransactionBuilder(WalletDb(InsufficientFundsUnderMaxSpendable(\\\"Max spendable value in wallet: 100, but target value: 10000000042\\\")))\"}".to_string());
-
-        // Add a block with significantly more MOB
-        add_block_to_ledger_db(
-            &mut ledger_db,
-            &vec![public_address],
-            100000000000000, // 100.0 MOB
-            &vec![KeyImage::from(rng.next_u64())],
-            &mut rng,
-        );
-
-        wait_for_sync(&client, &ledger_db, &network_state, &logger);
-
-        // Create a tx proposal to ourselves
-        let body = json!({
-            "method": "build_transaction",
-            "params": {
-                "account_id": account_id,
-                "recipient_public_address": b58_public_address,
-                "value": "42000000000000", // 42.0 MOB
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let tx_proposal = result.get("tx_proposal").unwrap();
-        let tx = tx_proposal.get("tx").unwrap();
-        let tx_prefix = tx.get("prefix").unwrap();
-
-        // Assert the fee is correct in both places
-        let prefix_fee = tx_prefix.get("fee").unwrap().as_str().unwrap();
-        let fee = tx_proposal.get("fee").unwrap();
-        // FIXME: WS-9 - Note, minimum fee does not fit into i32 - need to make sure we
-        // are not losing precision with the JsonTxProposal treating Fee as number
-        assert_eq!(fee, "10000000000");
-        assert_eq!(fee, prefix_fee);
-
-        // Transaction builder attempts to use as many inputs as we have txos
-        let inputs = tx_proposal.get("input_list").unwrap().as_array().unwrap();
-        assert_eq!(inputs.len(), 2);
-        let prefix_inputs = tx_prefix.get("inputs").unwrap().as_array().unwrap();
-        assert_eq!(prefix_inputs.len(), inputs.len());
-
-        // One destination
-        let outlays = tx_proposal.get("outlay_list").unwrap().as_array().unwrap();
-        assert_eq!(outlays.len(), 1);
-
-        // Map outlay -> tx_out, should have one entry for one outlay
-        let outlay_index_to_tx_out_index = tx_proposal
-            .get("outlay_index_to_tx_out_index")
-            .unwrap()
-            .as_array()
-            .unwrap();
-        assert_eq!(outlay_index_to_tx_out_index.len(), 1);
-
-        // Two outputs in the prefix, one for change
-        let prefix_outputs = tx_prefix.get("outputs").unwrap().as_array().unwrap();
-        assert_eq!(prefix_outputs.len(), 2);
-
-        // One outlay confirmation number for our one outlay (no receipt for change)
-        let outlay_confirmation_numbers = tx_proposal
-            .get("outlay_confirmation_numbers")
-            .unwrap()
-            .as_array()
-            .unwrap();
-        assert_eq!(outlay_confirmation_numbers.len(), 1);
-
-        // Tombstone block = ledger height (12 to start + 2 new blocks + 50 default
-        // tombstone)
-        let prefix_tombstone = tx_prefix.get("tombstone_block").unwrap();
-        assert_eq!(prefix_tombstone, "64");
-
-        // Get current balance
-        let body = json!({
-            "method": "get_balance",
-            "params": {
-                "account_id": account_id,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        assert_eq!(unspent, "100000000000100");
-
-        // Submit the tx_proposal
-        let body = json!({
-            "method": "submit_transaction",
-            "params": {
-                "tx_proposal": tx_proposal,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let transaction_id = result
-            .get("transaction")
-            .unwrap()
-            .get("transaction_id")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        // Note - we cannot test here that the transaction ID is consistent, because
-        // there is randomness in the transaction creation.
-
-        wait_for_sync(&client, &ledger_db, &network_state, &logger);
-
-        // Get balance after submission
-        let body = json!({
-            "method": "get_balance",
-            "params": {
-                "account_id": account_id,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get(TXO_UNSPENT).unwrap().as_str().unwrap();
-        let pending = balance_status.get(TXO_PENDING).unwrap().as_str().unwrap();
-        let spent = balance_status.get(TXO_SPENT).unwrap().as_str().unwrap();
-        let secreted = balance_status.get(TXO_SECRETED).unwrap().as_str().unwrap();
-        assert_eq!(unspent, "0");
-        assert_eq!(pending, "100000000000100");
-        assert_eq!(spent, "0");
-        assert_eq!(secreted, "0");
-
-        // FIXME: FS-93 Increment ledger manually so tx lands.
-
-        // Get the transaction_id and verify it contains what we expect
-        let body = json!({
-            "method": "get_transaction",
-            "params": {
-                "transaction_log_id": transaction_id,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let transaction_log = result.get("transaction").unwrap();
-        assert_eq!(
-            transaction_log.get("direction").unwrap().as_str().unwrap(),
-            "sent"
-        );
-        assert_eq!(
-            transaction_log.get("value_pmob").unwrap().as_str().unwrap(),
-            "42000000000000"
-        );
-        assert_eq!(
-            transaction_log
-                .get("recipient_address_id")
-                .unwrap()
-                .as_str()
-                .unwrap(),
-            b58_public_address
-        );
-        assert_eq!(
-            transaction_log.get("account_id").unwrap().as_str().unwrap(),
-            ""
-        );
-        assert_eq!(
-            transaction_log.get("fee_pmob").unwrap().as_str().unwrap(),
-            "10000000000"
-        );
-        assert_eq!(
-            transaction_log.get("status").unwrap().as_str().unwrap(),
-            "pending"
-        );
-        assert_eq!(
-            transaction_log
-                .get("submitted_block_index")
-                .unwrap()
-                .as_str()
-                .unwrap(),
-            "14"
-        );
-        assert_eq!(
-            transaction_log
-                .get("transaction_log_id")
-                .unwrap()
-                .as_str()
-                .unwrap(),
-            transaction_id
-        );
     }
 
     #[test_with_logger]

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -808,7 +808,7 @@ mod e2e {
                 .unwrap()
                 .as_str()
                 .unwrap(),
-            "13"
+            "14"
         );
         assert_eq!(
             transaction_log

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -132,10 +132,7 @@ mod e2e {
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        assert_eq!(
-            result.get("account").unwrap().get("account_id").unwrap(),
-            account_id
-        );
+        assert_eq!(result["success"].as_bool().unwrap(), true,);
 
         let body = json!({
             "jsonrpc": "2.0",
@@ -220,10 +217,7 @@ mod e2e {
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        assert_eq!(
-            result.get("account").unwrap().get("account_id").unwrap(),
-            account_id
-        );
+        assert_eq!(result["success"].as_bool().unwrap(), true);
 
         // Import it again - should succeed.
         let body = json!({
@@ -349,8 +343,7 @@ mod e2e {
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        // Should have deleted the correct account
-        assert_eq!(result["account"]["account_id"], account_id);
+        assert_eq!(result["success"].as_bool().unwrap(), true);
 
         let body = json!({
             "jsonrpc": "2.0",
@@ -755,10 +748,16 @@ mod e2e {
             .unwrap()
             .as_str()
             .unwrap();
+        let orphaned = balance_status
+            .get("orphaned_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "0");
-        assert_eq!(pending, "0");
-        assert_eq!(spent, "99990000000100");
-        assert_eq!(secreted, "0");
+        assert_eq!(pending, "100000000000100");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "99990000000100");
+        assert_eq!(orphaned, "0");
 
         // FIXME: FS-93 Increment ledger manually so tx lands.
 

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -131,15 +131,20 @@ pub enum JsonCommandRequestV2 {
         comment: Option<String>,
         account_id: Option<String>,
     },
-    /*
-    get_balance_for_subaddress {
-        address: String,
-    },*/
+    get_all_transaction_logs_for_account {
+        account_id: String,
+    },
+    get_transaction_log {
+        transaction_log_id: String,
+    },
     get_wallet_status,
     get_account_status {
         account_id: String,
     },
     /*
+    get_balance_for_subaddress {
+        address: String,
+    },
     get_all_txos_by_account {
         account_id: String,
     },
@@ -155,13 +160,6 @@ pub enum JsonCommandRequestV2 {
     },
     get_all_addresses_by_account {
         account_id: String,
-    },
-
-    get_all_transactions_by_account {
-        account_id: String,
-    },
-    get_transaction {
-        transaction_log_id: String,
     },
     get_transaction_object {
         transaction_log_id: String,

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -137,6 +137,10 @@ pub enum JsonCommandRequestV2 {
     get_transaction_log {
         transaction_log_id: String,
     },
+    get_all_transaction_logs_for_block {
+        block_index: String,
+    },
+    get_all_transaction_logs_ordered_by_block,
     get_wallet_status,
     get_account_status {
         account_id: String,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -185,14 +185,13 @@ pub enum JsonCommandResponseV2 {
     submit_transaction {
         transaction_log: Option<TransactionLog>,
     },
-    /*
-    get_balance_for_subaddress {
-        balance: Balance,
-    },*/
-    /* get_txos_for_subaddress {
-
-    }
-     */
+    get_all_transaction_logs_for_account {
+        transaction_log_ids: Vec<String>,
+        transaction_log_map: Map<String, serde_json::Value>,
+    },
+    get_transaction_log {
+        transaction_log: TransactionLog,
+    },
     get_wallet_status {
         wallet_status: WalletStatus,
     },
@@ -201,6 +200,12 @@ pub enum JsonCommandResponseV2 {
         balance: Balance,
     },
     /*
+    get_balance_for_subaddress {
+        balance: Balance,
+    },
+    get_txos_for_subaddress {
+
+    }
     get_all_txos_by_account {
         txo_ids: Vec<String>,
         txo_map: Map<String, serde_json::Value>,
@@ -215,13 +220,6 @@ pub enum JsonCommandResponseV2 {
     get_all_addresses_by_account {
         address_ids: Vec<String>,
         address_map: Map<String, serde_json::Value>,
-    },
-    get_all_transactions_by_account {
-        transaction_log_ids: Vec<String>,
-        transaction_log_map: Map<String, serde_json::Value>,
-    },
-    get_transaction {
-        transaction: JsonTransactionLog,
     },
     get_transaction_object {
         transaction: JsonTx,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -171,7 +171,7 @@ pub enum JsonCommandResponseV2 {
         account: Account,
     },
     delete_account {
-        account: Account,
+        success: bool,
     },
     get_balance_for_account {
         balance: Balance,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -192,6 +192,13 @@ pub enum JsonCommandResponseV2 {
     get_transaction_log {
         transaction_log: TransactionLog,
     },
+    get_all_transaction_logs_for_block {
+        transaction_log_ids: Vec<String>,
+        transaction_log_map: Map<String, serde_json::Value>,
+    },
+    get_all_transaction_logs_ordered_by_block {
+        transaction_log_map: Map<String, serde_json::Value>,
+    },
     get_wallet_status {
         wallet_status: WalletStatus,
     },

--- a/full-service/src/json_rpc/transaction_log.rs
+++ b/full-service/src/json_rpc/transaction_log.rs
@@ -59,7 +59,7 @@ pub struct TransactionLog {
 
     /// String representing the transaction log status. On "sent", valid
     /// statuses are "built", "pending", "succeeded", "failed".  On "received",
-    /// the status is "succeded".
+    /// the status is "succeeded".
     pub status: String,
 
     /// A list of the IDs of the Txos which were inputs to this transaction.

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -8,7 +8,7 @@ use crate::{
     json_rpc,
     json_rpc::{
         account_secrets::AccountSecrets,
-        api_v1::wallet_api::{help_str_v1, wallet_api_inner_v1, JsonCommandRequestV1},
+        api_v1::wallet_api::{wallet_api_inner_v1, JsonCommandRequestV1},
         balance::Balance,
         json_rpc_request::{help_str_v2, JsonCommandRequest, JsonCommandRequestV2},
         json_rpc_response::{

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -205,12 +205,9 @@ where
         }
         JsonCommandRequestV2::delete_account { account_id } => {
             JsonCommandResponseV2::delete_account {
-                account: json_rpc::account::Account::try_from(
-                    &service
-                        .delete_account(&AccountID(account_id))
-                        .map_err(format_error)?,
-                )
-                .map_err(format_error)?,
+                success: service
+                    .delete_account(&AccountID(account_id))
+                    .map_err(format_error)?,
             }
         }
         JsonCommandRequestV2::get_balance_for_account { account_id } => {

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -66,7 +66,7 @@ pub trait AccountService {
     ) -> Result<Account, WalletServiceError>;
 
     /// Delete an account from the wallet.
-    fn delete_account(&self, account_id: &AccountID) -> Result<Account, WalletServiceError>;
+    fn delete_account(&self, account_id: &AccountID) -> Result<bool, WalletServiceError>;
 }
 
 impl<T, FPR> AccountService for WalletService<T, FPR>
@@ -195,14 +195,11 @@ where
         })?)
     }
 
-    fn delete_account(&self, account_id: &AccountID) -> Result<Account, WalletServiceError> {
+    fn delete_account(&self, account_id: &AccountID) -> Result<bool, WalletServiceError> {
         log::info!(self.logger, "Deleting account {}", account_id,);
 
         let conn = self.wallet_db.get_conn()?;
-
-        let account = Account::get(account_id, &conn)?;
-        let deleted = account.clone();
-        account.delete(&conn)?;
-        Ok(deleted)
+        Account::get(account_id, &conn)?.delete(&conn)?;
+        Ok(true)
     }
 }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -156,8 +156,6 @@ where
                     min_synced_block_index,
                     (account.next_block as u64).saturating_sub(1),
                 );
-                println!("\x1b[1;33m For account {:?} got network block index = {:?}, local_ledger_block_count {:?}, and account.next_block {:?}", account_id, network_block_index, self.ledger_db.num_blocks().unwrap(), account.next_block);
-
                 account_ids.push(account_id);
             }
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -204,12 +204,15 @@ where
             .iter()
             .map(|t| t.value as u128)
             .sum::<u128>();
-        Ok((
+
+        let result = (
             unspent as u64,
+            pending as u64,
             spent as u64,
             secreted as u64,
             orphaned as u64,
-            pending as u64,
-        ))
+        );
+
+        Ok(result)
     }
 }

--- a/full-service/src/service/mod.rs
+++ b/full-service/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod balance;
 pub mod sync;
 pub mod transaction;
 pub mod transaction_builder;
+pub mod transaction_log;
 mod wallet_service;
 
 pub use wallet_service::WalletService;

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     db::{
+        account::AccountID,
         models::TransactionLog,
         transaction_log::{AssociatedTxos, TransactionLogModel},
     },
@@ -18,15 +19,28 @@ use diesel::connection::Connection;
 /// Trait defining the ways in which the wallet can interact with and manage
 /// transaction logs.
 pub trait TransactionLogService {
-    fn list_transactions(
+    /// List all transactions associated with the given Account ID.
+    fn list_transaction_logs(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError>;
 
-    fn get_transaction(
+    /// Get a specific transaction log.
+    fn get_transaction_log(
         &self,
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos), WalletServiceError>;
+
+    /// Get all transaction logs for a given block.
+    fn get_all_transaction_logs_for_block(
+        &self,
+        block_index: u64,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError>;
+
+    /// Get all transaction logs ordered by finalized_block_index.
+    fn get_all_transaction_logs_ordered_by_block(
+        &self,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError>;
 }
 
 impl<T, FPR> TransactionLogService for WalletService<T, FPR>
@@ -34,17 +48,17 @@ where
     T: BlockchainConnection + UserTxConnection + 'static,
     FPR: FogPubkeyResolver + Send + Sync + 'static,
 {
-    fn list_transactions(
+    fn list_transaction_logs(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         Ok(TransactionLog::list_all(
-            account_id_hex,
+            &account_id.to_string(),
             &self.wallet_db.get_conn()?,
         )?)
     }
 
-    fn get_transaction(
+    fn get_transaction_log(
         &self,
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos), WalletServiceError> {
@@ -57,6 +71,52 @@ where
 
                 Ok((transaction_log, associated))
             })?,
+        )
+    }
+
+    fn get_all_transaction_logs_for_block(
+        &self,
+        block_index: u64,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+
+        Ok(
+            conn.transaction::<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError, _>(
+                || {
+                    let transaction_logs =
+                        TransactionLog::get_all_for_block_index(block_index, &conn)?;
+                    let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
+                    for transaction_log in transaction_logs {
+                        res.push((
+                            transaction_log.clone(),
+                            transaction_log.get_associated_txos(&conn)?,
+                        ));
+                    }
+                    Ok(res)
+                },
+            )?,
+        )
+    }
+
+    fn get_all_transaction_logs_ordered_by_block(
+        &self,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+
+        Ok(
+            conn.transaction::<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError, _>(
+                || {
+                    let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
+                    let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
+                    for transaction_log in transaction_logs {
+                        res.push((
+                            transaction_log.clone(),
+                            transaction_log.get_associated_txos(&conn)?,
+                        ));
+                    }
+                    Ok(res)
+                },
+            )?,
         )
     }
 }

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! Service for managing transaction logs.
+
+use crate::{
+    db::{
+        models::TransactionLog,
+        transaction_log::{AssociatedTxos, TransactionLogModel},
+    },
+    error::WalletServiceError,
+    WalletService,
+};
+use mc_connection::{BlockchainConnection, UserTxConnection};
+use mc_fog_report_validation::FogPubkeyResolver;
+
+use diesel::connection::Connection;
+
+/// Trait defining the ways in which the wallet can interact with and manage
+/// transaction logs.
+pub trait TransactionLogService {
+    fn list_transactions(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError>;
+
+    fn get_transaction(
+        &self,
+        transaction_id_hex: &str,
+    ) -> Result<(TransactionLog, AssociatedTxos), WalletServiceError>;
+}
+
+impl<T, FPR> TransactionLogService for WalletService<T, FPR>
+where
+    T: BlockchainConnection + UserTxConnection + 'static,
+    FPR: FogPubkeyResolver + Send + Sync + 'static,
+{
+    fn list_transactions(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
+        Ok(TransactionLog::list_all(
+            account_id_hex,
+            &self.wallet_db.get_conn()?,
+        )?)
+    }
+
+    fn get_transaction(
+        &self,
+        transaction_id_hex: &str,
+    ) -> Result<(TransactionLog, AssociatedTxos), WalletServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+
+        Ok(
+            conn.transaction::<(TransactionLog, AssociatedTxos), WalletServiceError, _>(|| {
+                let transaction_log = TransactionLog::get(transaction_id_hex, &conn)?;
+                let associated = transaction_log.get_associated_txos(&conn)?;
+
+                Ok((transaction_log, associated))
+            })?,
+        )
+    }
+}

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -206,7 +206,7 @@ impl<
         &self,
         transaction_log_id: &str,
     ) -> Result<Vec<JsonProof>, WalletServiceError> {
-        let (_transaction_log, associated_txos) = self.get_transaction(&transaction_log_id)?;
+        let (_transaction_log, associated_txos) = self.get_transaction_log(&transaction_log_id)?;
         let proofs: Vec<JsonProof> = associated_txos
             .outputs
             .iter()

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -378,11 +378,10 @@ mod tests {
             .get_balance_for_account(&AccountID(alice.account_id_hex))
             .unwrap();
         assert_eq!(balance.unspent, 0);
-        assert_eq!(balance.pending, 0);
-        assert_eq!(balance.spent, 99990000000000);
-        assert_eq!(balance.secreted, 0);
-        assert_eq!(balance.orphaned, 100000000000000); // FIXME: Should not be
-                                                       // orphaned?
+        assert_eq!(balance.pending, 100000000000000);
+        assert_eq!(balance.spent, 0);
+        assert_eq!(balance.secreted, 99990000000000);
+        assert_eq!(balance.orphaned, 0);
 
         // FIXME: How to make the transaction actually hit the test ledger?
     }

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -534,7 +534,8 @@ pub fn random_account_with_seed_values(
         );
     }
 
-    std::thread::sleep(std::time::Duration::from_secs(6));
+    // FIXME: FS-122 - should not be sleeping in tests
+    std::thread::sleep(std::time::Duration::from_secs(8));
 
     // Make sure we have all our TXOs
     assert_eq!(


### PR DESCRIPTION
### Motivation

It is desirable to be able to get transactions by block number. This PR adds two API endpoints related to transaction_logs and block indices: 

* `get_all_transaction_logs_by_block`: Gets all transaction logs associated with a specific block index.
* `get_all_transaction_logs_ordered_by_block`: Gets all transaction logs, and orders them by `finalized_block_index`

### In this PR
* Continues the refactor for API v2 and moves `transaction_log` related service methods to a `TransactionService` trait.
* Adds two API endpoints for getting transaction_logs associated with a block

[FS-114](https://mobilecoin.atlassian.net/browse/FS-114)

Also cleans up transaction_log naming to make it consistent, for [FS-72](https://mobilecoin.atlassian.net/browse/FS-72)

Note: This PR is built on top of #56, so will be rebased on main once that PR goes in.

