### PR TITLE
FS-64: Export Account Secrets

### DIFF
--- a/API_v2.md
+++ b/API_v2.md
@@ -7,7 +7,8 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 ### Methods Overview
 
 * [create_account](#create-account)
-* [import_account](#import-account)
+* [import_account_by_entropy](#import-account-by-entropy)
+* [import_account_by_account_key](#import-account-by-account-key)
 * [get_all_accounts](#get-all-accounts)
 * [get_account](#get-account)
 * [update_account_name](#update-account-name)
@@ -34,6 +35,7 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 The methods above return data representations of wallet contents. The Full Service API Data types are as follows:
 
 * [account](#the-account-object)
+* [balance](#the-balance-object)
 * [wallet_status](#the-wallet-status-object)
 * [assigned_address](#the-assigned-address-object)
 * [transaction_log](#the-transaction-log-object)
@@ -61,26 +63,28 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "create_account",
   "result": {
     "account": {
-      "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
-      "account_key": {
-        "fog_authority_spki": "",
-        "fog_report_id": "",
-        "fog_report_url": "",
-        "object": "account_key",
-        "spend_private_key": "0a200c68151e777324da47a1e3a4f8b57e7d94d59084d4a343e1c600c1e4f66fc20d",
-        "view_private_key": "0a20765d49c5a524ddd4d9e96278b17eccd7b33e6bc071c5bc91dcd29435ce478a0d"
-      },
-      "entropy": "856fcacf2a819a065a9376fcdce0ff8dbe14f8b8d6118ef3a194f9e678ade0e0",
-      "main_address": "4bgkVAH1hs55dwLTGVpZER8ZayhqXbYqfuyisoRrmQPXoWcYQ3SQRTjsAytCiAgk21CRrVNysVw5qwzweURzDK9HL3rGXFmAAahb364kYe3",
-      "name": "Alice",
-      "next_subaddress_index": "2",
       "object": "account",
-      "recovery_mode": false
+      "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
+      "name": "Alice",
+      "main_address": "4bgkVAH1hs55dwLTGVpZER8ZayhqXbYqfuyisoRrmQPXoWcYQ3SQRTjsAytCiAgk21CRrVNysVw5qwzweURzDK9HL3rGXFmAAahb364kYe3",
+      "next_subaddress_index": "2",
+      "recovery_mode": false,
+      "entropy": "856fcacf2a819a065a9376fcdce0ff8dbe14f8b8d6118ef3a194f9e678ade0e0",
+      "account_key": {
+        "object": "account_key",
+        "view_private_key": "0a20765d49c5a524ddd4d9e96278b17eccd7b33e6bc071c5bc91dcd29435ce478a0d",
+        "spend_private_key": "0a200c68151e777324da47a1e3a4f8b57e7d94d59084d4a343e1c600c1e4f66fc20d",
+        "fog_report_url": "",
+        "fog_report_id": "",
+        "fog_authority_spki": ""
+      }
     }
   },
   "error": null,
@@ -96,14 +100,14 @@ curl -s localhost:9090/wallet \
 | `name`         | Label for this account   | Can have duplicates (not recommended) |
 | `first_block`  | The block from which to start scanning the ledger |  |
 
-#### Import Account
+#### Import Account by Entropy
 
 Import an existing account from the secret entropy.
 
 ```sh
 curl -s localhost:9090/wallet \
   -d '{
-        "method": "import_account",
+        "method": "import_account_by_entropy",
         "params": {
           "entropy": "c593274dc6f6eb94242e34ae5f0ab16bc3085d45d49d9e18b8a8c6f057e6b56b",
           "name": "Bob"
@@ -114,26 +118,28 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
    -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
-  "method": "import_account",
+  "method": "import_account_by_entropy",
   "result": {
     "account": {
-      "account_id": "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470",
-      "account_key": {
-        "fog_authority_spki": "",
-        "fog_report_id": "",
-        "fog_report_url": "",
-        "object": "account_key",
-        "spend_private_key": "0a2011035ae05a302e883af00f788cd7486f8f7445503187b080545c16c37056900e",
-        "view_private_key": "0a20e1d5a0622906afa27d87ab9f900e6099ce778d173b22068ce948832b549d2002"
-      },
-      "entropy": "ed62ae3259992ec31dc9fe08be1b9964327e0c4846be99a975397a32099b9860",
-      "main_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
-      "name": "Bob",
-      "next_subaddress_index": "2",
       "object": "account",
-      "recovery_mode": false
+      "account_id": "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470",
+      "name": "Bob",
+      "main_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
+      "next_subaddress_index": "2",
+      "recovery_mode": false,
+      "entropy": "ed62ae3259992ec31dc9fe08be1b9964327e0c4846be99a975397a32099b9860",
+      "account_key": {
+        "object": "account_key",
+        "view_private_key": "0a20e1d5a0622906afa27d87ab9f900e6099ce778d173b22068ce948832b549d2002",
+        "spend_private_key": "0a2011035ae05a302e883af00f788cd7486f8f7445503187b080545c16c37056900e",
+        "fog_report_url": "",
+        "fog_report_id": "",
+        "fog_authority_spki": ""
+      }
     }
   },
   "error": null,
@@ -160,6 +166,79 @@ If you receive the following error, it means that you attempted to import an acc
 {"error": "Database(Diesel(DatabaseError(UniqueViolation, "UNIQUE constraint failed: accounts.account_id_hex")))"}
 ```
 
+#### Import Account by Account Key
+
+Import an existing account from the secret account key.
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "import_account_by_account_key",
+        "params": {
+          "account_key": {
+            "object": "account_key",
+            "view_private_key": "0a20765d49c5a524ddd4d9e96278b17eccd7b33e6bc071c5bc91dcd29435ce478a0d"
+            "spend_private_key": "0a200c68151e777324da47a1e3a4f8b57e7d94d59084d4a343e1c600c1e4f66fc20d",
+            "fog_report_url": "",
+            "fog_report_id": "",
+            "fog_authority_spki": "",
+            },
+          "name": "Bob"
+          "first_block_index": 3500,
+        },
+        "jsonrpc": "2.0",
+        "api_version": "2",
+        "id": 1
+      }' \
+   -X POST -H 'Content-type: application/json' | jq
+```
+
+```json
+{
+  "method": "import_account_by_account_key",
+  "result": {
+    "account": {
+      "object": "account",
+      "account_id": "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470",
+      "main_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
+      "name": "Bob",
+      "next_subaddress_index": "2",
+      "recovery_mode": false,
+      "entropy": null,
+      "account_key": {
+        "object": "account_key",
+        "view_private_key": "0a20e1d5a0622906afa27d87ab9f900e6099ce778d173b22068ce948832b549d2002",
+        "spend_private_key": "0a2011035ae05a302e883af00f788cd7486f8f7445503187b080545c16c37056900e",
+        "fog_report_url": "",
+        "fog_report_id": "",
+        "fog_authority_spki": ""
+      }
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
+}
+```
+
+| Required Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `account_key`  | The secret account key   | A valid account key       |
+
+| Optional Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `name`         | Label for this account   | Can have duplicates (not recommended) |
+| `first_block`  | The block from which to start scanning the ledger |  |
+
+##### Troubleshooting
+
+If you receive the following error, it means that you attempted to import an account already in the wallet.
+
+```sh
+{"error": "Database(Diesel(DatabaseError(UniqueViolation, "UNIQUE constraint failed: accounts.account_id_hex")))"}
+```
+
 #### Get All Accounts
 
 ```sh
@@ -171,7 +250,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_all_accounts",
   "result": {
@@ -237,7 +318,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json'  | jq
+```
 
+```json
 {
   "method": "get_account",
   "result": {
@@ -296,7 +379,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json'  | jq
+```
 
+```json
 {
   "method": "update_account_name",
   "result": {
@@ -344,7 +429,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "delete_account",
   "result": {
@@ -393,7 +480,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json'  | jq
+```
 
+```json
 {
   "method": "get_all_txos_by_account",
   "result": {
@@ -469,7 +558,7 @@ curl -s localhost:9090/wallet \
         "key_image": "0a20784ab38c4541ce23abbec6744431d6ae14101c49c6535b3e9bf3fd728db13848",
         "minted_account_id": null,
         "object": "txo",
-        "offset_count": 8
+        "offset_count": 8,
         "proof": null,
         "public_key": "0a20d803a979c9ec0531f106363a885dde29101fcd70209f9ed686905512dfd14d5f",
         "received_account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
@@ -478,7 +567,7 @@ curl -s localhost:9090/wallet \
         "subaddress_index": "0",
         "target_key": "0a209abadbfcec6c81b3d184dc104e51cac4c4faa8bab4da21a3714901519810c20d",
         "txo_id": "58c2c3780792ccf9c51014c7688a71f03732b633f8c5dfa49040fa7f51328280",
-        "value_pmob": "4000000000000",
+        "value_pmob": "4000000000000"
       },
       "b496f4f3ec3159bf48517aa7d9cda193ef8bfcac343f81eaed0e0a55849e4726": {
         "account_status_map": {
@@ -493,7 +582,7 @@ curl -s localhost:9090/wallet \
         "key_image": null,
         "minted_account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
         "object": "txo",
-        "offset_count": 498
+        "offset_count": 498,
         "proof": null,
         "public_key": "0a209432c589bb4e5101c26e935b70930dfe45c78417527fb994872ebd65fcb9c116",
         "received_account_id": null,
@@ -502,7 +591,7 @@ curl -s localhost:9090/wallet \
         "subaddress_index": null,
         "target_key": "0a208c75723e9b9a4af0c833bfe190c43900c3b41834cf37024f5fecfbe9919dff23",
         "txo_id": "b496f4f3ec3159bf48517aa7d9cda193ef8bfcac343f81eaed0e0a55849e4726",
-        "value_pmob": "980000000000",
+        "value_pmob": "980000000000"
       }
     ]
   }
@@ -544,7 +633,8 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
-
+```
+```json
 {
   "method": "get_txo",
   "result": {
@@ -592,7 +682,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_wallet_status",
   "result": {
@@ -669,7 +761,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_balance_for_account",
   "result": {
@@ -713,7 +807,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_account_status",
   "result": {
@@ -772,7 +868,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "create_address",
   "result": {
@@ -812,7 +910,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_all_addresses_by_account",
   "result": {
@@ -881,7 +981,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
-
+```
+`
+```json
 {
   "method": "send_transaction",
   "result": {
@@ -936,7 +1038,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```
 {
   "method": "build_transaction",
   "result": {
@@ -1167,7 +1271,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json'
+```
 
+```json
 {
   "method": "submit_transaction",
   "result": {
@@ -1200,13 +1306,15 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_all_transactions_by_account",
   "result": {
     "transaction_log_ids": [
       "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c",
-      "fcd2979f737f213fc327cd79d10c490a9bd4cb163084d4a154585c5e93e8c075",
+      "fcd2979f737f213fc327cd79d10c490a9bd4cb163084d4a154585c5e93e8c075"
     ],
     "transaction_log_map": {
       "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c": {
@@ -1222,7 +1330,7 @@ curl -s localhost:9090/wallet \
         "input_txo_ids": [],
         "is_sent_recovered": null,
         "object": "transaction_log",
-        "offset_count": 296
+        "offset_count": 296,
         "output_txo_ids": [
           "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c"
         ],
@@ -1231,7 +1339,7 @@ curl -s localhost:9090/wallet \
         "status": "succeeded",
         "submitted_block_height": null,
         "transaction_log_id": "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c",
-        "value_pmob": "443990000000000",
+        "value_pmob": "443990000000000"
       },
       "6e51851495c628a3b6eefb3e14ee14bb7a167bba5ce727c8710601ba87f74c4c": {
         "account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
@@ -1251,7 +1359,7 @@ curl -s localhost:9090/wallet \
         ],
         "is_sent_recovered": null,
         "object": "transaction_log",
-        "offset_count": 496
+        "offset_count": 496,
         "output_txo_ids": [
           "badf415972dfc2dc6203ed90be132831ff29f394f65b0be5c35c79048d86af5b"
         ],
@@ -1260,9 +1368,8 @@ curl -s localhost:9090/wallet \
         "status": "succeeded",
         "submitted_block_height": "152826",
         "transaction_log_id": "ead39f2c0dea3004732adf1953dee876b73829768d4877809fe06ee0bfc6bf6d",
-        "value_pmob": "1000000000000",
+        "value_pmob": "1000000000000"
       }
-     ...
     }
   }
 }
@@ -1286,7 +1393,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_transaction",
   "result": {
@@ -1347,6 +1456,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
+
+```json
 {
   "method": "get_proofs",
   "result": {
@@ -1383,7 +1495,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "verify_proof",
   "result": {
@@ -1418,7 +1532,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_transaction_object",
   "result": {
@@ -1443,7 +1559,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_txo_object",
   "result": {
@@ -1468,7 +1586,9 @@ curl -s localhost:9090/wallet \
         "id": 1
       }' \
   -X POST -H 'Content-type: application/json' | jq
+```
 
+```json
 {
   "method": "get_block_object",
   "result": {

--- a/API_v2.md
+++ b/API_v2.md
@@ -1,4 +1,4 @@
-# Full Service API v1
+# Full Service API v2
 
 The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with your MobileCoin transactions.
 

--- a/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
+++ b/full-service/migrations/2020-21-09-165203_wallet_service/up.sql
@@ -2,7 +2,7 @@ CREATE TABLE accounts (
   id INTEGER NOT NULL PRIMARY KEY,
   account_id_hex VARCHAR NOT NULL UNIQUE,
   account_key BLOB NOT NULL,
-  entropy BLOB NOT NULL,
+  entropy BLOB,
   main_subaddress_index UNSIGNED BIG INT NOT NULL,
   change_subaddress_index UNSIGNED BIG INT NOT NULL,
   next_subaddress_index UNSIGNED BIG INT NOT NULL,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -365,7 +365,7 @@ mod tests {
     use mc_common::logger::{test_with_logger, Logger};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use std::{collections::HashSet, iter::FromIterator};
+    use std::{collections::HashSet, convert::TryFrom, iter::FromIterator};
 
     #[test_with_logger]
     fn test_account_crud(logger: Logger) {
@@ -523,8 +523,7 @@ mod tests {
             account_id_hex
         };
         let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-        let decoded_entropy: RootEntropy =
-            mc_util_serial::decode(&account.entropy.unwrap()).unwrap();
+        let decoded_entropy = RootEntropy::try_from(account.entropy.unwrap().as_slice()).unwrap();
         assert_eq!(decoded_entropy, root_id.root_entropy);
         let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();
         assert_eq!(decoded_account_key, account_key);
@@ -584,8 +583,7 @@ mod tests {
             account_id_hex
         };
         let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-        let decoded_entropy: RootEntropy =
-            mc_util_serial::decode(&account.entropy.unwrap()).unwrap();
+        let decoded_entropy = RootEntropy::try_from(account.entropy.unwrap().as_slice()).unwrap();
         assert_eq!(decoded_entropy, root_id.root_entropy);
         let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();
         assert_eq!(decoded_account_key, account_key);

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -129,20 +129,20 @@ impl AccountModel for Account {
 
         let account_key_to_create = if let Some(a) = account_key {
             a.clone()
+        } else if let Some(e) = entropy {
+            let root_id = RootIdentity::from(e);
+            AccountKey::from(&root_id)
         } else {
-            if let Some(e) = entropy {
-                let root_id = RootIdentity::from(e);
-                AccountKey::from(&root_id)
-            } else {
-                return Err(WalletDbError::InsufficientSecretsToCreateAccount);
-            }
+            return Err(WalletDbError::InsufficientSecretsToCreateAccount);
         };
 
         // Sanity check that the secrets match the same account in case both were
         // provided.
-        if account_key.is_some() && entropy.is_some() {
-            if &AccountKey::from(&RootIdentity::from(entropy.unwrap())) != account_key.unwrap() {
-                return Err(WalletDbError::AccountSecretsDoNotMatch);
+        if let Some(a) = account_key {
+            if let Some(e) = entropy {
+                if &AccountKey::from(&RootIdentity::from(e)) != a {
+                    return Err(WalletDbError::AccountSecretsDoNotMatch);
+                }
             }
         }
 

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -2,19 +2,14 @@
 
 //! DB impl for the Account model.
 
-use crate::{
-    db::{
-        assigned_subaddress::AssignedSubaddressModel,
-        b58_encode,
-        models::{
-            Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo,
-            TXO_STATUS_PENDING, TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
-        },
-        transaction_log::TransactionLogModel,
-        txo::TxoModel,
-        WalletDbError,
+use crate::db::{
+    assigned_subaddress::AssignedSubaddressModel,
+    models::{
+        Account, AccountTxoStatus, AssignedSubaddress, NewAccount, TransactionLog, Txo,
+        TXO_STATUS_SPENT,
     },
-    json_rpc::api_v1::decorated_types::JsonAccount,
+    transaction_log::TransactionLogModel,
+    WalletDbError,
 };
 
 use mc_account_keys::{AccountKey, RootEntropy, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
@@ -55,7 +50,8 @@ pub trait AccountModel {
     /// Returns:
     /// * (account_id, main_subaddress_b58)
     fn create(
-        entropy: &RootEntropy,
+        account_key: Option<&AccountKey>,
+        entropy: Option<&RootEntropy>,
         first_block: Option<u64>,
         import_block: Option<u64>,
         name: &str,
@@ -64,7 +60,8 @@ pub trait AccountModel {
 
     /// Import account.
     fn import(
-        entropy: &RootEntropy,
+        account_key: Option<&AccountKey>,
+        entropy: Option<&RootEntropy>,
         name: Option<String>,
         import_block: u64,
         first_block: Option<u64>,
@@ -84,18 +81,11 @@ pub trait AccountModel {
     /// Returns:
     /// * Account
     fn get(
-        account_id_hex: &AccountID,
+        account_id: &AccountID,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError>;
 
-    /// Get the API-decorated Account object
-    fn get_decorated(
-        account_id_hex: &AccountID,
-        local_height: u64,
-        network_height: u64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<JsonAccount, WalletDbError>;
-
+    /// Get the accounts associated with the given Txo.
     fn get_by_txo_id(
         txo_id_hex: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
@@ -128,7 +118,8 @@ pub trait AccountModel {
 
 impl AccountModel for Account {
     fn create(
-        entropy: &RootEntropy,
+        account_key: Option<&AccountKey>,
+        entropy: Option<&RootEntropy>,
         first_block: Option<u64>,
         import_block: Option<u64>,
         name: &str,
@@ -136,18 +127,35 @@ impl AccountModel for Account {
     ) -> Result<(AccountID, String), WalletDbError> {
         use crate::db::schema::accounts;
 
-        let root_id = RootIdentity::from(entropy);
-        let account_key = AccountKey::from(&root_id);
-        let account_id = AccountID::from(&account_key);
+        let account_key_to_create = if let Some(a) = account_key {
+            a.clone()
+        } else {
+            if let Some(e) = entropy {
+                let root_id = RootIdentity::from(e);
+                AccountKey::from(&root_id)
+            } else {
+                return Err(WalletDbError::InsufficientSecretsToCreateAccount);
+            }
+        };
+
+        // Sanity check that the secrets match the same account in case both were
+        // provided.
+        if account_key.is_some() && entropy.is_some() {
+            if &AccountKey::from(&RootIdentity::from(entropy.unwrap())) != account_key.unwrap() {
+                return Err(WalletDbError::AccountSecretsDoNotMatch);
+            }
+        }
+
+        let account_id = AccountID::from(&account_key_to_create);
         let fb = first_block.unwrap_or(DEFAULT_FIRST_BLOCK);
 
         Ok(
             conn.transaction::<(AccountID, String), WalletDbError, _>(|| {
                 let new_account = NewAccount {
                     account_id_hex: &account_id.to_string(),
-                    account_key: &mc_util_serial::encode(&account_key), /* FIXME: WS-6 - add
-                                                                         * encryption */
-                    entropy: &entropy.bytes,
+                    account_key: &mc_util_serial::encode(&account_key_to_create), // FIXME: WS-6 - add encryption
+
+                    entropy: entropy.map(|e| e.bytes.as_ref()),
                     main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
                     change_subaddress_index: DEFAULT_CHANGE_SUBADDRESS_INDEX as i64,
                     next_subaddress_index: DEFAULT_NEXT_SUBADDRESS_INDEX as i64,
@@ -162,7 +170,7 @@ impl AccountModel for Account {
                     .execute(conn)?;
 
                 let main_subaddress_b58 = AssignedSubaddress::create(
-                    &account_key,
+                    &account_key_to_create,
                     None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
                            * always for main? */
                     DEFAULT_SUBADDRESS_INDEX,
@@ -171,7 +179,7 @@ impl AccountModel for Account {
                 )?;
 
                 let _change_subaddress_b58 = AssignedSubaddress::create(
-                    &account_key,
+                    &account_key_to_create,
                     None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
                            * always for main? */
                     DEFAULT_CHANGE_SUBADDRESS_INDEX,
@@ -184,7 +192,8 @@ impl AccountModel for Account {
     }
 
     fn import(
-        entropy: &RootEntropy,
+        account_key: Option<&AccountKey>,
+        entropy: Option<&RootEntropy>,
         name: Option<String>,
         import_block: u64,
         first_block: Option<u64>,
@@ -192,7 +201,8 @@ impl AccountModel for Account {
     ) -> Result<Account, WalletDbError> {
         Ok(conn.transaction::<Account, WalletDbError, _>(|| {
             let (account_id, _public_address_b58) = Account::create(
-                &entropy,
+                account_key,
+                entropy,
                 first_block,
                 Some(import_block),
                 &name.unwrap_or_else(|| "".to_string()),
@@ -213,62 +223,22 @@ impl AccountModel for Account {
     }
 
     fn get(
-        account_id_hex: &AccountID,
+        account_id: &AccountID,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
         use crate::db::schema::accounts::dsl::{account_id_hex as dsl_account_id_hex, accounts};
 
         match accounts
-            .filter(dsl_account_id_hex.eq(account_id_hex.to_string()))
+            .filter(dsl_account_id_hex.eq(account_id.to_string()))
             .get_result::<Account>(conn)
         {
             Ok(a) => Ok(a),
             // Match on NotFound to get a more informative NotFound Error
             Err(diesel::result::Error::NotFound) => {
-                Err(WalletDbError::AccountNotFound(account_id_hex.to_string()))
+                Err(WalletDbError::AccountNotFound(account_id.to_string()))
             }
             Err(e) => Err(e.into()),
         }
-    }
-
-    fn get_decorated(
-        account_id_hex: &AccountID,
-        local_height: u64,
-        network_height: u64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<JsonAccount, WalletDbError> {
-        Ok(conn.transaction::<JsonAccount, WalletDbError, _>(|| {
-            let account = Account::get(account_id_hex, conn)?;
-
-            let unspent =
-                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_UNSPENT, conn)?
-                    .iter()
-                    .map(|t| t.value as u128)
-                    .sum::<u128>();
-            let pending =
-                Txo::list_by_status(&account_id_hex.to_string(), TXO_STATUS_PENDING, conn)?
-                    .iter()
-                    .map(|t| t.value as u128)
-                    .sum::<u128>();
-
-            let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-            let main_subaddress_b58 =
-                b58_encode(&account_key.subaddress(DEFAULT_SUBADDRESS_INDEX))?;
-            Ok(JsonAccount {
-                object: "account".to_string(),
-                account_id: account.account_id_hex,
-                name: account.name,
-                network_height: network_height.to_string(),
-                local_height: local_height.to_string(),
-                account_height: account.next_block.to_string(),
-                is_synced: account.next_block == network_height as i64,
-                available_pmob: unspent.to_string(),
-                pending_pmob: pending.to_string(),
-                main_address: main_subaddress_b58,
-                next_subaddress_index: account.next_subaddress_index.to_string(),
-                recovery_mode: false, // FIXME: WS-24 - Recovery mode for account
-            })
-        })?)
     }
 
     fn get_by_txo_id(
@@ -409,7 +379,8 @@ mod tests {
         let account_id_hex = {
             let conn = wallet_db.get_conn().unwrap();
             let (account_id_hex, _public_address_b58) = Account::create(
-                &root_id.root_entropy,
+                None,
+                Some(&root_id.root_entropy),
                 Some(0),
                 None,
                 "Alice's Main Account",
@@ -430,7 +401,7 @@ mod tests {
             id: 1,
             account_id_hex: account_id_hex.to_string(),
             account_key: mc_util_serial::encode(&account_key),
-            entropy: root_id.root_entropy.bytes.to_vec(),
+            entropy: Some(root_id.root_entropy.bytes.to_vec()),
             main_subaddress_index: 0,
             change_subaddress_index: 1,
             next_subaddress_index: 2,
@@ -468,7 +439,8 @@ mod tests {
         let root_id_secondary = RootIdentity::from_random(&mut rng);
         let account_key_secondary = AccountKey::from(&root_id_secondary);
         let (account_id_hex_secondary, _public_address_b58_secondary) = Account::create(
-            &root_id_secondary.root_entropy,
+            None,
+            Some(&root_id_secondary.root_entropy),
             Some(51),
             Some(50),
             "",
@@ -484,7 +456,7 @@ mod tests {
             id: 2,
             account_id_hex: account_id_hex_secondary.to_string(),
             account_key: mc_util_serial::encode(&account_key_secondary),
-            entropy: root_id_secondary.root_entropy.bytes.to_vec(),
+            entropy: Some(root_id_secondary.root_entropy.bytes.to_vec()),
             main_subaddress_index: 0,
             change_subaddress_index: 1,
             next_subaddress_index: 2,
@@ -523,6 +495,144 @@ mod tests {
                 assert_eq!(s, account_id_hex_secondary.to_string())
             }
             Err(_) => panic!("Should error with NotFound but got {:?}", res),
+        }
+    }
+
+    // Providing entropy only on create should succeed and derive account key.
+    #[test_with_logger]
+    fn test_create_account_with_entropy(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        // Test providing entropy only
+        let root_id = RootIdentity::from_random(&mut rng);
+        let account_key = AccountKey::from(&root_id);
+        let account_id = {
+            let conn = wallet_db.get_conn().unwrap();
+            let (account_id_hex, _public_address_b58) = Account::create(
+                None,
+                Some(&root_id.root_entropy),
+                Some(0),
+                None,
+                "Alice's Main Account",
+                &conn,
+            )
+            .unwrap();
+            account_id_hex
+        };
+        let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
+        let decoded_entropy: RootEntropy =
+            mc_util_serial::decode(&account.entropy.unwrap()).unwrap();
+        assert_eq!(decoded_entropy, root_id.root_entropy);
+        let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();
+        assert_eq!(decoded_account_key, account_key);
+    }
+
+    // Test providing account_key only should succeed and store None for entropy
+    #[test_with_logger]
+    fn test_create_account_with_account_key(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        let root_id = RootIdentity::from_random(&mut rng);
+        let account_key = AccountKey::from(&root_id);
+        let account_id = {
+            let conn = wallet_db.get_conn().unwrap();
+            let (account_id_hex, _public_address_b58) = Account::create(
+                Some(&account_key),
+                None,
+                Some(0),
+                None,
+                "Alice's Main Account",
+                &conn,
+            )
+            .unwrap();
+            account_id_hex
+        };
+        let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
+        assert!(account.entropy.is_none());
+        let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();
+        assert_eq!(decoded_account_key, account_key);
+    }
+
+    // Test providing account_key and entropy that match should succeed and store
+    // both.
+    #[test_with_logger]
+    fn test_create_account_with_matching_secrets(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        let root_id = RootIdentity::from_random(&mut rng);
+        let account_key = AccountKey::from(&root_id);
+        let account_id = {
+            let conn = wallet_db.get_conn().unwrap();
+            let (account_id_hex, _public_address_b58) = Account::create(
+                Some(&account_key),
+                Some(&root_id.root_entropy),
+                Some(0),
+                None,
+                "Alice's Main Account",
+                &conn,
+            )
+            .unwrap();
+            account_id_hex
+        };
+        let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
+        let decoded_entropy: RootEntropy =
+            mc_util_serial::decode(&account.entropy.unwrap()).unwrap();
+        assert_eq!(decoded_entropy, root_id.root_entropy);
+        let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();
+        assert_eq!(decoded_account_key, account_key);
+    }
+
+    // Test providing account_key and entropy that don't match should fail.
+    #[test_with_logger]
+    fn test_create_account_with_mismatched_secrets(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        let root_id1 = RootIdentity::from_random(&mut rng);
+        let account_key = AccountKey::from(&root_id1);
+        let root_id2 = RootIdentity::from_random(&mut rng);
+        {
+            let conn = wallet_db.get_conn().unwrap();
+            match Account::create(
+                Some(&account_key),
+                Some(&root_id2.root_entropy),
+                Some(0),
+                None,
+                "Alice's Main Account",
+                &conn,
+            ) {
+                Ok(_) => panic!("Should not be able to create account with mismatched secrets"),
+                Err(WalletDbError::AccountSecretsDoNotMatch) => {}
+                Err(e) => panic!(
+                    "Unexpected error testing account with mismatched secrets {:?}",
+                    e
+                ),
+            }
+        }
+    }
+
+    // Test providing no secrets should fail.
+    #[test_with_logger]
+    fn test_create_account_with_no_secrets(logger: Logger) {
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        let conn = wallet_db.get_conn().unwrap();
+        match Account::create(None, None, Some(0), None, "Alice's Main Account", &conn) {
+            Ok(_) => panic!("Should not be able to create account with no secrets"),
+            Err(WalletDbError::InsufficientSecretsToCreateAccount) => {}
+            Err(e) => panic!("Unexpected error testing account with no secrets {:?}", e),
         }
     }
 }

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -76,7 +76,7 @@ pub struct Account {
     pub account_key: Vec<u8>,
     /// The private entropy for this account, used to derive the view and send
     /// keys which comprise the account_key.
-    pub entropy: Vec<u8>,
+    pub entropy: Option<Vec<u8>>,
     /// Default subadress that is given out to refer to this account.
     pub main_subaddress_index: i64,
     /// Subaddress used to return transaction "change" to self.
@@ -104,7 +104,7 @@ pub struct Account {
 pub struct NewAccount<'a> {
     pub account_id_hex: &'a str,
     pub account_key: &'a [u8],
-    pub entropy: &'a [u8],
+    pub entropy: Option<&'a [u8]>,
     pub main_subaddress_index: i64,
     pub change_subaddress_index: i64,
     pub next_subaddress_index: i64,

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -12,7 +12,7 @@ table! {
         id -> Integer,
         account_id_hex -> Text,
         account_key -> Binary,
-        entropy -> Binary,
+        entropy -> Nullable<Binary>,
         main_subaddress_index -> BigInt,
         change_subaddress_index -> BigInt,
         next_subaddress_index -> BigInt,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -554,7 +554,8 @@ mod tests {
 
         // Now we'll ingest them.
         let (account_id, _address) = Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(0),
             None,
             "",

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -939,7 +939,8 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let alice_account_key = AccountKey::from(&root_id);
         let (alice_account_id, _public_address_b58) = Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(1),
             None,
             "Alice's Main Account",
@@ -1200,7 +1201,8 @@ mod tests {
         let bob_root_id = RootIdentity::from_random(&mut rng);
         let bob_account_key = AccountKey::from(&bob_root_id);
         let (bob_account_id, _public_address_b58) = Account::create(
-            &bob_root_id.root_entropy,
+            None,
+            Some(&bob_root_id.root_entropy),
             Some(1),
             None,
             "Bob's Main Account",
@@ -1258,7 +1260,8 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
         let (account_id_hex, _public_address_b58) = Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(1),
             None,
             "Alice's Main Account",
@@ -1363,7 +1366,8 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
         let (account_id_hex, _public_address_b58) = Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(0),
             None,
             "Alice's Main Account",
@@ -1415,7 +1419,8 @@ mod tests {
         let wallet_db = db_test_context.get_db_instance(logger.clone());
 
         Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(0),
             None,
             "",
@@ -1478,7 +1483,8 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
         Account::create(
-            &root_id.root_entropy,
+            None,
+            Some(&root_id.root_entropy),
             Some(0),
             None,
             "",

--- a/full-service/src/db/wallet_db_error.rs
+++ b/full-service/src/db/wallet_db_error.rs
@@ -97,6 +97,13 @@ pub enum WalletDbError {
 
     /// The Txo has neither received_to nor spent_from specified.
     MalformedTxoDatabaseEntry,
+
+    /// The account key and the entropy provided to create account do not match.
+    AccountSecretsDoNotMatch,
+
+    /// The account cannot be created without either an entropy or an account
+    /// key.
+    InsufficientSecretsToCreateAccount,
 }
 
 impl From<diesel::result::Error> for WalletDbError {

--- a/full-service/src/json_rpc/account.rs
+++ b/full-service/src/json_rpc/account.rs
@@ -65,7 +65,7 @@ impl TryFrom<&db::models::Account> for Account {
             main_address,
             next_subaddress_index: src.next_subaddress_index.to_string(),
             recovery_mode: false,
-            entropy: Some(hex::encode(&src.entropy)),
+            entropy: src.entropy.clone().map(|e| hex::encode(&e)),
             account_key: Some(
                 json_rpc::account_key::AccountKey::try_from(&account_key)
                     .map_err(|e| format!("Could not get json_rpc::AccountKey: {:?}", e))?,

--- a/full-service/src/json_rpc/account_key.rs
+++ b/full-service/src/json_rpc/account_key.rs
@@ -13,10 +13,10 @@ pub struct AccountKey {
     /// the same value.
     pub object: String,
 
-    ///  Private key used for view-key matching.
+    ///  Private key used for view-key matching, hex-encoded Ristretto bytes.
     pub view_private_key: String,
 
-    /// Private key used for spending.
+    /// Private key used for spending, hex-encoded Ristretto bytes.
     pub spend_private_key: String,
 
     /// Fog Report server url (if user has Fog service), empty string otherwise.

--- a/full-service/src/json_rpc/account_key.rs
+++ b/full-service/src/json_rpc/account_key.rs
@@ -63,8 +63,8 @@ impl TryFrom<&AccountKey> for mc_account_keys::AccountKey {
         let fog_authority_spki = hex::decode(&src.fog_authority_spki)
             .map_err(|err| format!("Could not hex decode fog_authority_spki: {:?}", err))?;
         Ok(mc_account_keys::AccountKey::new_with_fog(
-            &spend_private_key.into(),
-            &view_private_key.into(),
+            &spend_private_key,
+            &view_private_key,
             src.fog_report_url.clone(),
             src.fog_report_id.clone(),
             fog_authority_spki,

--- a/full-service/src/json_rpc/account_key.rs
+++ b/full-service/src/json_rpc/account_key.rs
@@ -2,6 +2,7 @@
 
 //! API definition for the Account Key object.
 
+use mc_crypto_keys::RistrettoPrivate;
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -32,17 +33,61 @@ pub struct AccountKey {
     pub fog_authority_spki: String,
 }
 
-impl TryFrom<&mc_account_keys::AccountKey> for AccountKey {
-    type Error = String;
-
-    fn try_from(src: &mc_account_keys::AccountKey) -> Result<AccountKey, String> {
-        Ok(AccountKey {
+impl From<&mc_account_keys::AccountKey> for AccountKey {
+    fn from(src: &mc_account_keys::AccountKey) -> AccountKey {
+        AccountKey {
             object: "account_key".to_string(),
             view_private_key: hex::encode(mc_util_serial::encode(src.view_private_key())),
             spend_private_key: hex::encode(mc_util_serial::encode(src.spend_private_key())),
             fog_report_url: src.fog_report_url().unwrap_or("").to_string(),
             fog_report_id: src.fog_report_id().unwrap_or("").to_string(),
             fog_authority_spki: hex::encode(&src.fog_authority_spki().unwrap_or(&[])),
-        })
+        }
+    }
+}
+
+impl TryFrom<&AccountKey> for mc_account_keys::AccountKey {
+    type Error = String;
+
+    fn try_from(src: &AccountKey) -> Result<mc_account_keys::AccountKey, String> {
+        let view_private_key: RistrettoPrivate = mc_util_serial::decode(
+            &hex::decode(&src.view_private_key)
+                .map_err(|err| format!("Could not hex decode spend_private_key: {:?}", err))?,
+        )
+        .map_err(|err| format!("Could not prost decode spend_private_key: {:?}", err))?;
+        let spend_private_key: RistrettoPrivate = mc_util_serial::decode(
+            &hex::decode(&src.spend_private_key)
+                .map_err(|err| format!("Could not hex decode spend_private_key: {:?}", err))?,
+        )
+        .map_err(|err| format!("Could not prost decode spend_private_key: {:?}", err))?;
+        let fog_authority_spki = hex::decode(&src.fog_authority_spki)
+            .map_err(|err| format!("Could not hex decode fog_authority_spki: {:?}", err))?;
+        Ok(mc_account_keys::AccountKey::new_with_fog(
+            &spend_private_key.into(),
+            &view_private_key.into(),
+            src.fog_report_url.clone(),
+            src.fog_report_id.clone(),
+            fog_authority_spki,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod account_key_tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_round_trip() {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let account_key1 = mc_account_keys::AccountKey::random(&mut rng);
+        let json_rpc_account_key1 = AccountKey::try_from(&account_key1).unwrap();
+        let json_account_key = serde_json::json!(json_rpc_account_key1);
+
+        let json_rpc_account_key2: AccountKey = serde_json::from_value(json_account_key).unwrap();
+        let account_key2 = mc_account_keys::AccountKey::try_from(&json_rpc_account_key2).unwrap();
+
+        assert_eq!(account_key1, account_key2);
     }
 }

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -19,7 +19,9 @@ pub struct AccountSecrets {
     pub account_id: String,
 
     /// The entropy from which this account key was derived, hex-encoded.
-    pub entropy: String,
+    ///
+    /// Optional because an account can be created from only the AccountKey.
+    pub entropy: Option<String>,
 
     ///  Private key for receiving and spending MobileCoin.
     pub account_key: AccountKey,
@@ -34,7 +36,7 @@ impl TryFrom<&Account> for AccountSecrets {
         Ok(AccountSecrets {
             object: "account_key".to_string(),
             account_id: src.account_id_hex.clone(),
-            entropy: hex::encode(&src.entropy),
+            entropy: src.entropy.clone().map(|e| hex::encode(&e)),
             account_key: AccountKey::try_from(&account_key).map_err(|err| {
                 format!(
                     "Could not convert account_key to json_rpc representation: {:?}",

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for the Account Secrets object.
+
+use crate::{db::models::Account, json_rpc::account_key::AccountKey};
+
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// The AccountSecrets contains the entropy and the account key derived from
+/// that entropy.
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct AccountSecrets {
+    /// String representing the object's type. Objects of the same type share
+    /// the same value.
+    pub object: String,
+
+    /// The account ID for this account key in the wallet database.
+    pub account_id: String,
+
+    /// The entropy from which this account key was derived, hex-encoded.
+    pub entropy: String,
+
+    ///  Private key for receiving and spending MobileCoin.
+    pub account_key: AccountKey,
+}
+
+impl TryFrom<&Account> for AccountSecrets {
+    type Error = String;
+
+    fn try_from(src: &Account) -> Result<AccountSecrets, String> {
+        let account_key: mc_account_keys::AccountKey = mc_util_serial::decode(&src.account_key)
+            .map_err(|err| format!("Could not decode account key from database: {:?}", err))?;
+        Ok(AccountSecrets {
+            object: "account_key".to_string(),
+            account_id: src.account_id_hex.clone(),
+            entropy: hex::encode(&src.entropy),
+            account_key: AccountKey::try_from(&account_key).map_err(|err| {
+                format!(
+                    "Could not convert account_key to json_rpc representation: {:?}",
+                    err
+                )
+            })?,
+        })
+    }
+}

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -14,12 +14,12 @@ use crate::{
     },
 };
 use mc_account_keys::PublicAddress;
-use mc_common::logger::{log, test_with_logger, Logger};
+use mc_common::logger::{log, Logger};
 use mc_connection_test_utils::MockBlockchainConnection;
 use mc_fog_report_validation::MockFogPubkeyResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_ledger_sync::PollingNetworkState;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::rngs::StdRng;
 use rocket::{
     http::{ContentType, Status},
     local::Client,
@@ -225,48 +225,5 @@ pub fn wait_for_sync(
         if count > 10 {
             panic!("Service did not sync after 10 iterations");
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Test that our "wallet" endpoint is backward compatible with previous API
-    // versions. Note: requires keeping the test_wallet_api in sync with the
-    // wallet.rs wallet_api method.
-    #[test_with_logger]
-    fn test_api_version(logger: Logger) {
-        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
-
-        // Create Account with API v1
-        let body = json!({
-            "method": "create_account",
-            "params": {
-                "name": "Alice Main Account",
-            }
-        });
-        let result = dispatch(&client, body, &logger);
-        assert!(result.get("result").unwrap().get("entropy").is_some());
-
-        // Create Account with API v2
-        let body = json!({
-            "jsonrpc": "2.0",
-            "method": "create_account",
-            "params": {
-                "name": "Alice Main Account",
-            },
-            "api_version": "2",
-        });
-        let result = dispatch(&client, body, &logger);
-        assert!(result
-            .get("result")
-            .unwrap()
-            .get("account")
-            .unwrap()
-            .get("entropy")
-            .is_some());
-        assert_eq!(result.get("jsonrpc").unwrap(), "2.0");
     }
 }

--- a/full-service/src/json_rpc/api_v1/decorated_types.rs
+++ b/full-service/src/json_rpc/api_v1/decorated_types.rs
@@ -16,40 +16,6 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::Map;
 use std::convert::TryFrom;
 
-#[derive(Deserialize, Serialize, Default, Debug)]
-pub struct JsonCreateAccountResponse {
-    pub entropy: String,
-    pub account: JsonAccount,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct JsonAccount {
-    pub object: String,
-    pub account_id: String,
-    pub name: String,
-    pub network_height: String,
-    pub local_height: String,
-    pub account_height: String,
-    pub is_synced: bool,
-    pub available_pmob: String,
-    pub pending_pmob: String,
-    pub main_address: String,
-    pub next_subaddress_index: String,
-    pub recovery_mode: bool,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct JsonWalletStatus {
-    pub object: String,
-    pub network_height: String,
-    pub local_height: String,
-    pub is_synced_all: bool,
-    pub total_available_pmob: String,
-    pub total_pending_pmob: String,
-    pub account_ids: Vec<String>,
-    pub account_map: Map<String, serde_json::Value>,
-}
-
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxo {
     pub object: String,
@@ -119,17 +85,6 @@ impl JsonTxo {
             offset_count: txo_details.txo.id,
         }
     }
-}
-
-#[derive(Deserialize, Serialize, Default, Debug)]
-pub struct JsonBalanceResponse {
-    pub unspent: String,
-    pub pending: String,
-    pub spent: String,
-    pub secreted: String,
-    pub orphaned: String,
-    pub local_block_count: String,
-    pub synced_blocks: String,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/full-service/src/json_rpc/api_v1/wallet_api.rs
+++ b/full-service/src/json_rpc/api_v1/wallet_api.rs
@@ -264,7 +264,7 @@ where
                 .map_err(format_error)?;
 
             let result = service
-                .import_account(entropy, name, fb)
+                .import_account_entropy(entropy, name, fb)
                 .map_err(format_error)?;
 
             let local_height = service.ledger_db.num_blocks().map_err(format_error)?;

--- a/full-service/src/json_rpc/api_v1/wallet_api.rs
+++ b/full-service/src/json_rpc/api_v1/wallet_api.rs
@@ -429,15 +429,19 @@ mod e2e {
         // Check the overall balance for the account
         let body = json!({
             "api_version": "2",
-            "method": "get_balance",
+            "method": "get_balance_for_account",
             "params": {
                 "account_id": account_id,
             }
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let balance_status = result.get("balance").unwrap();
+        let unspent = balance_status
+            .get("unspent_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "100");
     }
 
@@ -558,15 +562,20 @@ mod e2e {
 
         // Get current balance
         let body = json!({
-            "method": "get_balance",
+            "api_version": "2",
+            "method": "get_balance_for_account",
             "params": {
                 "account_id": account_id,
             }
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
+        let balance_status = result.get("balance").unwrap();
+        let unspent = balance_status
+            .get("unspent_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "100000000000100");
 
         // Submit the tx_proposal
@@ -593,18 +602,31 @@ mod e2e {
 
         // Get balance after submission
         let body = json!({
-            "method": "get_balance",
+            "api_version": "2",
+            "method": "get_balance_for_account",
             "params": {
                 "account_id": account_id,
             }
         });
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
-        let balance_status = result.get("status").unwrap();
-        let unspent = balance_status.get("unspent").unwrap().as_str().unwrap();
-        let pending = balance_status.get("pending").unwrap().as_str().unwrap();
-        let spent = balance_status.get("spent").unwrap().as_str().unwrap();
-        let secreted = balance_status.get("secreted").unwrap().as_str().unwrap();
+        let balance_status = result.get("balance").unwrap();
+        let unspent = balance_status
+            .get("unspent_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let pending = balance_status
+            .get("pending_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let spent = balance_status.get("spent_pmob").unwrap().as_str().unwrap();
+        let secreted = balance_status
+            .get("secreted_pmob")
+            .unwrap()
+            .as_str()
+            .unwrap();
         assert_eq!(unspent, "0");
         assert_eq!(pending, "0");
         assert_eq!(spent, "99990000000100");

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -157,7 +157,7 @@ mod e2e {
             "jsonrpc": "2.0",
             "api_version": "2",
             "id": 1,
-            "method": "import_account",
+            "method": "import_account_by_entropy",
             "params": {
                 "entropy": "c593274dc6f6eb94242e34ae5f0ab16bc3085d45d49d9e18b8a8c6f057e6b56b",
                 "name": "Alice Main Account",
@@ -187,7 +187,7 @@ mod e2e {
             "jsonrpc": "2.0",
             "api_version": "2",
             "id": 1,
-            "method": "import_account",
+            "method": "import_account_by_entropy",
             "params": {
                 "entropy": "c593274dc6f6eb94242e34ae5f0ab16bc3085d45d49d9e18b8a8c6f057e6b56b",
                 "name": "Alice Main Account",
@@ -229,7 +229,7 @@ mod e2e {
             "jsonrpc": "2.0",
             "api_version": "2",
             "id": 1,
-            "method": "import_account",
+            "method": "import_account_by_entropy",
             "params": {
                 "entropy": "c593274dc6f6eb94242e34ae5f0ab16bc3085d45d49d9e18b8a8c6f057e6b56b",
                 "name": "Alice Main Account",
@@ -311,6 +311,63 @@ mod e2e {
             serde_json::json!(json_rpc::account_key::AccountKey::try_from(&account_key).unwrap()),
             secrets["account_key"]
         );
+    }
+
+    // Import an account by the account key should succeed.
+    #[test_with_logger]
+    fn test_import_account_by_account_key(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
+
+        // Create account for a simple way to get the correctly-formatted json
+        let body = json!({
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1,
+            "method": "create_account",
+            "params": {
+                "name": "Alice Main Account",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let account_obj = res["result"]["account"].clone();
+        let account_key: json_rpc::account_key::AccountKey =
+            serde_json::from_value(account_obj["account_key"].clone()).unwrap();
+        let account_id = account_obj["account_id"].clone();
+        let public_address_from_entropy = account_obj["main_address"].clone();
+
+        // Delete the account to clear out the DB
+        let body = json!({
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 2,
+            "method": "delete_account",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        // Should have deleted the correct account
+        assert_eq!(result["account"]["account_id"], account_id);
+
+        println!("\x1b[1;31m Account key {:?}\x1b[0m", account_key);
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1,
+            "method": "import_account_by_account_key",
+            "params": {
+                "account_key": account_key,
+                "name": "Alice Main Account Part 2",
+                "first_block": "200",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let account_obj = res["result"]["account"].clone();
+        assert_eq!(account_obj["main_address"], public_address_from_entropy);
+        assert!(account_obj["entropy"].is_null());
     }
 
     #[test_with_logger]

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -396,7 +396,9 @@ mod e2e {
         let status = result.get("wallet_status").unwrap();
         assert_eq!(status.get("network_block_count").unwrap(), "12");
         assert_eq!(status.get("local_block_count").unwrap(), "12");
-        assert_eq!(status.get("min_synced_block_index").unwrap(), "0");
+        // Syncing will have already started, so we can't determine what the min synced
+        // index is.
+        assert!(status.get("min_synced_block_index").is_some());
         assert_eq!(status.get("total_unspent_pmob").unwrap(), "0");
         assert_eq!(status.get("total_pending_pmob").unwrap(), "0");
         assert_eq!(status.get("total_spent_pmob").unwrap(), "0");

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -4,7 +4,7 @@
 //!
 //! API v2
 
-use crate::json_rpc::api_v1::wallet_api::JsonCommandRequestV1;
+use crate::json_rpc::{account_key::AccountKey, api_v1::wallet_api::JsonCommandRequestV1};
 
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -78,8 +78,13 @@ pub enum JsonCommandRequestV2 {
         name: Option<String>,
         first_block_index: Option<String>,
     },
-    import_account {
+    import_account_by_entropy {
         entropy: String,
+        name: Option<String>,
+        first_block_index: Option<String>,
+    },
+    import_account_by_account_key {
+        account_key: AccountKey,
         name: Option<String>,
         first_block_index: Option<String>,
     },

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -83,6 +83,9 @@ pub enum JsonCommandRequestV2 {
         name: Option<String>,
         first_block_index: Option<String>,
     },
+    export_account_secrets {
+        account_id: String,
+    },
     get_all_accounts,
     get_account {
         account_id: String,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -4,8 +4,10 @@
 //!
 //! API v2
 
-use crate::json_rpc::{account::Account, balance::Balance, wallet_status::WalletStatus};
-
+use crate::json_rpc::{
+    account::Account, account_secrets::AccountSecrets, balance::Balance,
+    wallet_status::WalletStatus,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 
@@ -148,6 +150,9 @@ pub enum JsonCommandResponseV2 {
     },
     import_account {
         account: Account,
+    },
+    export_account_secrets {
+        account_secrets: AccountSecrets,
     },
     get_all_accounts {
         account_ids: Vec<String>,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -148,7 +148,10 @@ pub enum JsonCommandResponseV2 {
     create_account {
         account: Account,
     },
-    import_account {
+    import_account_by_entropy {
+        account: Account,
+    },
+    import_account_by_account_key {
         account: Account,
     },
     export_account_secrets {

--- a/full-service/src/json_rpc/mod.rs
+++ b/full-service/src/json_rpc/mod.rs
@@ -4,6 +4,7 @@
 
 mod account;
 mod account_key;
+pub mod account_secrets;
 pub mod api_v1;
 mod balance;
 pub mod json_rpc_request;

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -113,7 +113,7 @@ where
                     .map_err(|e| format!("Could not get RPC Account from DB Account {:?}", e))?,
             }
         }
-        JsonCommandRequestV2::import_account {
+        JsonCommandRequestV2::import_account_by_entropy {
             entropy,
             name,
             first_block_index,
@@ -123,10 +123,34 @@ where
                 .transpose()
                 .map_err(format_error)?;
 
-            JsonCommandResponseV2::import_account {
+            JsonCommandResponseV2::import_account_by_entropy {
                 account: json_rpc::account::Account::try_from(
                     &service
                         .import_account_entropy(entropy, name, fb)
+                        .map_err(format_error)?,
+                )
+                .map_err(format_error)?,
+            }
+        }
+        JsonCommandRequestV2::import_account_by_account_key {
+            account_key,
+            name,
+            first_block_index,
+        } => {
+            let fb = first_block_index
+                .map(|fb| fb.parse::<u64>())
+                .transpose()
+                .map_err(format_error)?;
+
+            JsonCommandResponseV2::import_account_by_account_key {
+                account: json_rpc::account::Account::try_from(
+                    &service
+                        .import_account_key(
+                            mc_account_keys::AccountKey::try_from(&account_key)
+                                .map_err(format_error)?,
+                            name,
+                            fb,
+                        )
                         .map_err(format_error)?,
                 )
                 .map_err(format_error)?,

--- a/full-service/src/json_rpc/wallet_status.rs
+++ b/full-service/src/json_rpc/wallet_status.rs
@@ -81,7 +81,7 @@ impl TryFrom<&service::balance::WalletStatus> for WalletStatus {
             object: "wallet_status".to_string(),
             network_block_count: src.network_block_count.to_string(),
             local_block_count: src.local_block_count.to_string(),
-            is_synced_all: src.min_synced_block_index == src.network_block_count - 1,
+            is_synced_all: src.min_synced_block_index >= src.network_block_count - 1,
             min_synced_block_index: src.min_synced_block_index.to_string(),
             total_unspent_pmob: src.unspent.to_string(),
             total_pending_pmob: src.pending.to_string(),

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -37,7 +37,7 @@ pub trait AccountService {
     ) -> Result<Account, WalletServiceError>;
 
     /// Import an existing account to the wallet.
-    fn import_account(
+    fn import_account_entropy(
         &self,
         entropy: String,
         name: Option<String>,
@@ -95,7 +95,7 @@ where
         Ok(account)
     }
 
-    fn import_account(
+    fn import_account_entropy(
         &self,
         entropy: String,
         name: Option<String>,

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -10,7 +10,7 @@ use crate::{
     error::WalletServiceError,
     service::WalletService,
 };
-use mc_account_keys::RootEntropy;
+use mc_account_keys::{AccountKey, RootEntropy};
 use mc_common::logger::log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
@@ -36,10 +36,18 @@ pub trait AccountService {
         first_block_index: Option<u64>,
     ) -> Result<Account, WalletServiceError>;
 
-    /// Import an existing account to the wallet.
+    /// Import an existing account to the wallet using the entropy.
     fn import_account_entropy(
         &self,
         entropy: String,
+        name: Option<String>,
+        first_block_index: Option<u64>,
+    ) -> Result<Account, WalletServiceError>;
+
+    /// Import an existing account to the wallet using the account key.
+    fn import_account_key(
+        &self,
+        account_key: AccountKey,
         name: Option<String>,
         first_block_index: Option<u64>,
     ) -> Result<Account, WalletServiceError>;
@@ -82,11 +90,21 @@ where
         let mut rng = rand::thread_rng();
         let entropy = RootEntropy::from_random(&mut rng);
 
+        // Since we are creating the account from randomness, it is highly unlikely that
+        // it would have collided with another account that already received funds. For
+        // this reason, start scanning at the current network block index.
+        let first_block = first_block_index.unwrap_or(self.get_network_block_index()?);
+
+        // The earliest we could start scanning is the current highest block index of
+        // the local ledger.
+        let import_block_index = self.ledger_db.num_blocks()? - 1;
+
         let conn = self.wallet_db.get_conn()?;
         let (account_id, _public_address_b58) = Account::create(
-            &entropy,
-            first_block_index,
             None,
+            Some(&entropy),
+            Some(first_block),
+            Some(import_block_index),
             &name.unwrap_or_else(|| "".to_string()),
             &conn,
         )?;
@@ -111,11 +129,42 @@ where
         let mut entropy_bytes = [0u8; 32];
         hex::decode_to_slice(entropy, &mut entropy_bytes)?;
 
+        // We record the local highest block index because that is the earliest we could
+        // start scanning.
         let import_block = self.ledger_db.num_blocks()? - 1;
 
         let conn = self.wallet_db.get_conn()?;
         Ok(Account::import(
-            &RootEntropy::from(&entropy_bytes),
+            None,
+            Some(&RootEntropy::from(&entropy_bytes)),
+            name,
+            import_block,
+            first_block_index,
+            &conn,
+        )?)
+    }
+
+    fn import_account_key(
+        &self,
+        account_key: AccountKey,
+        name: Option<String>,
+        first_block_index: Option<u64>,
+    ) -> Result<Account, WalletServiceError> {
+        log::info!(
+            self.logger,
+            "Importing account {:?} with first block: {:?}",
+            name,
+            first_block_index,
+        );
+
+        // We record the local highest block index because that is the earliest we could
+        // start scanning.
+        let import_block = self.ledger_db.num_blocks()? - 1;
+
+        let conn = self.wallet_db.get_conn()?;
+        Ok(Account::import(
+            Some(&account_key),
+            None,
             name,
             import_block,
             first_block_index,

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -25,13 +25,6 @@ use diesel::{
     Connection,
 };
 
-/*
-use displaydoc::Display;
-/// Errors for the Balance Service.
-#[derive(Display, Debug)]
-pub enum BalanceServiceError {}
-*/
-
 /// The balance object returned by balance services.
 ///
 /// This must be a service object because there is no "Balance" table in our
@@ -115,7 +108,7 @@ where
             spent,
             secreted,
             orphaned,
-            network_block_count: network_block_count,
+            network_block_count,
             local_block_count,
             synced_blocks: account.next_block as u64,
         })
@@ -163,6 +156,7 @@ where
                     min_synced_block_index,
                     (account.next_block as u64).saturating_sub(1),
                 );
+                println!("\x1b[1;33m For account {:?} got network block index = {:?}, local_ledger_block_count {:?}, and account.next_block {:?}", account_id, network_block_index, self.ledger_db.num_blocks().unwrap(), account.next_block);
 
                 account_ids.push(account_id);
             }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -18,7 +18,6 @@ use mc_common::HashMap;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
-use mc_ledger_sync::NetworkState;
 
 use diesel::{
     prelude::*,
@@ -106,13 +105,7 @@ where
         let (unspent, pending, spent, secreted, orphaned) =
             Self::get_balance_inner(account_id_hex, &conn)?;
 
-        let network_state = self.network_state.read().expect("lock poisoned");
-        // network_height = network_block_index + 1
-        let network_height = network_state
-            .highest_block_index_on_network()
-            .map(|v| v + 1)
-            .unwrap_or(0);
-
+        let network_block_count = self.get_network_block_index()? + 1;
         let local_block_count = self.ledger_db.num_blocks()?;
         let account = Account::get(account_id, &conn)?;
 
@@ -122,7 +115,7 @@ where
             spent,
             secreted,
             orphaned,
-            network_block_count: network_height,
+            network_block_count: network_block_count,
             local_block_count,
             synced_blocks: account.next_block as u64,
         })
@@ -141,12 +134,7 @@ where
     fn get_wallet_status(&self) -> Result<WalletStatus, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
 
-        let network_state = self.network_state.read().expect("lock poisoned");
-        // network_height = network_block_index + 1
-        let network_height = network_state
-            .highest_block_index_on_network()
-            .map(|v| v + 1)
-            .unwrap_or(0);
+        let network_block_index = self.get_network_block_index()?;
 
         Ok(conn.transaction::<WalletStatus, WalletServiceError, _>(|| {
             let accounts = Account::list_all(&conn)?;
@@ -158,7 +146,7 @@ where
             let mut secreted = 0;
             let mut orphaned = 0;
 
-            let mut min_synced_block_index = network_height;
+            let mut min_synced_block_index = network_block_index;
             let mut account_ids = Vec::new();
             for account in accounts {
                 let account_id = AccountID(account.account_id_hex.clone());
@@ -185,7 +173,7 @@ where
                 spent: spent as u64,
                 secreted: secreted as u64,
                 orphaned: orphaned as u64,
-                network_block_count: network_height,
+                network_block_count: network_block_index + 1,
                 local_block_count: self.ledger_db.num_blocks()?,
                 min_synced_block_index: min_synced_block_index as u64,
                 account_ids,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -27,7 +27,7 @@ use mc_connection::{
 use mc_crypto_rand::rand_core::RngCore;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
-use mc_ledger_sync::PollingNetworkState;
+use mc_ledger_sync::{NetworkState, PollingNetworkState};
 use mc_mobilecoind::payments::TxProposal;
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut, JsonTxProposal};
 use mc_transaction_core::tx::{Tx, TxOut, TxOutConfirmationNumber};
@@ -117,6 +117,14 @@ impl<
             offline,
             logger,
         }
+    }
+
+    pub fn get_network_block_index(&self) -> Result<u64, WalletServiceError> {
+        let network_state = self.network_state.read().expect("lock poisoned");
+        Ok(network_state
+            .highest_block_index_on_network()
+            .map(|v| v + 1)
+            .unwrap_or(0))
     }
 
     pub fn list_txos(&self, account_id_hex: &str) -> Result<Vec<JsonTxo>, WalletServiceError> {

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -121,10 +121,7 @@ impl<
 
     pub fn get_network_block_index(&self) -> Result<u64, WalletServiceError> {
         let network_state = self.network_state.read().expect("lock poisoned");
-        Ok(network_state
-            .highest_block_index_on_network()
-            .map(|v| v + 1)
-            .unwrap_or(0))
+        Ok(network_state.highest_block_index_on_network().unwrap_or(0))
     }
 
     pub fn list_txos(&self, account_id_hex: &str) -> Result<Vec<JsonTxo>, WalletServiceError> {

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -514,7 +514,8 @@ pub fn random_account_with_seed_values(
     let root_id = RootIdentity::from_random(&mut rng);
     let account_key = AccountKey::from(&root_id);
     Account::create(
-        &root_id.root_entropy,
+        None,
+        Some(&root_id.root_entropy),
         Some(0),
         None,
         "",


### PR DESCRIPTION
### Motivation

Users need a way to be able to export their account secrets. There should also be a way to import an account from an account key.

### In this PR
* adds account key secret export
* adds import by account key
* moves entropy to be a nullable field for the Account object (in case you import an account key)
* adds tests
* updates documentation
* removes tests and endpoints from api_v1 that are now deprecated.
* I think this also fixes the flaky test

[FS-64](https://mobilecoin.atlassian.net/browse/FS-64)
[FS-57](https://mobilecoin.atlassian.net/browse/FS-57)
[FS-125](https://mobilecoin.atlassian.net/browse/FS-125)

