### PR TITLE
Moves account get_decorated to the API layer

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -116,14 +116,6 @@ pub trait AccountModel {
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError>;
 
-    // /// Get the API-decorated Account object.
-    // fn get_decorated(
-    //     account_id_hex: &AccountID,
-    //     local_height: u64,
-    //     network_height: u64,
-    //     conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    // ) -> Result<JsonAccount, WalletDbError>;
-
     /// Get all accounts somehow related to a particular TXO?
     fn get_by_txo_id(
         txo_id_hex: &str,
@@ -275,47 +267,6 @@ impl AccountModel for Account {
         let account = accounts.find(id).get_result::<Account>(conn)?;
         Ok(account)
     }
-
-    // fn get_decorated(
-    //     account_id_hex: &AccountID,
-    //     local_height: u64,
-    //     network_height: u64,
-    //     conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    // ) -> Result<JsonAccount, WalletDbError> {
-    //     Ok(conn.transaction::<JsonAccount, WalletDbError, _>(|| {
-    //         let account = Account::get(account_id_hex, conn)?;
-    //
-    //         let unspent =
-    //             Txo::list_by_status(&account_id_hex.to_string(),
-    // TXO_STATUS_UNSPENT, conn)?                 .iter()
-    //                 .map(|t| t.value as u128)
-    //                 .sum::<u128>();
-    //         let pending =
-    //             Txo::list_by_status(&account_id_hex.to_string(),
-    // TXO_STATUS_PENDING, conn)?                 .iter()
-    //                 .map(|t| t.value as u128)
-    //                 .sum::<u128>();
-    //
-    //         let account_key: AccountKey =
-    // mc_util_serial::decode(&account.account_key)?;         let
-    // main_subaddress_b58 =             
-    // b58_encode(&account_key.subaddress(DEFAULT_SUBADDRESS_INDEX))?;
-    //         Ok(JsonAccount {
-    //             object: "account".to_string(),
-    //             account_id: account.account_id_hex,
-    //             name: account.name,
-    //             network_height: network_height.to_string(),
-    //             local_height: local_height.to_string(),
-    //             account_height: account.next_block.to_string(),
-    //             is_synced: account.next_block == network_height as i64,
-    //             available_pmob: unspent.to_string(),
-    //             pending_pmob: pending.to_string(),
-    //             main_address: main_subaddress_b58,
-    //             next_subaddress_index: account.next_subaddress_index.to_string(),
-    //             recovery_mode: false, // FIXME: WS-24 - Recovery mode for account
-    //         })
-    //     })?)
-    // }
 
     fn get_by_txo_id(
         txo_id_hex: &str,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -53,8 +53,10 @@ pub trait AccountModel {
     /// Create a new account.
     ///
     /// # Arguments
-    /// * `entropy` - The "root entropy" used to generate the account's private keys.
-    /// * `first_block` - Index of the first block where this account may have sent or received MobileCoin.
+    /// * `entropy` - The "root entropy" used to generate the account's private
+    ///   keys.
+    /// * `first_block` - Index of the first block where this account may have
+    ///   sent or received MobileCoin.
     /// * `import_block` - ???
     /// * `name` - A name for this account in the wallet.
     /// * `conn` - SQLite connection.
@@ -72,8 +74,10 @@ pub trait AccountModel {
     /// Import account.
     ///
     /// # Arguments
-    /// * `entropy` - The "root entropy" used to generate the account's private keys.
-    /// * `first_block` - Index of the first block where this account may have sent or received MobileCoin.
+    /// * `entropy` - The "root entropy" used to generate the account's private
+    ///   keys.
+    /// * `first_block` - Index of the first block where this account may have
+    ///   sent or received MobileCoin.
     /// * `import_block` - ???
     /// * `name` - A name for this account in the wallet.
     /// * `conn` - SQLite connection.
@@ -102,6 +106,18 @@ pub trait AccountModel {
     /// * Account
     fn get(
         account_id_hex: &AccountID,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Account, WalletDbError>;
+
+    /// Get an account.
+    ///
+    /// # Arguments
+    /// * `id` - The account's ID.
+    ///
+    /// # Returns
+    /// * Account
+    fn get_by_id(
+        id: i32,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError>;
 
@@ -247,6 +263,22 @@ impl AccountModel for Account {
             }
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Get an account.
+    ///
+    /// # Arguments
+    /// * `id` - The account's ID.
+    ///
+    /// # Returns
+    /// * Account
+    fn get_by_id(
+        id: i32,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Account, WalletDbError> {
+        use crate::db::schema::accounts::dsl::accounts;
+        let account = accounts.find(id).get_result::<Account>(conn)?;
+        Ok(account)
     }
 
     fn get_decorated(
@@ -416,7 +448,9 @@ mod tests {
     use std::{collections::HashSet, iter::FromIterator};
 
     /// Get a connection to an empty WalletDb.
-    fn get_wallet_db_connection(logger: Logger) -> PooledConnection<ConnectionManager<SqliteConnection>> {
+    fn get_wallet_db_connection(
+        logger: Logger,
+    ) -> PooledConnection<ConnectionManager<SqliteConnection>> {
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
         wallet_db.get_conn().unwrap()
@@ -431,8 +465,8 @@ mod tests {
         match Account::list_all(&conn) {
             Ok(accounts) => {
                 assert_eq!(accounts.len(), 0);
-            },
-            Err(e) => { panic!("Unexpected error {:?}", e) }
+            }
+            Err(e) => panic!("Unexpected error {:?}", e),
         }
     }
 
@@ -445,9 +479,9 @@ mod tests {
         match Account::get(&AccountID("foo".to_string()), &conn) {
             Ok(account) => {
                 panic!("Unexpected account {:?}", account);
-            },
-            Err(WalletDbError::AccountNotFound(_x)) => { /* This is expected */ },
-            Err(e) => { panic!("Unexpected error {:?}", e) }
+            }
+            Err(WalletDbError::AccountNotFound(_x)) => { /* This is expected */ }
+            Err(e) => panic!("Unexpected error {:?}", e),
         }
     }
 


### PR DESCRIPTION
### Motivation

Continues the theme of encapsulating JSON-related code in the API layer.

### In this PR
* Moves Account::get_decorated out of account.rs and into wallet_api.rs,
* Adds Account::get_by_id (Seemed like a good idea to support querying by primary key),
