### PR TITLE
FS-143: Verify public address

### DIFF
--- a/API_v2.md
+++ b/API_v2.md
@@ -19,6 +19,7 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 * [get_balance_for_account](#get-balance-for-a-given-account)
 * [assign_address_for_account](#assign-address-for-account)
 * [get_all_addresses_for_account](#get-all-assigned-addresses-for-a-given-account)
+* [verify_address](#verify-address)
 * [build_and_submit_transaction](#build-and-submit-transaction)
 * [build_transaction](#build-transaction)
 * [submit_transaction](#submit-transaction)
@@ -848,6 +849,38 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `account_id`   | The account on which to perform this action  | Account must exist in the wallet  |
+
+#### Verify Address
+
+Verify whether an address is correctly b58 encoded.
+
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "verify_address",
+        "params": {
+          "public_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
+        },
+        "jsonrpc": "2.0",
+        "api_version": "2",
+        "id": 1
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+```
+
+```json
+{
+  "method": "verify_address",
+  "result": {
+    "verified": true
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
+}
+```
 
 ### Transactions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,7 @@ dependencies = [
 name = "mc-full-service"
 version = "0.1.0"
 dependencies = [
+ "bs58",
  "chrono",
  "crossbeam-channel 0.4.4",
  "diesel",

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -61,6 +61,7 @@ mc-connection-test-utils = { path = "../mobilecoin/connection/test-utils" }
 mc-fog-report-validation = { path = "../mobilecoin/fog/report/validation", features = ["automock"] }
 mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils"}
 tempdir = "0.3"
+bs58 = "0.3.0"
 
 [build-dependencies]
 # clippy fails to run without this.

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -145,6 +145,9 @@ pub enum JsonCommandRequestV2 {
     get_all_addresses_for_account {
         account_id: String,
     },
+    verify_address {
+        public_address: String,
+    },
     /*
     get_balance_for_subaddress {
         address: String,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -210,6 +210,9 @@ pub enum JsonCommandResponseV2 {
         public_addresses: Vec<String>,
         address_map: Map<String, serde_json::Value>,
     },
+    verify_address {
+        verified: bool,
+    },
     /*
     get_balance_for_subaddress {
         balance: Balance,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -408,6 +408,13 @@ where
                 transaction_log_map,
             }
         }
+        JsonCommandRequestV2::verify_address { public_address } => {
+            JsonCommandResponseV2::verify_address {
+                verified: service
+                    .verify_address(&public_address)
+                    .map_err(format_error)?,
+            }
+        }
     };
     let response = Json(JsonRPCResponse::from(result));
     Ok(response)

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -2,17 +2,21 @@
 
 //! Service for managing addresses.
 
-use crate::{db::models::AssignedSubaddress, error::WalletServiceError, service::WalletService};
+use crate::{
+    db::{assigned_subaddress::AssignedSubaddressModel, b58_decode, models::AssignedSubaddress},
+    error::WalletServiceError,
+    service::WalletService,
+};
+use mc_common::logger::log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 
-use crate::db::assigned_subaddress::AssignedSubaddressModel;
 use diesel::Connection;
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// addresses.
 pub trait AddressService {
-    /// Creates a new account with default values.
+    /// Creates a new address with default values.
     fn assign_address_for_account(
         &self,
         account_id_hex: &str,
@@ -20,10 +24,14 @@ pub trait AddressService {
         // FIXME: FS-32 - add "sync from block"
     ) -> Result<AssignedSubaddress, WalletServiceError>;
 
+    /// Gets all the addresses for the given account.
     fn get_all_addresses_for_account(
         &self,
         account_id_hex: &str,
     ) -> Result<Vec<AssignedSubaddress>, WalletServiceError>;
+
+    /// Verifies whether an address can be decoded from b58.
+    fn verify_address(&self, public_address: &str) -> Result<bool, WalletServiceError>;
 }
 
 impl<T, FPR> AddressService for WalletService<T, FPR>
@@ -61,5 +69,82 @@ where
             account_id_hex,
             &self.wallet_db.get_conn()?,
         )?)
+    }
+
+    fn verify_address(&self, public_address: &str) -> Result<bool, WalletServiceError> {
+        match b58_decode(public_address) {
+            Ok(_a) => {
+                log::info!(self.logger, "Verified address {:?}", public_address);
+                Ok(true)
+            }
+            Err(e) => {
+                log::info!(
+                    self.logger,
+                    "Address did not verify {:?}: {:?}",
+                    public_address,
+                    e
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db::b58_encode,
+        test_utils::{get_test_ledger, setup_wallet_service},
+    };
+    use mc_account_keys::{AccountKey, PublicAddress};
+    use mc_common::logger::{test_with_logger, Logger};
+    use mc_crypto_rand::rand_core::RngCore;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    // A properly encoded address should verify.
+    #[test_with_logger]
+    fn test_verify_address_succeeds(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+
+        let account_key = AccountKey::random(&mut rng);
+        let public_address = account_key.subaddress(rng.next_u64());
+        let public_address_b58 =
+            b58_encode(&public_address).expect("Could not encode public address");
+
+        assert!(service
+            .verify_address(&public_address_b58)
+            .expect("Could not verify address"));
+    }
+
+    // An improperly encoded address should fail.
+    #[test_with_logger]
+    fn test_verify_address_fails(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+
+        // Empty string should fail
+        let public_address_b58 = "";
+        assert!(!service
+            .verify_address(&public_address_b58)
+            .expect("Could not verify address"));
+
+        // B58 encoding of public address should fail
+        let account_key = AccountKey::random(&mut rng);
+        let public_address = account_key.subaddress(rng.next_u64());
+        let public_address_b58 =
+            bs58::encode(mc_util_serial::encode(&public_address)).into_string();
+        assert!(!service
+            .verify_address(&public_address_b58)
+            .expect("Could not verify address"));
     }
 }


### PR DESCRIPTION
Soundtrack of this PR: [Marty O'Reilly & The Old Soul Orchestra](https://www.youtube.com/watch?v=lpIR4HCwlq0&list=PLZDAtvNZpqDGXDHI_ZEioFAaKce9jsIYH&index=4)

### Motivation

We should verify addresses, particularly before sending to them

### In this PR
* Adds verify_address endpoint and tests
* Updates build_transaction to verify_address, and adds a test

[FS-143](https://mobilecoin.atlassian.net/browse/FS-143)
[FS-157](https://mobilecoin.atlassian.net/browse/FS-157)

