### PR TITLE
FS-106: Get balance for address

### DIFF
--- a/API_v2.md
+++ b/API_v2.md
@@ -17,6 +17,7 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 * [get_txo](#get-txo-details)
 * [get_wallet_status](#get-wallet-status)
 * [get_balance_for_account](#get-balance-for-a-given-account)
+* [get_balance_for_address](#get-balance-for-a-given-address)
 * [assign_address_for_account](#assign-address-for-account)
 * [get_all_addresses_for_account](#get-all-assigned-addresses-for-a-given-account)
 * [verify_address](#verify-address)
@@ -671,11 +672,11 @@ curl -s localhost:9090/wallet \
       "local_block_index": "152918",
       "account_block_index": "152003",
       "is_synced": false,
-      "unspent_pmob": "110000000000000000"
+      "unspent_pmob": "110000000000000000",
       "pending_pmob": "0",
       "spent_pmob": "0",
       "secreted_pmob": "0",
-      "orphaned_pmob": "0",
+      "orphaned_pmob": "0"
     }
   },
   "error": null,
@@ -688,6 +689,52 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `account_id`   | The account on which to perform this action  | Account must exist in the wallet  |
+
+
+#### Get Balance for a Given Address
+
+```sh
+curl -s localhost:9090/wallet \
+  -d '{
+        "method": "get_balance_for_address",
+        "params": {
+           "address": "3P4GtGkp5UVBXUzBqirgj7QFetWn4PsFPsHBXbC6A8AXw1a9CMej969jneiN1qKcwdn6e1VtD64EruGVSFQ8wHk5xuBHndpV9WUGQ78vV7Z"
+        },
+        "jsonrpc": "2.0",
+        "api_version": "2",
+        "id": 1
+      }' \
+  -X POST -H 'Content-type: application/json' | jq
+```
+
+```json
+{
+  "method": "get_balance_for_address",
+  "result": {
+    "balance": {
+      "object": "balance",
+      "network_block_index": "152961",
+      "local_block_index": "152961",
+      "account_block_index": "152961",
+      "is_synced": true,
+      "unspent_pmob": "11881402222024",
+      "pending_pmob": "0",
+      "spent_pmob": "84493835554166",
+      "secreted_pmob": "0",
+      "orphaned_pmob": "0"
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+  "api_version": "2"
+}
+```
+
+| Required Param | Purpose                  | Requirements              |
+| :------------- | :----------------------- | :------------------------ |
+| `address`      | The address on which to perform this action  | Address must be assigned for an account in the wallet  |
+
 
 #### Get Account Status for a Given Account
 

--- a/API_v2.md
+++ b/API_v2.md
@@ -860,7 +860,7 @@ curl -s localhost:9090/wallet \
   -d '{
         "method": "verify_address",
         "params": {
-          "public_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
+          "address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
         },
         "jsonrpc": "2.0",
         "api_version": "2",

--- a/full-service/src/error.rs
+++ b/full-service/src/error.rs
@@ -2,7 +2,13 @@
 
 //! Errors for the wallet service.
 
-use crate::{db::WalletDbError, service::transaction::TransactionServiceError};
+use crate::{
+    db::WalletDbError,
+    service::{
+        balance::BalanceServiceError, ledger::LedgerServiceError,
+        transaction::TransactionServiceError,
+    },
+};
 use displaydoc::Display;
 
 #[derive(Display, Debug)]
@@ -38,6 +44,12 @@ pub enum WalletServiceError {
 
     /// Error with the transaction service: {0}
     TransactionService(TransactionServiceError),
+
+    /// Error with the balance service: {0}
+    BalanceService(BalanceServiceError),
+
+    /// Error with the ledger service: {0}
+    LedgerService(LedgerServiceError),
 }
 
 impl From<WalletDbError> for WalletServiceError {
@@ -55,6 +67,18 @@ impl From<hex::FromHexError> for WalletServiceError {
 impl From<TransactionServiceError> for WalletServiceError {
     fn from(src: TransactionServiceError) -> Self {
         Self::TransactionService(src)
+    }
+}
+
+impl From<BalanceServiceError> for WalletServiceError {
+    fn from(src: BalanceServiceError) -> Self {
+        Self::BalanceService(src)
+    }
+}
+
+impl From<LedgerServiceError> for WalletServiceError {
+    fn from(src: LedgerServiceError) -> Self {
+        Self::LedgerService(src)
     }
 }
 

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -945,7 +945,7 @@ mod e2e {
             "id": 1,
             "method": "verify_address",
             "params": {
-                "public_address": "NOTVALIDB58",
+                "address": "NOTVALIDB58",
             }
         });
         let res = dispatch(&client, body, &logger);
@@ -972,7 +972,7 @@ mod e2e {
             "id": 1,
             "method": "verify_address",
             "params": {
-                "public_address": b58_public_address,
+                "address": b58_public_address,
             }
         });
         let res = dispatch(&client, body, &logger);

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -146,19 +146,19 @@ pub enum JsonCommandRequestV2 {
         account_id: String,
     },
     verify_address {
-        public_address: String,
+        address: String,
+    },
+    get_balance_for_address {
+        address: String,
     },
     /*
-    get_balance_for_subaddress {
+    get_all_txos_for_address {
         address: String,
     },
     get_all_txos_for_account {
         account_id: String,
     },
-    get_all_txos_by_subadress {
-        address: String,
-    },
-    get_txo {
+        get_txo {
         txo_id: String,
     },
     get_transaction_object {

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -213,12 +213,11 @@ pub enum JsonCommandResponseV2 {
     verify_address {
         verified: bool,
     },
-    /*
-    get_balance_for_subaddress {
+    get_balance_for_address {
         balance: Balance,
     },
-    get_txos_for_subaddress {
-
+    /*
+    get_all_txos_for_address {
     }
     get_all_txos_for_account {
         txo_ids: Vec<String>,
@@ -227,8 +226,6 @@ pub enum JsonCommandResponseV2 {
     get_txo {
         txo: JsonTxo,
     },
-
-
     get_transaction_object {
         transaction: JsonTx,
     },

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -408,11 +408,16 @@ where
                 transaction_log_map,
             }
         }
-        JsonCommandRequestV2::verify_address { public_address } => {
-            JsonCommandResponseV2::verify_address {
-                verified: service
-                    .verify_address(&public_address)
-                    .map_err(format_error)?,
+        JsonCommandRequestV2::verify_address { address } => JsonCommandResponseV2::verify_address {
+            verified: service.verify_address(&address).map_err(format_error)?,
+        },
+        JsonCommandRequestV2::get_balance_for_address { address } => {
+            JsonCommandResponseV2::get_balance_for_address {
+                balance: Balance::from(
+                    service
+                        .get_balance_for_address(&address)
+                        .map_err(format_error)?,
+                ),
             }
         }
     };

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -222,13 +222,13 @@ where
         } => JsonCommandResponseV2::assign_address_for_account {
             address: Address::from(
                 &service
-                    .assign_address_for_account(&account_id, metadata.as_deref())
+                    .assign_address_for_account(&AccountID(account_id), metadata.as_deref())
                     .map_err(format_error)?,
             ),
         },
         JsonCommandRequestV2::get_all_addresses_for_account { account_id } => {
             let addresses = service
-                .get_all_addresses_for_account(&account_id)
+                .get_all_addresses_for_account(&AccountID(account_id))
                 .map_err(format_error)?;
             let address_map: Map<String, serde_json::Value> = Map::from_iter(
                 addresses
@@ -414,7 +414,7 @@ where
         JsonCommandRequestV2::get_balance_for_address { address } => {
             JsonCommandResponseV2::get_balance_for_address {
                 balance: Balance::from(
-                    service
+                    &service
                         .get_balance_for_address(&address)
                         .map_err(format_error)?,
                 ),

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -8,7 +8,7 @@ use crate::{
         models::Account,
     },
     error::WalletServiceError,
-    service::WalletService,
+    service::{ledger::LedgerService, WalletService},
 };
 use mc_account_keys::RootEntropy;
 use mc_common::logger::log;

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     db::{
-        assigned_subaddress::AssignedSubaddressModel, b58_decode, models::AssignedSubaddress,
-        WalletDbError,
+        account::AccountID, assigned_subaddress::AssignedSubaddressModel, b58_decode,
+        models::AssignedSubaddress, WalletDbError,
     },
     service::WalletService,
 };
@@ -45,7 +45,7 @@ pub trait AddressService {
     /// Creates a new address with default values.
     fn assign_address_for_account(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
         metadata: Option<&str>,
         // FIXME: FS-32 - add "sync from block"
     ) -> Result<AssignedSubaddress, AddressServiceError>;
@@ -53,7 +53,7 @@ pub trait AddressService {
     /// Gets all the addresses for the given account.
     fn get_all_addresses_for_account(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError>;
 
     /// Verifies whether an address can be decoded from b58.
@@ -67,7 +67,7 @@ where
 {
     fn assign_address_for_account(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
         metadata: Option<&str>,
         // FIXME: WS-32 - add "sync from block"
     ) -> Result<AssignedSubaddress, AddressServiceError> {
@@ -77,7 +77,7 @@ where
             conn.transaction::<AssignedSubaddress, AddressServiceError, _>(|| {
                 let (public_address_b58, _subaddress_index) =
                     AssignedSubaddress::create_next_for_account(
-                        account_id_hex,
+                        &account_id.to_string(),
                         metadata.unwrap_or(""),
                         &conn,
                     )?;
@@ -89,10 +89,10 @@ where
 
     fn get_all_addresses_for_account(
         &self,
-        account_id_hex: &str,
+        account_id: &AccountID,
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError> {
         Ok(AssignedSubaddress::list_all(
-            account_id_hex,
+            &account_id.to_string(),
             &self.wallet_db.get_conn()?,
         )?)
     }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -5,30 +5,73 @@
 use crate::{
     db::{
         account::{AccountID, AccountModel},
+        account_txo_status::AccountTxoStatusModel,
+        assigned_subaddress::AssignedSubaddressModel,
         models::{
-            Account, Txo, TXO_STATUS_ORPHANED, TXO_STATUS_PENDING, TXO_STATUS_SECRETED,
-            TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
+            Account, AccountTxoStatus, AssignedSubaddress, Txo, TXO_STATUS_ORPHANED,
+            TXO_STATUS_PENDING, TXO_STATUS_SECRETED, TXO_STATUS_SPENT, TXO_STATUS_UNSPENT,
         },
         txo::TxoModel,
+        WalletDbError,
     },
-    error::WalletServiceError,
     service::WalletService,
 };
-use mc_common::HashMap;
-use mc_connection::{BlockchainConnection, UserTxConnection};
-use mc_fog_report_validation::FogPubkeyResolver;
-use mc_ledger_db::Ledger;
 
-use crate::db::{
-    account_txo_status::AccountTxoStatusModel,
-    assigned_subaddress::AssignedSubaddressModel,
-    models::{AccountTxoStatus, AssignedSubaddress},
-};
+use crate::service::ledger::{LedgerService, LedgerServiceError};
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},
     Connection,
 };
+use displaydoc::Display;
+use mc_common::HashMap;
+use mc_connection::{BlockchainConnection, UserTxConnection};
+use mc_fog_report_validation::FogPubkeyResolver;
+use mc_ledger_db::Ledger;
+
+/// Errors for the Address Service.
+#[derive(Display, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum BalanceServiceError {
+    /// Error interacting with the database: {0}
+    Database(WalletDbError),
+
+    /// Diesel Error: {0}
+    Diesel(diesel::result::Error),
+
+    /// Error with LedgerDB: {0}
+    LedgerDB(mc_ledger_db::Error),
+
+    /// Error getting network block index: {0}
+    NetworkBlockIndex(LedgerServiceError),
+
+    /// Unexpected Account Txo Status: {0}
+    UnexpectedAccountTxoStatus(String),
+}
+
+impl From<WalletDbError> for BalanceServiceError {
+    fn from(src: WalletDbError) -> Self {
+        Self::Database(src)
+    }
+}
+
+impl From<diesel::result::Error> for BalanceServiceError {
+    fn from(src: diesel::result::Error) -> Self {
+        Self::Diesel(src)
+    }
+}
+
+impl From<mc_ledger_db::Error> for BalanceServiceError {
+    fn from(src: mc_ledger_db::Error) -> Self {
+        Self::LedgerDB(src)
+    }
+}
+
+impl From<LedgerServiceError> for BalanceServiceError {
+    fn from(src: LedgerServiceError) -> Self {
+        Self::NetworkBlockIndex(src)
+    }
+}
 
 /// The balance object returned by balance services.
 ///
@@ -74,11 +117,11 @@ pub trait BalanceService {
     fn get_balance_for_account(
         &self,
         account_id: &AccountID,
-    ) -> Result<Balance, WalletServiceError>;
+    ) -> Result<Balance, BalanceServiceError>;
 
-    fn get_balance_for_address(&self, address: String) -> Result<Balance, WalletServiceError>;
+    fn get_balance_for_address(&self, address: &str) -> Result<Balance, BalanceServiceError>;
 
-    fn get_wallet_status(&self) -> Result<WalletStatus, WalletServiceError>;
+    fn get_wallet_status(&self) -> Result<WalletStatus, BalanceServiceError>;
 }
 
 impl<T, FPR> BalanceService for WalletService<T, FPR>
@@ -89,7 +132,7 @@ where
     fn get_balance_for_account(
         &self,
         account_id: &AccountID,
-    ) -> Result<Balance, WalletServiceError> {
+    ) -> Result<Balance, BalanceServiceError> {
         let conn = self.wallet_db.get_conn()?;
         let account_id_hex = &account_id.to_string();
 
@@ -112,57 +155,15 @@ where
         })
     }
 
-    fn get_balance_for_address(&self, address: &str) -> Result<Balance, WalletServiceError> {
+    fn get_balance_for_address(&self, address: &str) -> Result<Balance, BalanceServiceError> {
         let conn = self.wallet_db.get_conn()?;
 
         let network_block_index = self.get_network_block_index()? + 1;
         let local_block_index = self.ledger_db.num_blocks()?;
-        let account = Account::get(account_id, &conn)?;
 
-        Ok(conn.transaction::<Balance, WalletServiceError, _>(|| {
+        Ok(conn.transaction::<Balance, BalanceServiceError, _>(|| {
             let txos = Txo::list_for_address(address.to_string(), &conn)?;
-            let account_id = AssignedSubaddress::get(address, &conn);
-
-            let mut unspent: u64 = 0;
-            let mut pending: u64 = 0;
-            let mut spent: u64 = 0;
-            let mut secreted: u64 = 0;
-            let mut orphaned: u64 = 0;
-
-            for txo in txos {
-                let status = AccountTxoStatus::get(&txo.txo.txo_id_hex, &account_id, &conn)?;
-                match status.txo_status.as_str() {
-                    TXO_STATUS_UNSPENT => unspent += txo.value.value,
-                    TXO_STATUS_PENDING => pending += txo.txo.value,
-                    TXO_STATUS_SPENT => spent += txo.txo.value,
-                    TXO_STATUS_SECRETED => secreted += txo.txo.value,
-                    TXO_STATUS_ORPHANED => orphaned += txo.txo.value,
-                    _ => return Err(WalletServiceError::U64Parse), // FIXME: balance service errors
-                }
-            }
-
-            Ok(Balance {
-                unspent,
-                pending,
-                spent,
-                secreted,
-                orphaned,
-                network_block_index,
-                local_block_index,
-                synced_blocks: account.next_block as u64,
-            })
-        }))
-    }
-
-    // Wallet Status is an overview of the wallet's status
-    fn get_wallet_status(&self) -> Result<WalletStatus, WalletServiceError> {
-        let conn = self.wallet_db.get_conn()?;
-
-        let network_block_index = self.get_network_block_index()?;
-
-        Ok(conn.transaction::<WalletStatus, WalletServiceError, _>(|| {
-            let accounts = Account::list_all(&conn)?;
-            let mut account_map = HashMap::default();
+            let assigned_address = AssignedSubaddress::get(address, &conn)?;
 
             let mut unspent = 0;
             let mut pending = 0;
@@ -170,39 +171,92 @@ where
             let mut secreted = 0;
             let mut orphaned = 0;
 
-            let mut min_synced_block_index = network_block_index;
-            let mut account_ids = Vec::new();
-            for account in accounts {
-                let account_id = AccountID(account.account_id_hex.clone());
-                let balance = Self::get_balance_inner(&account_id.to_string(), &conn)?;
-                account_map.insert(account_id.clone(), account.clone());
-                unspent += balance.0;
-                pending += balance.1;
-                spent += balance.2;
-                secreted += balance.3;
-                orphaned += balance.4;
-
-                // account.next_block_index is an index in range [0..ledger_db.num_blocks()]
-                min_synced_block_index = std::cmp::min(
-                    min_synced_block_index,
-                    (account.next_block_index as u64).saturating_sub(1),
-                );
-                account_ids.push(account_id);
+            for txo in txos {
+                let status = AccountTxoStatus::get(
+                    &assigned_address.account_id_hex,
+                    &txo.txo.txo_id_hex,
+                    &conn,
+                )?;
+                match status.txo_status.as_str() {
+                    TXO_STATUS_UNSPENT => unspent += txo.txo.value,
+                    TXO_STATUS_PENDING => pending += txo.txo.value,
+                    TXO_STATUS_SPENT => spent += txo.txo.value,
+                    TXO_STATUS_SECRETED => secreted += txo.txo.value,
+                    TXO_STATUS_ORPHANED => orphaned += txo.txo.value,
+                    _ => {
+                        return Err(BalanceServiceError::UnexpectedAccountTxoStatus(
+                            status.txo_status,
+                        ))
+                    }
+                }
             }
 
-            Ok(WalletStatus {
+            let account = Account::get(&AccountID(assigned_address.account_id_hex), &conn)?;
+
+            Ok(Balance {
                 unspent: unspent as u64,
                 pending: pending as u64,
                 spent: spent as u64,
                 secreted: secreted as u64,
                 orphaned: orphaned as u64,
-                network_block_index: network_block_index + 1,
-                local_block_index: self.ledger_db.num_blocks()?,
-                min_synced_block_index: min_synced_block_index as u64,
-                account_ids,
-                account_map,
+                network_block_index,
+                local_block_index,
+                synced_blocks: account.next_block as u64,
             })
         })?)
+    }
+
+    // Wallet Status is an overview of the wallet's status
+    fn get_wallet_status(&self) -> Result<WalletStatus, BalanceServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+
+        let network_block_index = self.get_network_block_index()?;
+
+        Ok(
+            conn.transaction::<WalletStatus, BalanceServiceError, _>(|| {
+                let accounts = Account::list_all(&conn)?;
+                let mut account_map = HashMap::default();
+
+                let mut unspent = 0;
+                let mut pending = 0;
+                let mut spent = 0;
+                let mut secreted = 0;
+                let mut orphaned = 0;
+
+                let mut min_synced_block_index = network_block_index;
+                let mut account_ids = Vec::new();
+                for account in accounts {
+                    let account_id = AccountID(account.account_id_hex.clone());
+                    let balance = Self::get_balance_inner(&account_id.to_string(), &conn)?;
+                    account_map.insert(account_id.clone(), account.clone());
+                    unspent += balance.0;
+                    pending += balance.1;
+                    spent += balance.2;
+                    secreted += balance.3;
+                    orphaned += balance.4;
+
+                    // account.next_block_index is an index in range [0..ledger_db.num_blocks()]
+                    min_synced_block_index = std::cmp::min(
+                        min_synced_block_index,
+                        (account.next_block_index as u64).saturating_sub(1),
+                    );
+                    account_ids.push(account_id);
+                }
+
+                Ok(WalletStatus {
+                    unspent: unspent as u64,
+                    pending: pending as u64,
+                    spent: spent as u64,
+                    secreted: secreted as u64,
+                    orphaned: orphaned as u64,
+                    network_block_index: network_block_index + 1,
+                    local_block_index: self.ledger_db.num_blocks()?,
+                    min_synced_block_index: min_synced_block_index as u64,
+                    account_ids,
+                    account_map,
+                })
+            })?,
+        )
     }
 }
 
@@ -214,7 +268,7 @@ where
     fn get_balance_inner(
         account_id_hex: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(u64, u64, u64, u64, u64), WalletServiceError> {
+    ) -> Result<(u64, u64, u64, u64, u64), BalanceServiceError> {
         let unspent = Txo::list_by_status(account_id_hex, TXO_STATUS_UNSPENT, &conn)?
             .iter()
             .map(|t| t.value as u128)
@@ -245,5 +299,106 @@ where
         );
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        db::b58_encode,
+        service::{account::AccountService, address::AddressService},
+        test_utils::{get_test_ledger, manually_sync_account, setup_wallet_service, MOB},
+    };
+    use mc_account_keys::{AccountKey, PublicAddress, RootEntropy, RootIdentity};
+    use mc_common::logger::{test_with_logger, Logger};
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    // The balance for an address should be accurate.
+    #[test_with_logger]
+    fn test_address_balance(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let entropy = RootEntropy::from_random(&mut rng);
+        let account_key = AccountKey::from(&RootIdentity::from(&entropy));
+
+        // Set up the ledger to be seeded with multiple subaddresses paid
+        let public_address0 = account_key.subaddress(0);
+        let public_address1 = account_key.subaddress(1);
+        let public_address2 = account_key.subaddress(2);
+        let public_address3 = account_key.subaddress(3);
+
+        let known_recipients: Vec<PublicAddress> = vec![
+            public_address0.clone(),
+            public_address1,
+            public_address2,
+            public_address3.clone(),
+        ];
+        let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+
+        let account = service
+            .import_account_entropy(hex::encode(&entropy.bytes), None, None)
+            .expect("Could not import account entropy");
+
+        let address = service
+            .assign_address_for_account(&AccountID(account.account_id_hex.clone()), None)
+            .expect("Could not assign address");
+        assert_eq!(address.subaddress_index, 2);
+
+        let _account = manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(account.account_id_hex.to_string()),
+            12,
+            &logger,
+        );
+
+        let account_balance = service
+            .get_balance_for_account(&AccountID(account.account_id_hex))
+            .expect("Could not get balance for account");
+
+        // 3 accounts * 5_000 MOB * 12 blocks
+        assert_eq!(account_balance.unspent, 180_000 * MOB as u64);
+        assert_eq!(account_balance.pending, 0);
+        assert_eq!(account_balance.spent, 0);
+        assert_eq!(account_balance.secreted, 0);
+        assert_eq!(account_balance.orphaned, 60_000 * MOB as u64); // Public address 3
+
+        let db_account_key: AccountKey =
+            mc_util_serial::decode(&account.account_key).expect("Could not decode account key");
+        let db_pub_address = db_account_key.subaddress(account.main_subaddress_index as u64);
+        assert_eq!(db_pub_address, public_address0);
+        let b58_pub_address = b58_encode(&db_pub_address).expect("Could not encode public address");
+        let address_balance = service
+            .get_balance_for_address(&b58_pub_address)
+            .expect("Could not get balance for address");
+
+        assert_eq!(address_balance.unspent, 60_000 * MOB as u64);
+        assert_eq!(address_balance.pending, 0);
+        assert_eq!(address_balance.spent, 0);
+        assert_eq!(address_balance.secreted, 0);
+        assert_eq!(address_balance.orphaned, 0);
+
+        let address_balance2 = service
+            .get_balance_for_address(&address.assigned_subaddress_b58)
+            .expect("Could not get balance for address");
+        assert_eq!(address_balance2.unspent, 60_000 * MOB as u64);
+        assert_eq!(address_balance2.pending, 0);
+        assert_eq!(address_balance2.spent, 0);
+        assert_eq!(address_balance2.secreted, 0);
+        assert_eq!(address_balance2.orphaned, 0);
+
+        // Even though subaddress 3 has funds, we are not watching it, so we should get
+        // an error.
+        let b58_pub_address3 =
+            b58_encode(&public_address3).expect("Could not encode public address");
+        match service.get_balance_for_address(&b58_pub_address3) {
+            Ok(_) => panic!("Should not get success getting balance for a non-assigned address"),
+            Err(BalanceServiceError::Database(WalletDbError::AssignedSubaddressNotFound(_))) => {}
+            Err(e) => panic!("Unexpected error {:?}", e),
+        }
     }
 }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -201,7 +201,7 @@ where
                 orphaned: orphaned as u64,
                 network_block_index,
                 local_block_index,
-                synced_blocks: account.next_block as u64,
+                synced_blocks: account.next_block_index as u64,
             })
         })?)
     }

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! Service for managing ledger materials and interfaces.
+
+use crate::WalletService;
+use mc_connection::{BlockchainConnection, UserTxConnection};
+use mc_fog_report_validation::FogPubkeyResolver;
+use mc_ledger_sync::NetworkState;
+
+use displaydoc::Display;
+
+/// Errors for the Address Service.
+#[derive(Display, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum LedgerServiceError {
+    /// Error with LedgerDB: {0}
+    LedgerDB(mc_ledger_db::Error),
+}
+
+impl From<mc_ledger_db::Error> for LedgerServiceError {
+    fn from(src: mc_ledger_db::Error) -> Self {
+        Self::LedgerDB(src)
+    }
+}
+
+/// Trait defining the ways in which the wallet can interact with and manage
+/// ledger objects and interfaces.
+pub trait LedgerService {
+    /// Gets the network highest block index on the live MobileCoin consensus
+    /// network.
+    fn get_network_block_index(&self) -> Result<u64, LedgerServiceError>;
+}
+
+impl<T, FPR> LedgerService for WalletService<T, FPR>
+where
+    T: BlockchainConnection + UserTxConnection + 'static,
+    FPR: FogPubkeyResolver + Send + Sync + 'static,
+{
+    fn get_network_block_index(&self) -> Result<u64, LedgerServiceError> {
+        let network_state = self.network_state.read().expect("lock poisoned");
+        Ok(network_state.highest_block_index_on_network().unwrap_or(0))
+    }
+}

--- a/full-service/src/service/mod.rs
+++ b/full-service/src/service/mod.rs
@@ -5,6 +5,7 @@
 pub mod account;
 pub mod address;
 pub mod balance;
+pub mod ledger;
 pub mod sync;
 pub mod transaction;
 pub mod transaction_builder;

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -345,7 +345,7 @@ mod tests {
 
         // Create an assigned subaddress for Bob
         let bob_address_from_alice = service
-            .assign_address_for_account(&bob.account_id_hex, Some("From Alice"))
+            .assign_address_for_account(&AccountID(bob.account_id_hex.clone()), Some("From Alice"))
             .unwrap();
 
         // Send a transaction from Alice to Bob

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -21,7 +21,7 @@ use mc_connection::{
 use mc_crypto_rand::rand_core::RngCore;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
-use mc_ledger_sync::{NetworkState, PollingNetworkState};
+use mc_ledger_sync::PollingNetworkState;
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut};
 use mc_transaction_core::tx::{Tx, TxOut, TxOutConfirmationNumber};
 use mc_util_uri::FogUri;
@@ -103,11 +103,6 @@ impl<
             offline,
             logger,
         }
-    }
-
-    pub fn get_network_block_index(&self) -> Result<u64, WalletServiceError> {
-        let network_state = self.network_state.read().expect("lock poisoned");
-        Ok(network_state.highest_block_index_on_network().unwrap_or(0))
     }
 
     pub fn list_txos(&self, account_id_hex: &str) -> Result<Vec<JsonTxo>, WalletServiceError> {


### PR DESCRIPTION
Soundtrack of this PR: [MobileCoin Radio: Graham Patzner](https://www.youtube.com/watch?v=j5ufaau-l34&list=PLZDAtvNZpqDGXDHI_ZEioFAaKce9jsIYH&index=3)

### Motivation

The balance for a subaddress may be useful for determining the value that has been received or spent from an existing subaddress.

### In this PR
* Adds `get_balance_for_address`
* Refactors the `get_network_block_index` to a new `LedgerService`. This service will also hold all the `get_ledger_object` calls, but that will be in a future PR.

[FS-106](https://mobilecoin.atlassian.net/browse/FS-106)
