### PR TITLE
FS-95: Receipts

### DIFF
--- a/full-service/migrations/2021-03-07-192850_receipts/down.sql
+++ b/full-service/migrations/2021-03-07-192850_receipts/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_txos__txo_public_key;

--- a/full-service/migrations/2021-03-07-192850_receipts/up.sql
+++ b/full-service/migrations/2021-03-07-192850_receipts/up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_txos__txo_public_key ON txos (public_key);

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -52,6 +52,7 @@ impl fmt::Display for TransactionID {
     }
 }
 
+#[derive(Debug)]
 pub struct AssociatedTxos {
     pub inputs: Vec<String>,
     pub outputs: Vec<String>,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1629,7 +1629,7 @@ mod tests {
         // Seed Txos
         let mut src_txos = Vec::new();
         for i in 0..10 {
-            let (txo_id, txo, key_image) =
+            let (_txo_id, txo, _key_image) =
                 create_test_received_txo(&account_key, i, i * MOB as u64, i, &mut rng, &wallet_db);
             src_txos.push(txo);
         }
@@ -1648,7 +1648,7 @@ mod tests {
     }
 
     // FIXME: once we have create_minted, then select_txos test with no
-    // spendable FIXME: test update txo after tombstone block is exceeded
+    // FIXME: test update txo after tombstone block is exceeded
     // FIXME: test update txo after it has landed via key_image update
     // FIXME: test any_failed and are_all_spent
     // FIXME: test max_spendable

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -17,7 +17,7 @@ use crate::db::{
 };
 use mc_account_keys::{AccountKey, PublicAddress};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
-use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 use mc_mobilecoind::payments::TxProposal;
 use mc_transaction_core::{
     constants::MAX_INPUTS,
@@ -74,8 +74,9 @@ pub trait TxoModel {
     /// * `subaddress_index` - The receiving subaddress index, if known.
     /// * `key_image` -
     /// * `value` - The value of the output, in picoMob.
-    /// * `received_block_index` - ???
-    /// * `account_id_hex` - ???
+    /// * `received_block_index` - the block at which the Txo was received.
+    /// * `account_id_hex` - the account ID for the account which received this
+    ///   Txo.
     /// * `conn` - Sqlite database connection.
     ///
     /// The subaddress_index may be None, and the Txo is said to be "orphaned",
@@ -161,6 +162,15 @@ pub trait TxoModel {
         txo_id_hex: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<TxoDetails, WalletDbError>;
+
+    /// Get several Txos by Txo public_keys.
+    ///
+    /// Returns:
+    /// * Vec<Txo>
+    fn select_by_public_key(
+        public_keys: &[&CompressedRistrettoPublic],
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<Txo>, WalletDbError>;
 
     /// Select several Txos by their TxoIds
     ///
@@ -725,6 +735,35 @@ impl TxoModel for Txo {
         }
 
         Ok(txo_details)
+    }
+
+    fn select_by_public_key(
+        public_keys: &[&CompressedRistrettoPublic],
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<Vec<Txo>, WalletDbError> {
+        use crate::db::schema::txos::dsl::{public_key, txos};
+
+        let public_key_blobs: Vec<Vec<u8>> = public_keys
+            .iter()
+            .map(|p| mc_util_serial::encode(*p))
+            .collect();
+        let selected: Vec<Txo> = match txos
+            .filter(public_key.eq_any(public_key_blobs))
+            .load::<Txo>(conn)
+        {
+            Ok(t) => t,
+            // Match on NotFound to get a more informative NotFound Error
+            Err(diesel::result::Error::NotFound) => {
+                return Err(WalletDbError::TxoNotFound(format!(
+                    "TxPublicKeys({:?})",
+                    public_keys
+                )));
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+        Ok(selected)
     }
 
     fn select_by_id(
@@ -1580,6 +1619,34 @@ mod tests {
         )
         .unwrap();
         assert!(verified);
+    }
+
+    #[test_with_logger]
+    fn test_select_txos_by_public_key(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger);
+
+        let account_key = AccountKey::random(&mut rng);
+
+        // Seed Txos
+        let mut src_txos = Vec::new();
+        for i in 0..10 {
+            let (txo_id, txo, key_image) =
+                create_test_received_txo(&account_key, i, i * MOB as u64, i, &mut rng, &wallet_db);
+            src_txos.push(txo);
+        }
+        let pubkeys: Vec<&CompressedRistrettoPublic> =
+            src_txos.iter().map(|t| &t.public_key).collect();
+
+        let txos = Txo::select_by_public_key(&pubkeys, &wallet_db.get_conn().unwrap())
+            .expect("Could not get txos by public keys");
+        assert_eq!(txos.len(), 10);
+
+        let txos = Txo::select_by_public_key(&pubkeys[0..5], &wallet_db.get_conn().unwrap())
+            .expect("Could not get txos by public keys");
+        assert_eq!(txos.len(), 5);
     }
 
     // FIXME: once we have create_minted, then select_txos test with no

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -6,6 +6,7 @@
 
 use crate::json_rpc::tx_proposal::TxProposal;
 
+use crate::json_rpc::receiver_receipt::ReceiverReceipt;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use strum::IntoEnumIterator;
@@ -162,5 +163,13 @@ pub enum JsonCommandRequestV2 {
     },
     get_block {
         block_index: String,
+    },
+    check_receiver_receipts_status {
+        account_id: String,
+        receiver_receipts: Vec<ReceiverReceipt>,
+        expected_value: String,
+    },
+    create_receiver_receipts {
+        tx_proposal: TxProposal,
     },
 }

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -4,17 +4,21 @@
 //!
 //! API v2
 
-use crate::json_rpc::{
-    account::Account,
-    account_secrets::AccountSecrets,
-    address::Address,
-    balance::Balance,
-    block::{Block, BlockContents},
-    proof::Proof,
-    transaction_log::TransactionLog,
-    tx_proposal::TxProposal,
-    txo::Txo,
-    wallet_status::WalletStatus,
+use crate::{
+    json_rpc::{
+        account::Account,
+        account_secrets::AccountSecrets,
+        address::Address,
+        balance::Balance,
+        block::{Block, BlockContents},
+        proof::Proof,
+        receiver_receipt::ReceiverReceipt,
+        transaction_log::TransactionLog,
+        tx_proposal::TxProposal,
+        txo::Txo,
+        wallet_status::WalletStatus,
+    },
+    service::receipt::ReceiptTransactionStatus,
 };
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut};
 use serde::{Deserialize, Serialize};
@@ -246,5 +250,11 @@ pub enum JsonCommandResponseV2 {
     get_block {
         block: Block,
         block_contents: BlockContents,
+    },
+    check_receiver_receipts_status {
+        receipts_transaction_status: ReceiptTransactionStatus,
+    },
+    create_receiver_receipts {
+        receiver_receipts: Vec<ReceiverReceipt>,
     },
 }

--- a/full-service/src/json_rpc/mod.rs
+++ b/full-service/src/json_rpc/mod.rs
@@ -11,6 +11,7 @@ mod block;
 pub mod json_rpc_request;
 pub mod json_rpc_response;
 mod proof;
+mod receiver_receipt;
 mod transaction_log;
 mod tx_proposal;
 mod txo;

--- a/full-service/src/json_rpc/receiver_receipt.rs
+++ b/full-service/src/json_rpc/receiver_receipt.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for the ReceiverReceipt object.
+
+use crate::{
+    db::{b58_decode, b58_encode},
+    service,
+};
+use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_transaction_core::tx::TxOutConfirmationNumber;
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// An receipt provided from the sender of a transaction for the receiver to use
+/// in order to check the status of a transaction.
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct ReceiverReceipt {
+    /// String representing the object's type. Objects of the same type share
+    /// the same value.
+    pub object: String,
+
+    /// The recipient of this Txo.
+    pub recipient: String,
+
+    /// The public key of the Txo sent to the recipient.
+    pub txo_public_key: String,
+
+    /// The hash of the Txo sent to the recipient.
+    pub txo_hash: String,
+
+    /// The tombstone block for the transaction.
+    pub tombstone: String,
+
+    /// The proof for this Txo, which links the sender to this Txo.
+    pub proof: String,
+}
+
+impl TryFrom<&service::receipt::ReceiverReceipt> for ReceiverReceipt {
+    type Error = String;
+
+    fn try_from(src: &service::receipt::ReceiverReceipt) -> Result<ReceiverReceipt, String> {
+        Ok(ReceiverReceipt {
+            object: "receiver_receipt".to_string(),
+            recipient: b58_encode(&src.recipient)
+                .map_err(|err| format!("Could not encode public address: {:?}", err))?,
+            txo_public_key: hex::encode(&mc_util_serial::encode(&src.txo_public_key)),
+            txo_hash: hex::encode(&src.txo_hash),
+            tombstone: src.tombstone.to_string(),
+            proof: hex::encode(&mc_util_serial::encode(&src.proof)),
+        })
+    }
+}
+
+impl TryFrom<&ReceiverReceipt> for service::receipt::ReceiverReceipt {
+    type Error = String;
+
+    fn try_from(src: &ReceiverReceipt) -> Result<service::receipt::ReceiverReceipt, String> {
+        let txo_public_key: CompressedRistrettoPublic = mc_util_serial::decode(
+            &hex::decode(&src.txo_public_key)
+                .map_err(|err| format!("Could not decode hex for txo_public_key: {:?}", err))?,
+        )
+        .map_err(|err| format!("Could not decode txo public key: {:?}", err))?;
+        let proof: TxOutConfirmationNumber = mc_util_serial::decode(
+            &hex::decode(&src.proof)
+                .map_err(|err| format!("Could not decode hex for proof: {:?}", err))?,
+        )
+        .map_err(|err| format!("Could not decode proof: {:?}", err))?;
+        Ok(service::receipt::ReceiverReceipt {
+            recipient: b58_decode(&src.recipient)
+                .map_err(|err| format!("Could not decode public address: {:?}", err))?,
+            txo_public_key,
+            txo_hash: hex::decode(&src.txo_hash)
+                .map_err(|err| format!("Could not decode hex for txo_hash: {:?}", err))?,
+            tombstone: src
+                .tombstone
+                .parse::<u64>()
+                .map_err(|err| format!("Could not parse u64: {:?}", err))?,
+            proof,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_account_keys::AccountKey;
+    use mc_crypto_keys::RistrettoPrivate;
+    use mc_crypto_rand::RngCore;
+    use mc_transaction_core::tx::TxOut;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_rpc_receipt_round_trip() {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let account_key = AccountKey::random(&mut rng);
+        let public_address = account_key.default_subaddress();
+        let txo = TxOut::new(
+            rng.next_u64(),
+            &public_address,
+            &RistrettoPrivate::from_random(&mut rng),
+            Default::default(),
+        )
+        .expect("Could not make TxOut");
+        let tombstone = rng.next_u64();
+        let mut proof_bytes = [0u8; 32];
+        rng.fill_bytes(&mut proof_bytes);
+        let confirmation_number = TxOutConfirmationNumber::from(proof_bytes);
+
+        let service_receipt = service::receipt::ReceiverReceipt {
+            recipient: public_address,
+            txo_public_key: txo.public_key,
+            txo_hash: txo.hash().to_vec(),
+            tombstone,
+            proof: confirmation_number,
+        };
+
+        let json_rpc_receipt = ReceiverReceipt::try_from(&service_receipt)
+            .expect("Could not get json receipt from service receipt");
+
+        let service_receipt_from_json =
+            service::receipt::ReceiverReceipt::try_from(&json_rpc_receipt)
+                .expect("Could not get receipt from json");
+
+        assert_eq!(service_receipt, service_receipt_from_json);
+    }
+}

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -505,7 +505,7 @@ where
         } => {
             let receipts: Vec<service::receipt::ReceiverReceipt> = receiver_receipts
                 .iter()
-                .map(|r| service::receipt::ReceiverReceipt::try_from(r))
+                .map(service::receipt::ReceiverReceipt::try_from)
                 .collect::<Result<Vec<service::receipt::ReceiverReceipt>, String>>()
                 .map_err(format_error)?;
             let status = service
@@ -528,7 +528,7 @@ where
                 .map_err(format_error)?;
             let json_receipts: Vec<ReceiverReceipt> = receipts
                 .iter()
-                .map(|r| ReceiverReceipt::try_from(r))
+                .map(ReceiverReceipt::try_from)
                 .collect::<Result<Vec<ReceiverReceipt>, String>>()
                 .map_err(format_error)?;
             JsonCommandResponseV2::create_receiver_receipts {

--- a/full-service/src/service/mod.rs
+++ b/full-service/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod address;
 pub mod balance;
 pub mod ledger;
 pub mod proof;
+pub mod receipt;
 pub mod sync;
 pub mod transaction;
 pub mod transaction_builder;

--- a/full-service/src/service/proof.rs
+++ b/full-service/src/service/proof.rs
@@ -93,6 +93,7 @@ impl From<TransactionLogServiceError> for ProofServiceError {
     }
 }
 
+#[derive(Debug)]
 pub struct Proof {
     pub txo_id: TxoID,
     pub txo_index: u64,

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -570,14 +570,6 @@ mod tests {
             14,
             &logger,
         );
-
-        // Status for Bob should still be pending, even though the Txos will show up in
-        // the wallet, but under Alice's account.
-        let status = service
-            .check_receiver_receipts_status(&bob_account_id, &receipts, 24 * MOB as u64)
-            .expect("Could not check status of receipt");
-        assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
-
         manually_sync_account(
             &ledger_db,
             &service.wallet_db,

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -12,9 +12,10 @@ use crate::{
     db::{
         account::AccountID,
         models::{AccountTxoStatus, Txo, TXO_STATUS_SECRETED, TXO_TYPE_MINTED},
-        txo::TxoModel,
+        txo::{TxoID, TxoModel},
         WalletDbError,
     },
+    service::proof::{ProofService, ProofServiceError},
     WalletService,
 };
 use displaydoc::Display;
@@ -25,7 +26,11 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_mobilecoind::payments::TxProposal;
 use mc_transaction_core::tx::TxOutConfirmationNumber;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    iter::FromIterator,
+};
 
 /// Errors for the Address Service.
 #[derive(Display, Debug)]
@@ -45,6 +50,9 @@ pub enum ReceiptServiceError {
 
     /// Error Converting Proto but throws convert::Infallible.
     ProtoConversionInfallible,
+
+    /// Error with the Proof Service
+    ProofService(ProofServiceError),
 }
 
 impl From<WalletDbError> for ReceiptServiceError {
@@ -65,7 +73,13 @@ impl From<mc_api::ConversionError> for ReceiptServiceError {
     }
 }
 
-#[derive(Debug)]
+impl From<ProofServiceError> for ReceiptServiceError {
+    fn from(src: ProofServiceError) -> Self {
+        Self::ProofService(src)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ReceiverTxReceipt {
     /// The recipient of this Txo.
     recipient: PublicAddress,
@@ -103,6 +117,12 @@ pub enum ReceiptTransactionStatus {
 
     /// The expected value of the Txos did not match the actual value.
     UnexpectedValue,
+
+    /// Invalid proof
+    InvalidProof,
+
+    /// Receipt contains duplicate Txos
+    DuplicateTxos,
 }
 
 impl TryFrom<&mc_mobilecoind_api::ReceiverTxReceipt> for ReceiverTxReceipt {
@@ -130,17 +150,9 @@ impl TryFrom<&mc_mobilecoind_api::ReceiverTxReceipt> for ReceiverTxReceipt {
 /// Trait defining the ways in which the wallet can interact with and manage
 /// receipts.
 pub trait ReceiptService {
-    /// Applies the transaction receipts from a sender to the wallet.
+    /// Check the status of the Txos in the receipts.
     ///
-    /// Verifies the proof of each Txo, and updates the associated transaction
-    /// logs.
-    fn apply_receiver_receipts(
-        &self,
-        receiver_receipts: &[ReceiverTxReceipt],
-        sender_metadata: String,
-    ) -> Result<Vec<Txo>, ReceiptServiceError>;
-
-    /// Check status
+    /// Applies the proofs by verifying the proofs once the Txos have landed.
     fn check_receiver_receipts_status(
         &self,
         account_id: &AccountID,
@@ -160,16 +172,6 @@ where
     T: BlockchainConnection + UserTxConnection + 'static,
     FPR: FogPubkeyResolver + Send + Sync + 'static,
 {
-    fn apply_receiver_receipts(
-        &self,
-        receiver_receipts: &[ReceiverTxReceipt],
-        sender_metadata: String,
-    ) -> Result<Vec<Txo>, ReceiptServiceError> {
-        //let txos = Txo::select_by_public_key()
-
-        Ok(vec![])
-    }
-
     fn check_receiver_receipts_status(
         &self,
         account_id: &AccountID,
@@ -180,8 +182,14 @@ where
             .iter()
             .map(|r| &r.txo_public_key)
             .collect();
+        let dup_check: HashSet<&&CompressedRistrettoPublic> = HashSet::from_iter(&public_keys);
+        if dup_check.len() < public_keys.len() {
+            return Ok(ReceiptTransactionStatus::DuplicateTxos);
+        }
+
         let txos_and_statuses =
             Txo::select_by_public_key(account_id, &public_keys, &self.wallet_db.get_conn()?)?;
+
         // None of the Txos from the receipts are in this wallet.
         if txos_and_statuses.len() == 0 {
             return Ok(ReceiptTransactionStatus::TransactionPending);
@@ -191,7 +199,7 @@ where
         // (For to-self transactions).
         let minted: Vec<&(Txo, AccountTxoStatus)> = txos_and_statuses
             .iter()
-            .filter(|(txo, status)| {
+            .filter(|(_txo, status)| {
                 status.txo_type == TXO_TYPE_MINTED && status.txo_status == TXO_STATUS_SECRETED
             })
             .collect();
@@ -205,7 +213,11 @@ where
         // Some of the Txos are in this wallet, but some are missing. The receipt is
         // malformed.
         if txos_and_statuses.len() != receiver_receipts.len() {
-            // FIXME also minted?
+            // The case where the sender and receiver share the same wallet, from the
+            // sender's perspective - if they sent to themselves, it is still pending.
+            if minted.len() + txos_and_statuses.len() == receiver_receipts.len() {
+                return Ok(ReceiptTransactionStatus::TransactionPending);
+            }
             return Ok(ReceiptTransactionStatus::SomeTxosMissing);
         }
 
@@ -213,7 +225,7 @@ where
         // block index.
         let received_block_indices: Vec<u64> = txos_and_statuses
             .iter()
-            .map(|(txo, status)| txo.received_block_index)
+            .map(|(txo, _status)| txo.received_block_index)
             .filter_map(|b| b.map(|i| i as u64))
             .collect();
         if received_block_indices.iter().min() != received_block_indices.iter().max() {
@@ -223,12 +235,31 @@ where
         // Check that the value of the received Txos matches the expected value
         let received_total: u64 = txos_and_statuses
             .iter()
-            .map(|(txo, status)| txo.value as u64)
+            .map(|(txo, _status)| txo.value as u64)
             .collect::<Vec<u64>>()
             .iter()
             .sum();
         if received_total != expected_value {
             return Ok(ReceiptTransactionStatus::UnexpectedValue);
+        }
+
+        // Create a mapping from public_key -> (Txo, Status)
+        let pubkey_to_txo: HashMap<Vec<u8>, (&Txo, &AccountTxoStatus)> = HashMap::from_iter(
+            txos_and_statuses
+                .iter()
+                .map(|(txo, status)| (txo.public_key.clone(), (txo, status)))
+                .collect::<Vec<(Vec<u8>, (&Txo, &AccountTxoStatus))>>(),
+        );
+
+        // Verify the proofs in the receipts
+        for receipt in receiver_receipts {
+            // Get the Txo which matches this receipt
+            let (txo, _status) =
+                pubkey_to_txo[&mc_util_serial::encode(&receipt.txo_public_key)].clone();
+            let proof_hex = hex::encode(mc_util_serial::encode(&receipt.proof));
+            if !self.verify_proof(account_id, &TxoID(txo.txo_id_hex.clone()), &proof_hex)? {
+                return Ok(ReceiptTransactionStatus::InvalidProof);
+            }
         }
 
         Ok(ReceiptTransactionStatus::TransactionSuccess)
@@ -447,7 +478,8 @@ mod tests {
         assert_eq!(receipts[0].proof, proofs[0].proof);
     }
 
-    // All txos received should return TransactionSuccess
+    // All txos received should return TransactionSuccess, and TransactionPending
+    // until they are received.
     #[test_with_logger]
     fn test_check_receiver_receipts_status_success(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
@@ -567,6 +599,540 @@ mod tests {
                 &AccountID(alice.account_id_hex),
                 &receipts,
                 24 * MOB as u64,
+            )
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
+    }
+
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_missing_txos(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+
+        // Create a TxProposal to Bob
+        let tx_proposal0 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts0 = service
+            .create_receiver_receipts(&tx_proposal0)
+            .expect("Could not create receiver receipts");
+
+        // Land the Txo in the ledger - only sync for the sender
+        TransactionLog::log_submitted(
+            tx_proposal0.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal0);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+
+        // Create another TxProposal to Bob (but do not send this one)
+        let tx_proposal1 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (32 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts1 = service
+            .create_receiver_receipts(&tx_proposal1)
+            .expect("Could not create receiver receipts");
+
+        // Construct an invalid receipt that includes a Txo which has landed, and one
+        // which has not.
+        let mut receipts = receipts0.clone();
+        receipts.extend(receipts1);
+
+        // Sync the ledger for Bob
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+
+        // Bob checks the status, and gets SomeTxosMissing because he has only received
+        // one txo
+        let status = service
+            .check_receiver_receipts_status(&bob_account_id, &receipts, 24 * MOB as u64)
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::SomeTxosMissing);
+
+        // Status for Alice would be pending, because she never received (and never will
+        // receive) the Txos.
+        let status = service
+            .check_receiver_receipts_status(
+                &AccountID(alice.account_id_hex),
+                &receipts,
+                24 * MOB as u64,
+            )
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
+    }
+
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_different_block_indices(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+
+        // Create a TxProposal to Bob
+        let tx_proposal0 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts0 = service
+            .create_receiver_receipts(&tx_proposal0)
+            .expect("Could not create receiver receipts");
+
+        // Land the Txo in the ledger - only sync for the sender
+        TransactionLog::log_submitted(
+            tx_proposal0.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal0);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+
+        // Create another TxProposal to Bob and send.
+        let tx_proposal1 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (32 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts1 = service
+            .create_receiver_receipts(&tx_proposal1)
+            .expect("Could not create receiver receipts");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal1);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            15,
+            &logger,
+        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 15, &logger);
+
+        // Construct an invalid receipt that includes Txos that landed in different
+        // blocks.
+        let mut receipts = receipts0.clone();
+        receipts.extend(receipts1);
+
+        // Bob checks the status, and gets DifferingBlocks
+        let status = service
+            .check_receiver_receipts_status(&bob_account_id, &receipts, 24 * MOB as u64)
+            .expect("Could not check status of receipt");
+        assert_eq!(
+            status,
+            ReceiptTransactionStatus::TxosReceivedAtDifferentBlockIndices
+        );
+
+        // Status for Alice would be pending, because she never received (and never will
+        // receive) the Txos.
+        let status = service
+            .check_receiver_receipts_status(
+                &AccountID(alice.account_id_hex),
+                &receipts,
+                24 * MOB as u64,
+            )
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
+    }
+
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_wrong_value(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+
+        // Create a TxProposal to Bob
+        let tx_proposal0 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts0 = service
+            .create_receiver_receipts(&tx_proposal0)
+            .expect("Could not create receiver receipts");
+
+        // Land the Txo in the ledger - only sync for the sender
+        TransactionLog::log_submitted(
+            tx_proposal0.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal0);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+
+        // Bob checks the status, and is expecting an incorrect value
+        let status = service
+            .check_receiver_receipts_status(&bob_account_id, &receipts0, 18 * MOB as u64)
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::UnexpectedValue);
+
+        // Status for Alice would be pending, because she never received (and never will
+        // receive) the Txos.
+        let status = service
+            .check_receiver_receipts_status(
+                &AccountID(alice.account_id_hex),
+                &receipts0,
+                18 * MOB as u64,
+            )
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
+    }
+
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_duplicate_txos(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+
+        // Create a TxProposal to Bob
+        let tx_proposal0 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts0 = service
+            .create_receiver_receipts(&tx_proposal0)
+            .expect("Could not create receiver receipts");
+
+        // Land the Txo in the ledger - only sync for the sender
+        TransactionLog::log_submitted(
+            tx_proposal0.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal0);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+
+        // Construct an invalid receipt with the same Txos
+        let mut receipts = receipts0.clone();
+        receipts.extend(receipts0);
+
+        // Bob checks the status, and is expecting an incorrect value
+        let status = service
+            .check_receiver_receipts_status(&bob_account_id, &receipts, 24 * MOB as u64)
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::DuplicateTxos);
+
+        // Checking for the sender should also fail if duplicate Txos in receipt.
+        let status = service
+            .check_receiver_receipts_status(
+                &AccountID(alice.account_id_hex),
+                &receipts,
+                18 * MOB as u64,
+            )
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::DuplicateTxos);
+    }
+
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_invalid_proof(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+
+        // Create a TxProposal to Bob
+        let tx_proposal0 = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts0 = service
+            .create_receiver_receipts(&tx_proposal0)
+            .expect("Could not create receiver receipts");
+
+        // Land the Txo in the ledger - only sync for the sender
+        TransactionLog::log_submitted(
+            tx_proposal0.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal0);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+
+        // Construct an invalid receipt with an incorrect proof
+        let mut receipts = receipts0.clone();
+        let mut bad_proof_bytes = [0u8; 32];
+        rng.fill_bytes(&mut bad_proof_bytes);
+        let bad_proof = TxOutConfirmationNumber::from(bad_proof_bytes);
+        receipts[0].proof = bad_proof;
+
+        // Bob checks the status, and is expecting an incorrect value
+        let status = service
+            .check_receiver_receipts_status(&bob_account_id, &receipts, 24 * MOB as u64)
+            .expect("Could not check status of receipt");
+        assert_eq!(status, ReceiptTransactionStatus::InvalidProof);
+
+        // Checking for the sender will be pending because the Txos haven't landed for
+        // alice (and never will).
+        let status = service
+            .check_receiver_receipts_status(
+                &AccountID(alice.account_id_hex),
+                &receipts,
+                18 * MOB as u64,
             )
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionPending);

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -191,7 +191,7 @@ where
             Txo::select_by_public_key(account_id, &public_keys, &self.wallet_db.get_conn()?)?;
 
         // None of the Txos from the receipts are in this wallet.
-        if txos_and_statuses.len() == 0 {
+        if txos_and_statuses.is_empty() {
             return Ok(ReceiptTransactionStatus::TransactionPending);
         }
 
@@ -254,8 +254,7 @@ where
         // Verify the proofs in the receipts
         for receipt in receiver_receipts {
             // Get the Txo which matches this receipt
-            let (txo, _status) =
-                pubkey_to_txo[&mc_util_serial::encode(&receipt.txo_public_key)].clone();
+            let (txo, _status) = pubkey_to_txo[&mc_util_serial::encode(&receipt.txo_public_key)];
             let proof_hex = hex::encode(mc_util_serial::encode(&receipt.proof));
             if !self.verify_proof(account_id, &TxoID(txo.txo_id_hex.clone()), &proof_hex)? {
                 return Ok(ReceiptTransactionStatus::InvalidProof);

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -9,7 +9,11 @@
 //! example, in the case of a dispute.
 
 use crate::{
-    db::{models::Txo, txo::TxoModel, WalletDbError},
+    db::{
+        models::{AccountTxoStatus, Txo, TXO_STATUS_SECRETED, TXO_TYPE_MINTED},
+        txo::TxoModel,
+        WalletDbError,
+    },
     WalletService,
 };
 use displaydoc::Display;
@@ -17,7 +21,9 @@ use mc_account_keys::PublicAddress;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
+use mc_mobilecoind::payments::TxProposal;
 use mc_transaction_core::tx::TxOutConfirmationNumber;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// Errors for the Address Service.
@@ -76,6 +82,28 @@ pub struct ReceiverTxReceipt {
     proof: TxOutConfirmationNumber,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ReceiptTransactionStatus {
+    /// All Txos are in the ledger at the same block index, and the expected
+    /// value matches the value of the Txos.
+    TransactionSuccess,
+
+    /// No Txos have landed in the wallet yet.
+    TransactionPending,
+
+    /// All Txos are in the ledger, at different block indices. This indicates
+    /// the Txos were spent in different transactions, and the receipt is
+    /// invalid.
+    TxosReceivedAtDifferentBlockIndices,
+
+    /// Some Txos received, some not. This indicates the Txos were spent in
+    /// different transactions, and the receipt is invalid.
+    SomeTxosMissing,
+
+    /// The expected value of the Txos did not match the actual value.
+    UnexpectedValue,
+}
+
 impl TryFrom<&mc_mobilecoind_api::ReceiverTxReceipt> for ReceiverTxReceipt {
     type Error = ReceiptServiceError;
 
@@ -112,7 +140,17 @@ pub trait ReceiptService {
     ) -> Result<Vec<Txo>, ReceiptServiceError>;
 
     /// Check status
-    fn check_receipts_status(&self, receiver_receipts: &[ReceiverTxReceipt]);
+    fn check_receiver_receipts_status(
+        &self,
+        receiver_receipts: &[ReceiverTxReceipt],
+        expected_value: u64,
+    ) -> Result<ReceiptTransactionStatus, ReceiptServiceError>;
+
+    /// Create a receipt from a given TxProposal
+    fn create_receiver_receipts(
+        &self,
+        tx_proposal: &TxProposal,
+    ) -> Result<Vec<ReceiverTxReceipt>, ReceiptServiceError>;
 }
 
 impl<T, FPR> ReceiptService for WalletService<T, FPR>
@@ -130,26 +168,122 @@ where
         Ok(vec![])
     }
 
-    fn check_receipts_status(&self, receiver_receipts: &[ReceiverTxReceipt]) {
-        let txos = Txo::select_by_public_key(
-            receiver_receipts
-                .iter()
-                .map(|r| &r.txo_public_key)
-                .collect(),
-        )?;
+    fn check_receiver_receipts_status(
+        &self,
+        receiver_receipts: &[ReceiverTxReceipt],
+        expected_value: u64,
+    ) -> Result<ReceiptTransactionStatus, ReceiptServiceError> {
+        let public_keys: Vec<&CompressedRistrettoPublic> = receiver_receipts
+            .iter()
+            .map(|r| &r.txo_public_key)
+            .collect();
+        let txos_and_statuses =
+            Txo::select_by_public_key(&public_keys, &self.wallet_db.get_conn()?)?;
+        // None of the Txos from the receipts are in this wallet.
+        if txos_and_statuses.len() == 0 {
+            return Ok(ReceiptTransactionStatus::TransactionPending);
+        }
+
+        // Figure out which Txos were minted by us and have not yet been received by us.
+        // (For to-self transactions).
+        let minted: Vec<&(Txo, AccountTxoStatus)> = txos_and_statuses
+            .iter()
+            .filter(|(txo, status)| {
+                status.txo_type == TXO_TYPE_MINTED && status.txo_status == TXO_STATUS_SECRETED
+            })
+            .collect();
+
+        // Need to verify if the Txos in the wallet were minted by us - in which
+        // case, this transaction could be pending.
+        if minted.len() == receiver_receipts.len() {
+            return Ok(ReceiptTransactionStatus::TransactionPending);
+        }
+
+        // Some of the Txos are in this wallet, but some are missing. The receipt is
+        // malformed.
+        if txos_and_statuses.len() != receiver_receipts.len() {
+            // FIXME also minted?
+            return Ok(ReceiptTransactionStatus::SomeTxosMissing);
+        }
+
+        // We have received all the Txos in this wallet. Check that they're in the same
+        // block index.
+        let received_block_indices: Vec<u64> = txos_and_statuses
+            .iter()
+            .map(|(txo, status)| txo.received_block_index)
+            .filter_map(|b| b.map(|i| i as u64))
+            .collect();
+        if received_block_indices.iter().min() != received_block_indices.iter().max() {
+            return Ok(ReceiptTransactionStatus::TxosReceivedAtDifferentBlockIndices);
+        }
+
+        // Check that the value of the received Txos matches the expected value
+        let received_total: u64 = txos_and_statuses
+            .iter()
+            .map(|(txo, status)| txo.value as u64)
+            .collect::<Vec<u64>>()
+            .iter()
+            .sum();
+        if received_total != expected_value {
+            return Ok(ReceiptTransactionStatus::UnexpectedValue);
+        }
+
+        Ok(ReceiptTransactionStatus::TransactionSuccess)
+    }
+
+    fn create_receiver_receipts(
+        &self,
+        tx_proposal: &TxProposal,
+    ) -> Result<Vec<ReceiverTxReceipt>, ReceiptServiceError> {
+        let receiver_tx_receipts: Vec<ReceiverTxReceipt> = tx_proposal
+            .outlays
+            .iter()
+            .enumerate()
+            .map(|(outlay_index, outlay)| {
+                let tx_out_index = tx_proposal.outlay_index_to_tx_out_index[&outlay_index];
+                let tx_out = tx_proposal.tx.prefix.outputs[tx_out_index].clone();
+                ReceiverTxReceipt {
+                    recipient: outlay.clone().receiver,
+                    txo_public_key: tx_out.public_key,
+                    txo_hash: tx_out.hash().to_vec(),
+                    tombstone: tx_proposal.tx.prefix.tombstone_block,
+                    proof: tx_proposal.outlay_confirmation_numbers[outlay_index].clone(),
+                }
+            })
+            .collect::<Vec<ReceiverTxReceipt>>();
+        Ok(receiver_tx_receipts)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        db::{
+            account::AccountID,
+            b58_decode,
+            models::{TransactionLog, TX_DIRECTION_SENT},
+            transaction_log::{AssociatedTxos, TransactionLogModel},
+        },
+        service::{
+            account::AccountService, address::AddressService, proof::ProofService,
+            transaction::TransactionService, transaction_log::TransactionLogService,
+            txo::TxoService,
+        },
+        test_utils::{
+            add_block_to_ledger_db, add_block_with_tx_proposal, get_test_ledger,
+            manually_sync_account, setup_wallet_service, MOB,
+        },
+    };
     use mc_account_keys::AccountKey;
+    use mc_common::logger::{test_with_logger, Logger};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_crypto_rand::RngCore;
-    use mc_transaction_core::tx::TxOut;
+    use mc_transaction_core::{ring_signature::KeyImage, tx::TxOut};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
+    // The receipt should convert between the rust and proto representations.
     #[test]
     fn test_receipt_round_trip() {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
@@ -182,5 +316,162 @@ mod tests {
         assert_eq!(txo.hash().to_vec(), tx_receipt.txo_hash);
         assert_eq!(tombstone, tx_receipt.tombstone);
         assert_eq!(confirmation_number, tx_receipt.proof);
+    }
+
+    #[test_with_logger]
+    fn test_create_receipt(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            13,
+            &logger,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+        let bob_addresses = service
+            .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
+            .expect("Could not get addresses for Bob");
+        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+
+        // Create a TxProposal to Bob
+        let tx_proposal = service
+            .build_transaction(
+                &alice.account_id_hex,
+                &bob_address,
+                (24 * MOB).to_string(),
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Could not build transaction");
+
+        let receipts = service
+            .create_receiver_receipts(&tx_proposal)
+            .expect("Could not create receiver receipts");
+
+        // Note: Since we manually added the block rather than using "Submit," we need
+        // to manually log submitted. This needs to happen before it hits the ledger, or
+        // else we will get a Unique constraint failed if we had already scanned
+        // before logging submitted.
+        TransactionLog::log_submitted(
+            tx_proposal.clone(),
+            14,
+            "".to_string(),
+            Some(&alice.account_id_hex),
+            &service.wallet_db.get_conn().unwrap(),
+        )
+        .expect("Could not log submitted");
+
+        // Add the txo to the ledger
+        add_block_with_tx_proposal(&mut ledger_db, tx_proposal);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(alice.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &AccountID(bob.account_id_hex.to_string()),
+            14,
+            &logger,
+        );
+
+        // Get corresponding Txo for Bob
+        let txos = service
+            .list_txos(&AccountID(bob.account_id_hex))
+            .expect("Could not get Bob Txos");
+        assert_eq!(txos.len(), 1);
+
+        // Get the corresponding TransactionLog for Alice's Account - only the sender
+        // has the proof.
+        let transaction_logs = service
+            .list_transaction_logs(&AccountID(alice.account_id_hex))
+            .expect("Could not get transaction logs");
+        // Alice should have two received (initial and change), and one sent
+        // TransactionLog.
+        assert_eq!(transaction_logs.len(), 3);
+        let sent_transaction_logs_and_associated_txos: Vec<&(TransactionLog, AssociatedTxos)> =
+            transaction_logs
+                .iter()
+                .filter(|t| t.0.direction == TX_DIRECTION_SENT)
+                .collect();
+        assert_eq!(sent_transaction_logs_and_associated_txos.len(), 1);
+        let sent_transaction_log: TransactionLog =
+            sent_transaction_logs_and_associated_txos[0].0.clone();
+        let proofs = service
+            .get_proofs(&sent_transaction_log.transaction_id_hex)
+            .expect("Could not get proofs");
+        assert_eq!(proofs.len(), 1);
+
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(
+            receipts[0].recipient,
+            b58_decode(&bob_address).expect("Could not decode public address")
+        );
+        let txo_pubkey =
+            mc_util_serial::decode(&txos[0].txo.public_key).expect("Could not decode pubkey");
+        assert_eq!(receipts[0].txo_public_key, txo_pubkey);
+        assert_eq!(receipts[0].tombstone, 63); // Ledger seeded with 12 blocks at tx construction, then one appended + 50
+        let txo: TxOut = mc_util_serial::decode(&txos[0].txo.txo).expect("Could not decode txo");
+        assert_eq!(receipts[0].txo_hash, txo.hash());
+        assert_eq!(receipts[0].proof, proofs[0].proof);
+    }
+
+    // All txos received should return TransactionSuccess
+    #[test_with_logger]
+    fn test_check_receiver_receipts_status_success(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger);
+        let alice = service
+            .create_account(Some("Alice's Main Account".to_string()), None)
+            .unwrap();
+
+        // Fund Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB as u64,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+
+        let bob = service
+            .create_account(Some("Bob's Main Account".to_string()), None)
+            .unwrap();
+
+        // Alice sends a transaction to Bob
     }
 }

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! Service for managing transaction receipts.
+//!
+//! A transaction receipt is constructed at the same time a transaction is
+//! constructed. It contains details about the outputs in the transaction, as
+//! well as a confirmation proof for each output, linking the sender to the
+//! output. The chooses whether to share this receipt with the recipient, for
+//! example, in the case of a dispute.
+
+use crate::{
+    db::{models::Txo, WalletDbError},
+    WalletService,
+};
+use displaydoc::Display;
+use mc_account_keys::PublicAddress;
+use mc_connection::{BlockchainConnection, UserTxConnection};
+use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_fog_report_validation::FogPubkeyResolver;
+use mc_transaction_core::tx::TxOutConfirmationNumber;
+use std::convert::TryFrom;
+
+/// Errors for the Address Service.
+#[derive(Display, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum ReceiptServiceError {
+    /// Error interacting with the database: {0}
+    Database(WalletDbError),
+
+    /// Diesel Error: {0}
+    Diesel(diesel::result::Error),
+
+    /// Error with LedgerDB: {0}
+    LedgerDB(mc_ledger_db::Error),
+
+    /// Error converting to/from API protos: {0}
+    ProtoConversion(mc_api::ConversionError),
+
+    /// Error Converting Proto but throws convert::Infallible.
+    ProtoConversionInfallible,
+}
+
+impl From<WalletDbError> for ReceiptServiceError {
+    fn from(src: WalletDbError) -> Self {
+        Self::Database(src)
+    }
+}
+
+impl From<diesel::result::Error> for ReceiptServiceError {
+    fn from(src: diesel::result::Error) -> Self {
+        Self::Diesel(src)
+    }
+}
+
+impl From<mc_api::ConversionError> for ReceiptServiceError {
+    fn from(src: mc_api::ConversionError) -> Self {
+        Self::ProtoConversion(src)
+    }
+}
+
+#[derive(Debug)]
+pub struct ReceiverTxReceipt {
+    /// The recipient of this Txo.
+    recipient: PublicAddress,
+
+    /// The public key of the Txo sent to the recipient.
+    tx_public_key: CompressedRistrettoPublic,
+
+    /// The hash of the Txo sent to the recipient.
+    tx_out_hash: Vec<u8>,
+
+    /// The tombstone block for the transaction.
+    tombstone: u64,
+
+    /// The proof for this Txo, which links the sender to this Txo.
+    proof: TxOutConfirmationNumber,
+}
+
+impl TryFrom<&mc_mobilecoind_api::ReceiverTxReceipt> for ReceiverTxReceipt {
+    type Error = ReceiptServiceError;
+
+    fn try_from(
+        src: &mc_mobilecoind_api::ReceiverTxReceipt,
+    ) -> Result<ReceiverTxReceipt, ReceiptServiceError> {
+        let recipient: PublicAddress = PublicAddress::try_from(src.get_recipient())?;
+        let tx_public_key: CompressedRistrettoPublic =
+            CompressedRistrettoPublic::try_from(src.get_tx_public_key())?;
+        let mut proof_bytes = [0u8; 32];
+        proof_bytes[0..32].copy_from_slice(src.get_confirmation_number());
+        let proof = TxOutConfirmationNumber::from(&proof_bytes);
+        Ok(ReceiverTxReceipt {
+            recipient,
+            tx_public_key,
+            tx_out_hash: src.get_tx_out_hash().to_vec(),
+            tombstone: src.get_tombstone(),
+            proof,
+        })
+    }
+}
+
+/// Trait defining the ways in which the wallet can interact with and manage
+/// receipts.
+pub trait ReceiptService {
+    /// Applies the transaction receipts from a sender to the wallet.
+    ///
+    /// Verifies the proof of each Txo, and updates the associated transaction
+    /// logs.
+    fn apply_receiver_receipts(
+        &self,
+        receiver_receipts: &[ReceiverTxReceipt],
+    ) -> Result<Vec<Txo>, ReceiptServiceError>;
+}
+
+impl<T, FPR> ReceiptService for WalletService<T, FPR>
+where
+    T: BlockchainConnection + UserTxConnection + 'static,
+    FPR: FogPubkeyResolver + Send + Sync + 'static,
+{
+    fn apply_receiver_receipts(
+        &self,
+        receiver_receipts: &[ReceiverTxReceipt],
+    ) -> Result<Vec<Txo>, ReceiptServiceError> {
+        println!("{:?}", receiver_receipts);
+        Ok(vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_account_keys::AccountKey;
+    use mc_crypto_keys::RistrettoPrivate;
+    use mc_crypto_rand::RngCore;
+    use mc_transaction_core::tx::TxOut;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_receipt_round_trip() {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let account_key = AccountKey::random(&mut rng);
+        let public_address = account_key.default_subaddress();
+        let txo = TxOut::new(
+            rng.next_u64(),
+            &public_address,
+            &RistrettoPrivate::from_random(&mut rng),
+            Default::default(),
+        )
+        .expect("Could not make TxOut");
+        let tombstone = rng.next_u64();
+        let mut proof_bytes = [0u8; 32];
+        rng.fill_bytes(&mut proof_bytes);
+        let confirmation_number = TxOutConfirmationNumber::from(proof_bytes);
+
+        let mut proto_tx_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+        proto_tx_receipt.set_recipient((&public_address).into());
+        proto_tx_receipt.set_tx_public_key((&txo.public_key).into());
+        proto_tx_receipt.set_tx_out_hash(txo.hash().to_vec());
+        proto_tx_receipt.set_tombstone(tombstone);
+        proto_tx_receipt.set_confirmation_number(confirmation_number.to_vec());
+
+        let tx_receipt =
+            ReceiverTxReceipt::try_from(&proto_tx_receipt).expect("Could not convert tx receipt");
+        assert_eq!(public_address, tx_receipt.recipient);
+        assert_eq!(txo.public_key, tx_receipt.tx_public_key);
+        assert_eq!(txo.hash().to_vec(), tx_receipt.tx_out_hash);
+        assert_eq!(tombstone, tx_receipt.tombstone);
+        assert_eq!(confirmation_number, tx_receipt.proof);
+    }
+}

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -108,7 +108,7 @@ pub trait TransactionService {
         &self,
         account_id_hex: &str,
         recipient_public_address: &str,
-        value: String,
+        value: String, // FIXME: Service should take u64
         input_txo_ids: Option<&Vec<String>>,
         fee: Option<String>,
         tombstone_block: Option<String>,
@@ -129,7 +129,7 @@ pub trait TransactionService {
         &self,
         account_id_hex: &str,
         recipient_public_address: &str,
-        value: String,
+        value: String, // FIXME: Service should take u64
         input_txo_ids: Option<&Vec<String>>,
         fee: Option<String>,
         tombstone_block: Option<String>,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -117,8 +117,7 @@ mod tests {
             .unwrap();
 
         // Add a block with a transaction for this recipient
-        // Add a block with a txo for this address (note that value is smaller than
-        // MINIMUM_FEE)
+        // Add a block with a txo for this address
         let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
         let alice_public_address = alice_account_key.subaddress(alice.main_subaddress_index as u64);
         add_block_to_ledger_db(


### PR DESCRIPTION
### Motivation

A primitive in the MobileCoin system is the "Receiver Receipt," where a recipient can be handed a "Receiver Receipt" from the sender, and they can use the data in this receipt to poll for the Txos in the transaction, and the verify the proof that the Txo was associated with the Receipt, implying that whoever is providing the receipt constructed the transaction.

### In this PR
* Adds a ReceiptService
* Implements `check_receiver_receipt_status` and `create_receiver_receipt`
* Implements `Txo::select_by_public_key` to select the Txos from the receipt
* Adds tests at each layer

[FS-95](https://mobilecoin.atlassian.net/browse/FS-95)

### Future Work
* Explore other convenience endpoints based on feedback from merchant services prototypes

