### PR TITLE
FS-174: Improve Receipt API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1769,7 +1769,11 @@ curl -s localhost:9090/wallet \
             "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
             "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
             "tombstone_block": "154512",
-            "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
+            "amount": {
+              "object": "amount",
+              "commitment": "782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d",
+              "masked_value": "12052895925511073331"
+            }
           }
         },
         "jsonrpc": "2.0",
@@ -1841,7 +1845,11 @@ curl -s localhost:9090/wallet \
         "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
         "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
         "tombstone_block": "154512",
-        "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
+        "amount": {
+          "object": "amount",
+          "commitment": "782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d",
+          "masked_value": "12052895925511073331"
+        }
       }
     ]
   },
@@ -2658,7 +2666,11 @@ Txo Spent from One Account to Another in the Same Wallet
   "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
   "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
   "tombstone_block": "154512",
-  "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
+  "amount": {
+    "object": "amount",
+    "commitment": "782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d",
+    "masked_value": "12052895925511073331"
+  }
 }
 ```
 

--- a/API.md
+++ b/API.md
@@ -1754,7 +1754,7 @@ curl -s localhost:9090/wallet \
 
 ### Transaction Receipts
 
-Senders can optionally provide `receiver_receipts` to the recipient of a transaction. This has more information than the proof (it contains the proof), and can be used by the receiver to poll for the status of the transaction.
+Senders can optionally provide `receiver_receipts` to the recipient of a transaction. This has more information than the confirmation proof (it contains the confirmation proof), and can be used by the receiver to poll for the status of the transaction.
 
 #### Check Receiver Receipt Status
 
@@ -1763,16 +1763,14 @@ curl -s localhost:9090/wallet \
   -d '{
         "method": "check_receiver_receipt_status",
         "params": {
-          "account_id": "4b4fd11738c03bf5179781aeb27d725002fb67d8a99992920d3654ac00ee1a2c",
+          "address": "3Dg4iFavKJScgCUeqb1VnET5ADmKjZgWz15fN7jfeCCWb72serxKE7fqz7htQvRirN4yeU2xxtcHRAN2zbF6V9n7FomDm69VX3FghvkDfpq",
           "receiver_receipt": {
             "object": "receiver_receipt",
-            "recipient": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
-            "txo_public_key": "0a206ad9d7600a1a5570050a05bbd64c83f56ad8239e12452253bfadd1f67676df0d",
-            "txo_hash": "9db71b4d7718b797154c42a22a3aac6c012a8e3706c35ad7e4a929a1392e7afa",
-            "tombstone": "153017",
-            "proof": "0a20c77fd2d8e5434557ddbe4a4565e701a815b8581a529112a4eb3b814d69878b34"
+            "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
+            "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
+            "tombstone_block": "154512",
+            "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
           }
-          "expected_value": "10000000",
         },
         "jsonrpc": "2.0",
         "id": 1
@@ -1784,7 +1782,31 @@ curl -s localhost:9090/wallet \
 {
   "method": "check_receiver_receipt_status",
   "result": {
-    "receipts_transaction_status": "TransactionSuccess"
+    "receipts_transaction_status": "TransactionSuccess",
+    "txo": {
+      "object": "txo",
+      "txo_id": "fff4cae55a74e5ce852b79c31576f4041d510c26e59fec178b3e45705c5b35a7",
+      "value_pmob": "2960000000000",
+      "received_block_index": "8094",
+      "spent_block_index": "8180",
+      "is_spent_recovered": false,
+      "received_account_id": "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10",
+      "minted_account_id": null,
+      "account_status_map": {
+        "a4db032dcedc14e39608fe6f26deadf57e306e8c03823b52065724fb4d274c10": {
+          "txo_status": "spent",
+          "txo_type": "received"
+        }
+      },
+      "target_key": "0a209eefc082a656a34fae5cec81044d1b13bd8963c411afa28aecfce4839fc9f74e",
+      "public_key": "0a20f03f9684e5420d5410fe732f121626352d45e4e799d725432a0c61fa1343ac51",
+      "e_fog_hint": "0a544944e7527b7f09322651b7242663edf17478fd1804aeea24838a35ad3c66d5194763642ae1c1e0cd2bbe2571a97a8c0fb49e346d2fd5262113e7333c7f012e61114bd32d335b1a8183be8e1865b0a10199b60100",
+      "subaddress_index": "0",
+      "assigned_subaddress": "3Dg4iFavKJScgCUeqb1VnET5ADmKjZgWz15fN7jfeCCWb72serxKE7fqz7htQvRirN4yeU2xxtcHRAN2zbF6V9n7FomDm69VX3FghvkDfpq",
+      "key_image": "0a205445b406012d26baebb51cbcaaaceb0d56387a67353637d07265f4e886f33419",
+      "proof": null,
+      "offset_count": 25
+    }
   },
   "error": null,
   "jsonrpc": "2.0",
@@ -1816,11 +1838,10 @@ curl -s localhost:9090/wallet \
     "receiver_receipts": [
       {
         "object": "receiver_receipt",
-        "recipient": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
-        "txo_public_key": "0a206ad9d7600a1a5570050a05bbd64c83f56ad8239e12452253bfadd1f67676df0d",
-        "txo_hash": "9db71b4d7718b797154c42a22a3aac6c012a8e3706c35ad7e4a929a1392e7afa",
-        "tombstone": "153017",
-        "proof": "0a20c77fd2d8e5434557ddbe4a4565e701a815b8581a529112a4eb3b814d69878b34"
+        "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
+        "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
+        "tombstone_block": "154512",
+        "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
       }
     ]
   },
@@ -2616,6 +2637,34 @@ Txo Spent from One Account to Another in the Same Wallet
 
 * [get_proofs](#get-proofs)
 * [verify_proof](#verify-proof)
+
+### The Receiver Receipt Object
+
+#### Attributes
+
+| *Name* | *Type* | *Description*
+| :--- | :--- | :---
+| object | string, value is "proof" | String representing the object's type. Objects of the same type share the same value.
+| public_key | string | Hex-encoded public key for the Txo.
+| tombstone_block | string | The block index after which this Txo would be rejected by consensus.
+| confirmation | string | Hex-encoded proof that can be verified to confirm that another party constructed or had knowledge of the construction of the associated Txo.
+| amount | string | The encrypted amount in the Txo referenced by this receipt.
+
+#### Example Object
+
+```json
+{
+  "object": "receiver_receipt",
+  "public_key": "0a20d2118a065192f11e228e0fce39e90a878b5aa628b7613a4556c193461ebd4f67",
+  "confirmation": "0a205e5ca2fa40f837d7aff6d37e9314329d21bad03d5fac2ec1fc844a09368c33e5",
+  "tombstone_block": "154512",
+  "amount": "0a220a20782c575ed7d893245d10d7dd49dcffc3515a7ed252bcade74e719a17d639092d11332ed73afc7c44a7"
+}
+```
+
+#### API Methods Returning Receipt Objects
+
+* [create_receiver_receipts](#create-receiver-receipts)
 
 ### The Gift Code Object
 

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -21,7 +21,7 @@ use diesel::{
 pub trait AssignedSubaddressModel {
     /// Assign a subaddress to a contact.
     ///
-    /// Inserts (upserts?) an AssignedSubaddress to the DB.
+    /// Inserts an AssignedSubaddress to the DB.
     ///
     /// # Arguments
     /// * `account_key` - An account's private keys.

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -597,7 +597,6 @@ impl TxoModel for Txo {
             results.iter().map(|t| Txo::get(t, &conn)).collect();
         details
     }
-
     fn list_for_address(
         assigned_subaddress_b58: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,

--- a/full-service/src/json_rpc/amount.rs
+++ b/full-service/src/json_rpc/amount.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for the Account object.
+
+use mc_crypto_keys::ReprBytes;
+use mc_transaction_core::CompressedCommitment;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// The encrypted amount of pMOB in a Txo.
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct Amount {
+    /// String representing the object's type. Objects of the same type share
+    /// the same value.
+    pub object: String,
+
+    /// A Pedersen commitment `v*G + s*H`
+    pub commitment: String,
+
+    /// The masked value of pMOB in a Txo.
+    ///
+    /// The private view key is required to decrypt the amount, via:
+    /// `masked_value = value XOR_8 Blake2B("value_mask" || shared_secret)`
+    pub masked_value: String,
+}
+
+impl From<&mc_api::external::Amount> for Amount {
+    fn from(src: &mc_api::external::Amount) -> Self {
+        Self {
+            object: "amount".to_string(),
+            commitment: hex::encode(src.get_commitment().get_data()),
+            masked_value: src.get_masked_value().to_string(),
+        }
+    }
+}
+
+impl From<&mc_transaction_core::Amount> for Amount {
+    fn from(src: &mc_transaction_core::Amount) -> Self {
+        Self {
+            object: "amount".to_string(),
+            commitment: hex::encode(src.commitment.to_bytes()),
+            masked_value: src.masked_value.to_string(),
+        }
+    }
+}
+
+impl TryFrom<&Amount> for mc_transaction_core::Amount {
+    type Error = String;
+
+    fn try_from(src: &Amount) -> Result<Self, String> {
+        let mut commitment_bytes = [0u8; 32];
+        commitment_bytes[0..32].copy_from_slice(
+            &hex::decode(&src.commitment)
+                .map_err(|err| format!("Could not decode hex for amount commitment: {:?}", err))?,
+        );
+        Ok(Self {
+            commitment: CompressedCommitment::from(&commitment_bytes),
+            masked_value: src
+                .masked_value
+                .parse::<u64>()
+                .map_err(|err| format!("Could not parse masked value u64: {:?}", err))?,
+        })
+    }
+}

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -1430,7 +1430,6 @@ mod e2e {
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
         let bob_account_obj = result.get("account").unwrap();
-        let bob_account_id = bob_account_obj.get("account_id").unwrap().as_str().unwrap();
         let bob_b58_public_address = bob_account_obj
             .get("main_address")
             .unwrap()
@@ -1473,9 +1472,8 @@ mod e2e {
             "id": 1,
             "method": "check_receiver_receipt_status",
             "params": {
-                "account_id": bob_account_id,
+                "address": bob_b58_public_address,
                 "receiver_receipt": receipt,
-                "expected_value": "42000000000000",
             }
         });
         let res = dispatch(&client, body, &logger);
@@ -1499,9 +1497,8 @@ mod e2e {
             "id": 1,
             "method": "check_receiver_receipt_status",
             "params": {
-                "account_id": bob_account_id,
+                "address": bob_b58_public_address,
                 "receiver_receipt": receipt,
-                "expected_value": "42000000000000",
             }
         });
         let res = dispatch(&client, body, &logger);

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -162,9 +162,8 @@ pub enum JsonCommandRequest {
         block_index: String,
     },
     check_receiver_receipt_status {
-        account_id: String,
+        address: String,
         receiver_receipt: ReceiverReceipt,
-        expected_value: String,
     },
     create_receiver_receipts {
         tx_proposal: TxProposal,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -227,6 +227,7 @@ pub enum JsonCommandResponse {
     },
     check_receiver_receipt_status {
         receipt_transaction_status: ReceiptTransactionStatus,
+        txo: Option<Txo>,
     },
     create_receiver_receipts {
         receiver_receipts: Vec<ReceiverReceipt>,

--- a/full-service/src/json_rpc/mod.rs
+++ b/full-service/src/json_rpc/mod.rs
@@ -6,6 +6,7 @@ mod account;
 mod account_key;
 pub mod account_secrets;
 mod address;
+mod amount;
 mod balance;
 mod block;
 mod gift_code;

--- a/full-service/src/json_rpc/receiver_receipt.rs
+++ b/full-service/src/json_rpc/receiver_receipt.rs
@@ -2,37 +2,35 @@
 
 //! API definition for the ReceiverReceipt object.
 
-use crate::{
-    db::{b58_decode, b58_encode},
-    service,
-};
+use crate::service;
 use mc_crypto_keys::CompressedRistrettoPublic;
-use mc_transaction_core::tx::TxOutConfirmationNumber;
+use mc_transaction_core::{tx::TxOutConfirmationNumber, Amount};
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// An receipt provided from the sender of a transaction for the receiver to use
 /// in order to check the status of a transaction.
+///
+/// Note: This should stay in line wth the Receipt defined in external.proto
+/// https://github.com/mobilecoinfoundation/mobilecoin/blob/master/api/proto/external.proto#L255
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct ReceiverReceipt {
     /// String representing the object's type. Objects of the same type share
     /// the same value.
     pub object: String,
 
-    /// The recipient of this Txo.
-    pub recipient: String,
-
     /// The public key of the Txo sent to the recipient.
-    pub txo_public_key: String,
+    pub public_key: String,
 
-    /// The hash of the Txo sent to the recipient.
-    pub txo_hash: String,
+    /// The confirmation proof for this Txo, which links the sender to this Txo.
+    pub confirmation: String,
 
     /// The tombstone block for the transaction.
-    pub tombstone: String,
+    pub tombstone_block: String,
 
-    /// The proof for this Txo, which links the sender to this Txo.
-    pub proof: String,
+    /// The amount of the Txo.
+    /// Note: This value is self-reported by the sender and is unverifiable.
+    pub amount: String,
 }
 
 impl TryFrom<&service::receipt::ReceiverReceipt> for ReceiverReceipt {
@@ -41,12 +39,10 @@ impl TryFrom<&service::receipt::ReceiverReceipt> for ReceiverReceipt {
     fn try_from(src: &service::receipt::ReceiverReceipt) -> Result<ReceiverReceipt, String> {
         Ok(ReceiverReceipt {
             object: "receiver_receipt".to_string(),
-            recipient: b58_encode(&src.recipient)
-                .map_err(|err| format!("Could not encode public address: {:?}", err))?,
-            txo_public_key: hex::encode(&mc_util_serial::encode(&src.txo_public_key)),
-            txo_hash: hex::encode(&src.txo_hash),
-            tombstone: src.tombstone.to_string(),
-            proof: hex::encode(&mc_util_serial::encode(&src.proof)),
+            public_key: hex::encode(&mc_util_serial::encode(&src.public_key)),
+            tombstone_block: src.tombstone_block.to_string(),
+            confirmation: hex::encode(&mc_util_serial::encode(&src.confirmation)),
+            amount: hex::encode(&mc_util_serial::encode(&src.amount)),
         })
     }
 }
@@ -56,26 +52,28 @@ impl TryFrom<&ReceiverReceipt> for service::receipt::ReceiverReceipt {
 
     fn try_from(src: &ReceiverReceipt) -> Result<service::receipt::ReceiverReceipt, String> {
         let txo_public_key: CompressedRistrettoPublic = mc_util_serial::decode(
-            &hex::decode(&src.txo_public_key)
+            &hex::decode(&src.public_key)
                 .map_err(|err| format!("Could not decode hex for txo_public_key: {:?}", err))?,
         )
         .map_err(|err| format!("Could not decode txo public key: {:?}", err))?;
         let proof: TxOutConfirmationNumber = mc_util_serial::decode(
-            &hex::decode(&src.proof)
+            &hex::decode(&src.confirmation)
                 .map_err(|err| format!("Could not decode hex for proof: {:?}", err))?,
         )
         .map_err(|err| format!("Could not decode proof: {:?}", err))?;
+        let amount: Amount = mc_util_serial::decode(
+            &hex::decode(&src.amount)
+                .map_err(|err| format!("Could not decode hex for amount: {:?}", err))?,
+        )
+        .map_err(|err| format!("Could not decode amount: {:?}", err))?;
         Ok(service::receipt::ReceiverReceipt {
-            recipient: b58_decode(&src.recipient)
-                .map_err(|err| format!("Could not decode public address: {:?}", err))?,
-            txo_public_key,
-            txo_hash: hex::decode(&src.txo_hash)
-                .map_err(|err| format!("Could not decode hex for txo_hash: {:?}", err))?,
-            tombstone: src
-                .tombstone
+            public_key: txo_public_key,
+            tombstone_block: src
+                .tombstone_block
                 .parse::<u64>()
                 .map_err(|err| format!("Could not parse u64: {:?}", err))?,
-            proof,
+            confirmation: proof,
+            amount,
         })
     }
 }
@@ -84,7 +82,7 @@ impl TryFrom<&ReceiverReceipt> for service::receipt::ReceiverReceipt {
 mod tests {
     use super::*;
     use mc_account_keys::AccountKey;
-    use mc_crypto_keys::RistrettoPrivate;
+    use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
     use mc_crypto_rand::RngCore;
     use mc_transaction_core::tx::TxOut;
     use mc_util_from_random::FromRandom;
@@ -107,13 +105,14 @@ mod tests {
         let mut proof_bytes = [0u8; 32];
         rng.fill_bytes(&mut proof_bytes);
         let confirmation_number = TxOutConfirmationNumber::from(proof_bytes);
+        let amount = Amount::new(rng.next_u64(), &RistrettoPublic::from_random(&mut rng))
+            .expect("Could not create amount");
 
         let service_receipt = service::receipt::ReceiverReceipt {
-            recipient: public_address,
-            txo_public_key: txo.public_key,
-            txo_hash: txo.hash().to_vec(),
-            tombstone,
-            proof: confirmation_number,
+            public_key: txo.public_key,
+            tombstone_block: tombstone,
+            confirmation: confirmation_number,
+            amount,
         };
 
         let json_rpc_receipt = ReceiverReceipt::try_from(&service_receipt)

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -512,21 +512,17 @@ where
             }
         }
         JsonCommandRequest::check_receiver_receipt_status {
-            account_id,
+            address,
             receiver_receipt,
-            expected_value,
         } => {
             let receipt = service::receipt::ReceiverReceipt::try_from(&receiver_receipt)
                 .map_err(format_error)?;
-            let status = service
-                .check_receiver_receipt_status(
-                    &AccountID(account_id),
-                    &receipt,
-                    expected_value.parse::<u64>().map_err(format_error)?,
-                )
+            let (status, txo) = service
+                .check_receipt_status(&address, &receipt)
                 .map_err(format_error)?;
             JsonCommandResponse::check_receiver_receipt_status {
                 receipt_transaction_status: status,
+                txo: txo.as_ref().map(Txo::from),
             }
         }
         JsonCommandRequest::create_receiver_receipts { tx_proposal } => {

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -10,21 +10,24 @@
 
 use crate::{
     db::{
-        account::AccountID,
-        models::{Txo, TXO_STATUS_SECRETED, TXO_TYPE_MINTED},
-        txo::{TxoID, TxoModel},
+        account::{AccountID, AccountModel},
+        assigned_subaddress::AssignedSubaddressModel,
+        models::{Account, AssignedSubaddress, Txo, TXO_STATUS_SECRETED, TXO_TYPE_MINTED},
+        txo::{TxoDetails, TxoModel},
         WalletDbError,
     },
-    service::proof::{ProofService, ProofServiceError},
     WalletService,
 };
+use diesel::Connection;
 use displaydoc::Display;
-use mc_account_keys::PublicAddress;
+use mc_account_keys::AccountKey;
 use mc_connection::{BlockchainConnection, UserTxConnection};
-use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_mobilecoind::payments::TxProposal;
-use mc_transaction_core::tx::TxOutConfirmationNumber;
+use mc_transaction_core::{
+    get_tx_out_shared_secret, tx::TxOutConfirmationNumber, Amount, AmountError,
+};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -47,8 +50,14 @@ pub enum ReceiptServiceError {
     /// Error Converting Proto but throws convert::Infallible.
     ProtoConversionInfallible,
 
-    /// Error with the Proof Service
-    ProofService(ProofServiceError),
+    /// Error decoding prost: {0}
+    ProstDecode(prost::DecodeError),
+
+    /// Error with crypto keys: {0}
+    CryptoKey(mc_crypto_keys::KeyError),
+
+    /// Error decoding from hex: {0}
+    HexDecode(hex::FromHexError),
 }
 
 impl From<WalletDbError> for ReceiptServiceError {
@@ -69,28 +78,39 @@ impl From<mc_api::ConversionError> for ReceiptServiceError {
     }
 }
 
-impl From<ProofServiceError> for ReceiptServiceError {
-    fn from(src: ProofServiceError) -> Self {
-        Self::ProofService(src)
+impl From<prost::DecodeError> for ReceiptServiceError {
+    fn from(src: prost::DecodeError) -> Self {
+        Self::ProstDecode(src)
+    }
+}
+
+impl From<mc_crypto_keys::KeyError> for ReceiptServiceError {
+    fn from(src: mc_crypto_keys::KeyError) -> Self {
+        Self::CryptoKey(src)
+    }
+}
+
+impl From<hex::FromHexError> for ReceiptServiceError {
+    fn from(src: hex::FromHexError) -> Self {
+        Self::HexDecode(src)
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ReceiverReceipt {
-    /// The recipient of this Txo.
-    pub recipient: PublicAddress,
-
     /// The public key of the Txo sent to the recipient.
-    pub txo_public_key: CompressedRistrettoPublic,
+    pub public_key: CompressedRistrettoPublic,
 
-    /// The hash of the Txo sent to the recipient.
-    pub txo_hash: Vec<u8>,
+    /// The confirmation number for this Txo, which links the sender to this
+    /// Txo.
+    pub confirmation: TxOutConfirmationNumber,
 
     /// The tombstone block for the transaction.
-    pub tombstone: u64,
+    pub tombstone_block: u64,
 
-    /// The proof for this Txo, which links the sender to this Txo.
-    pub proof: TxOutConfirmationNumber,
+    /// The encrypted amount of this transaction.
+    /// Note: This value is self-reported by the sender and is unverifiable.
+    pub amount: Amount,
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
@@ -107,34 +127,32 @@ pub enum ReceiptTransactionStatus {
     /// invalid.
     TxosReceivedAtDifferentBlockIndices,
 
-    /// The expected value of the Txos did not match the actual value.
-    UnexpectedValue,
-
     /// Invalid proof
     InvalidProof,
 
     /// Receipt contains duplicate Txos
     DuplicateTxos,
+
+    /// Receipt Amount does not match the Amount in the Txo: {0}
+    AmountMismatch(String),
+
+    /// Failed to decrypt the amount for the given Txo
+    FailedAmountDecryption,
 }
 
-impl TryFrom<&mc_mobilecoind_api::ReceiverTxReceipt> for ReceiverReceipt {
+impl TryFrom<&mc_api::external::Receipt> for ReceiverReceipt {
     type Error = ReceiptServiceError;
 
-    fn try_from(
-        src: &mc_mobilecoind_api::ReceiverTxReceipt,
-    ) -> Result<ReceiverReceipt, ReceiptServiceError> {
-        let recipient: PublicAddress = PublicAddress::try_from(src.get_recipient())?;
-        let tx_public_key: CompressedRistrettoPublic =
-            CompressedRistrettoPublic::try_from(src.get_tx_public_key())?;
-        let mut proof_bytes = [0u8; 32];
-        proof_bytes[0..32].copy_from_slice(src.get_confirmation_number());
-        let proof = TxOutConfirmationNumber::from(&proof_bytes);
+    fn try_from(src: &mc_api::external::Receipt) -> Result<ReceiverReceipt, ReceiptServiceError> {
+        let public_key: CompressedRistrettoPublic =
+            CompressedRistrettoPublic::try_from(src.get_public_key())?;
+        let confirmation = TxOutConfirmationNumber::try_from(src.get_confirmation())?;
+        let amount = Amount::try_from(src.get_amount())?;
         Ok(ReceiverReceipt {
-            recipient,
-            txo_public_key: tx_public_key,
-            txo_hash: src.get_tx_out_hash().to_vec(),
-            tombstone: src.get_tombstone(),
-            proof,
+            public_key,
+            confirmation,
+            tombstone_block: src.get_tombstone_block(),
+            amount,
         })
     }
 }
@@ -145,12 +163,11 @@ pub trait ReceiptService {
     /// Check the status of the Txos in the receipts.
     ///
     /// Applies the proofs by verifying the proofs once the Txos have landed.
-    fn check_receiver_receipt_status(
+    fn check_receipt_status(
         &self,
-        account_id: &AccountID,
+        address: &String,
         receiver_receipt: &ReceiverReceipt,
-        expected_value: u64,
-    ) -> Result<ReceiptTransactionStatus, ReceiptServiceError>;
+    ) -> Result<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError>;
 
     /// Create a receipt from a given TxProposal
     fn create_receiver_receipts(
@@ -164,44 +181,80 @@ where
     T: BlockchainConnection + UserTxConnection + 'static,
     FPR: FogPubkeyResolver + Send + Sync + 'static,
 {
-    fn check_receiver_receipt_status(
+    fn check_receipt_status(
         &self,
-        account_id: &AccountID,
+        address: &String,
         receiver_receipt: &ReceiverReceipt,
-        expected_value: u64,
-    ) -> Result<ReceiptTransactionStatus, ReceiptServiceError> {
-        // Get the transaction from the database, with status.
-        let txos_and_statuses = Txo::select_by_public_key(
-            account_id,
-            &[&receiver_receipt.txo_public_key],
-            &self.wallet_db.get_conn()?,
-        )?;
+    ) -> Result<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError> {
+        let conn = &self.wallet_db.get_conn()?;
 
-        // Return if the Txo from the receipt is not in this wallet yet.
-        if txos_and_statuses.is_empty() {
-            return Ok(ReceiptTransactionStatus::TransactionPending);
-        }
-        let (txo, status) = &txos_and_statuses[0];
+        Ok(conn
+            .transaction::<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError, _>(
+                || {
+                    let assigned_address = AssignedSubaddress::get(address, &conn)?;
+                    let account_id = AccountID(assigned_address.account_id_hex.clone());
+                    let account = Account::get(&account_id, &conn)?;
+                    // Get the transaction from the database, with status.
+                    let txos_and_statuses = Txo::select_by_public_key(
+                        &account_id,
+                        &[&receiver_receipt.public_key],
+                        &conn,
+                    )?;
 
-        // Figure out whether the Txo was minted by us, and has not yet been received by
-        // us. (For to-self transactions). If the Txo was minted by us, this
-        // transaction is pending.
-        if status.txo_type == TXO_TYPE_MINTED && status.txo_status == TXO_STATUS_SECRETED {
-            return Ok(ReceiptTransactionStatus::TransactionPending);
-        }
+                    // Return if the Txo from the receipt is not in this wallet yet.
+                    if txos_and_statuses.is_empty() {
+                        return Ok((ReceiptTransactionStatus::TransactionPending, None));
+                    }
+                    let (txo, status) = &txos_and_statuses[0];
 
-        // Check that the value of the received Txo matches the expected value.
-        if (txo.value as u64) != expected_value {
-            return Ok(ReceiptTransactionStatus::UnexpectedValue);
-        }
+                    // Figure out whether the Txo was minted by us, and has not yet been received by
+                    // us. (For to-self transactions). If the Txo was minted by us, this
+                    // transaction is pending.
+                    if status.txo_type == TXO_TYPE_MINTED
+                        && status.txo_status == TXO_STATUS_SECRETED
+                    {
+                        return Ok((ReceiptTransactionStatus::TransactionPending, None));
+                    }
+                    let details = Txo::get(&txo.txo_id_hex, &conn)?;
 
-        // Verify the proof.
-        let proof_hex = hex::encode(mc_util_serial::encode(&receiver_receipt.proof));
-        if !self.verify_proof(account_id, &TxoID(txo.txo_id_hex.clone()), &proof_hex)? {
-            return Ok(ReceiptTransactionStatus::InvalidProof);
-        }
+                    // Decrypt the amount to get the expected value
+                    let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+                    let public_key: RistrettoPublic =
+                        RistrettoPublic::try_from(&receiver_receipt.public_key)?;
+                    let shared_secret =
+                        get_tx_out_shared_secret(account_key.view_private_key(), &public_key);
+                    let expected_value = match receiver_receipt.amount.get_value(&shared_secret) {
+                        Ok((v, _blinding)) => v,
+                        Err(AmountError::InconsistentCommitment) => {
+                            return Ok((
+                                ReceiptTransactionStatus::FailedAmountDecryption,
+                                Some(details),
+                            ))
+                        }
+                    };
+                    // Check that the value of the received Txo matches the expected value.
+                    if (txo.value as u64) != expected_value {
+                        return Ok((
+                            ReceiptTransactionStatus::AmountMismatch(format!(
+                                "Expected: {}, Got: {}",
+                                expected_value, txo.value
+                            )),
+                            Some(details),
+                        ));
+                    }
 
-        Ok(ReceiptTransactionStatus::TransactionSuccess)
+                    // Verify the proof.
+                    let proof_hex =
+                        hex::encode(mc_util_serial::encode(&receiver_receipt.confirmation));
+                    let proof: TxOutConfirmationNumber =
+                        mc_util_serial::decode(&hex::decode(proof_hex)?)?;
+                    if !Txo::verify_proof(&account_id, &txo.txo_id_hex.clone(), &proof, &conn)? {
+                        return Ok((ReceiptTransactionStatus::InvalidProof, Some(details)));
+                    }
+
+                    Ok((ReceiptTransactionStatus::TransactionSuccess, Some(details)))
+                },
+            )?)
     }
 
     fn create_receiver_receipts(
@@ -212,15 +265,14 @@ where
             .outlays
             .iter()
             .enumerate()
-            .map(|(outlay_index, outlay)| {
+            .map(|(outlay_index, _outlay)| {
                 let tx_out_index = tx_proposal.outlay_index_to_tx_out_index[&outlay_index];
                 let tx_out = tx_proposal.tx.prefix.outputs[tx_out_index].clone();
                 ReceiverReceipt {
-                    recipient: outlay.clone().receiver,
-                    txo_public_key: tx_out.public_key,
-                    txo_hash: tx_out.hash().to_vec(),
-                    tombstone: tx_proposal.tx.prefix.tombstone_block,
-                    proof: tx_proposal.outlay_confirmation_numbers[outlay_index].clone(),
+                    public_key: tx_out.public_key,
+                    tombstone_block: tx_proposal.tx.prefix.tombstone_block,
+                    confirmation: tx_proposal.outlay_confirmation_numbers[outlay_index].clone(),
+                    amount: tx_out.amount,
                 }
             })
             .collect::<Vec<ReceiverReceipt>>();
@@ -234,22 +286,23 @@ mod tests {
     use crate::{
         db::{
             account::AccountID,
-            b58_decode,
+            b58_encode,
             models::{TransactionLog, TX_DIRECTION_SENT},
             transaction_log::{AssociatedTxos, TransactionLogModel},
         },
         service::{
-            account::AccountService, address::AddressService, transaction::TransactionService,
-            transaction_log::TransactionLogService, txo::TxoService,
+            account::AccountService, address::AddressService, proof::ProofService,
+            transaction::TransactionService, transaction_log::TransactionLogService,
+            txo::TxoService,
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, get_test_ledger,
             manually_sync_account, setup_wallet_service, MOB,
         },
     };
-    use mc_account_keys::AccountKey;
+    use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{test_with_logger, Logger};
-    use mc_crypto_keys::RistrettoPrivate;
+    use mc_crypto_keys::{ReprBytes, RistrettoPrivate, RistrettoPublic};
     use mc_crypto_rand::RngCore;
     use mc_transaction_core::{ring_signature::KeyImage, tx::TxOut};
     use mc_util_from_random::FromRandom;
@@ -274,20 +327,25 @@ mod tests {
         rng.fill_bytes(&mut proof_bytes);
         let confirmation_number = TxOutConfirmationNumber::from(proof_bytes);
 
-        let mut proto_tx_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
-        proto_tx_receipt.set_recipient((&public_address).into());
-        proto_tx_receipt.set_tx_public_key((&txo.public_key).into());
-        proto_tx_receipt.set_tx_out_hash(txo.hash().to_vec());
-        proto_tx_receipt.set_tombstone(tombstone);
-        proto_tx_receipt.set_confirmation_number(confirmation_number.to_vec());
+        let mut proto_tx_receipt = mc_api::external::Receipt::new();
+        proto_tx_receipt.set_public_key((&txo.public_key).into());
+        proto_tx_receipt.set_tombstone_block(tombstone);
+        let mut proto_confirmation = mc_api::external::TxOutConfirmationNumber::new();
+        proto_confirmation.set_hash(confirmation_number.to_vec());
+        proto_tx_receipt.set_confirmation(proto_confirmation);
+        let mut proto_commitment = mc_api::external::CompressedRistretto::new();
+        proto_commitment.set_data(txo.amount.commitment.to_bytes().to_vec());
+        let mut proto_amount = mc_api::external::Amount::new();
+        proto_amount.set_commitment(proto_commitment);
+        proto_amount.set_masked_value(txo.amount.masked_value);
+        proto_tx_receipt.set_amount(proto_amount);
 
         let tx_receipt =
             ReceiverReceipt::try_from(&proto_tx_receipt).expect("Could not convert tx receipt");
-        assert_eq!(public_address, tx_receipt.recipient);
-        assert_eq!(txo.public_key, tx_receipt.txo_public_key);
-        assert_eq!(txo.hash().to_vec(), tx_receipt.txo_hash);
-        assert_eq!(tombstone, tx_receipt.tombstone);
-        assert_eq!(confirmation_number, tx_receipt.proof);
+        assert_eq!(txo.public_key, tx_receipt.public_key);
+        assert_eq!(tombstone, tx_receipt.tombstone_block);
+        assert_eq!(confirmation_number, tx_receipt.confirmation);
+        assert_eq!(txo.amount, tx_receipt.amount);
     }
 
     #[test_with_logger]
@@ -404,17 +462,13 @@ mod tests {
             .expect("Could not get proofs");
         assert_eq!(proofs.len(), 1);
 
-        assert_eq!(
-            receipt.recipient,
-            b58_decode(&bob_address).expect("Could not decode public address")
-        );
         let txo_pubkey =
             mc_util_serial::decode(&txos[0].txo.public_key).expect("Could not decode pubkey");
-        assert_eq!(receipt.txo_public_key, txo_pubkey);
-        assert_eq!(receipt.tombstone, 63); // Ledger seeded with 12 blocks at tx construction, then one appended + 50
+        assert_eq!(receipt.public_key, txo_pubkey);
+        assert_eq!(receipt.tombstone_block, 63); // Ledger seeded with 12 blocks at tx construction, then one appended + 50
         let txo: TxOut = mc_util_serial::decode(&txos[0].txo.txo).expect("Could not decode txo");
-        assert_eq!(receipt.txo_hash, txo.hash());
-        assert_eq!(receipt.proof, proofs[0].proof);
+        assert_eq!(receipt.amount, txo.amount);
+        assert_eq!(receipt.confirmation, proofs[0].proof);
     }
 
     // All txos received should return TransactionSuccess, and TransactionPending
@@ -455,8 +509,7 @@ mod tests {
         let bob_addresses = service
             .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
             .expect("Could not get addresses for Bob");
-        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
-        let bob_account_id = AccountID(bob.account_id_hex.to_string());
+        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
 
         // Create a TxProposal to Bob
         let tx_proposal = service
@@ -477,8 +530,8 @@ mod tests {
         let receipt = &receipts[0];
 
         // Bob checks the status of the receipts.
-        let status = service
-            .check_receiver_receipt_status(&bob_account_id, &receipt, 24 * MOB as u64)
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt)
             .expect("Could not check status of receipt");
 
         // Status should be pending until block lands and is scanned
@@ -496,8 +549,8 @@ mod tests {
 
         // Status for Bob should still be pending, even though the Txos will show up in
         // the wallet, but under Alice's account.
-        let status = service
-            .check_receiver_receipt_status(&bob_account_id, &receipt, 24 * MOB as u64)
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
 
@@ -519,19 +572,17 @@ mod tests {
         );
 
         // Status for Bob is succeeded.
-        let status = service
-            .check_receiver_receipt_status(&bob_account_id, &receipt, 24 * MOB as u64)
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionSuccess);
 
         // Status for Alice would be pending, because she never received (and never will
         // receive) the Txos.
-        let status = service
-            .check_receiver_receipt_status(
-                &AccountID(alice.account_id_hex),
-                &receipt,
-                24 * MOB as u64,
-            )
+        let alice_address =
+            &b58_encode(&alice_public_address).expect("Could not encode Alice address");
+        let (status, _txo) = service
+            .check_receipt_status(&alice_address, &receipt)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
     }
@@ -572,7 +623,7 @@ mod tests {
         let bob_addresses = service
             .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
             .expect("Could not get addresses for Bob");
-        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
         let bob_account_id = AccountID(bob.account_id_hex.to_string());
 
         // Create a TxProposal to Bob
@@ -591,7 +642,7 @@ mod tests {
         let receipts = service
             .create_receiver_receipts(&tx_proposal0)
             .expect("Could not create receiver receipt");
-        let receipt0 = &receipts[0];
+        let mut receipt0 = receipts[0].clone();
 
         // Land the Txo in the ledger - only sync for the sender
         TransactionLog::log_submitted(
@@ -612,20 +663,44 @@ mod tests {
         );
         manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
 
-        // Bob checks the status, and is expecting an incorrect value
-        let status = service
-            .check_receiver_receipt_status(&bob_account_id, &receipt0, 18 * MOB as u64)
+        // Bob checks the status, and is expecting an incorrect value, from a
+        // transaction with a different shared secret
+        receipt0.amount = Amount::new(18 * MOB as u64, &RistrettoPublic::from_random(&mut rng))
+            .expect("Could not create Amount");
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt0)
             .expect("Could not check status of receipt");
-        assert_eq!(status, ReceiptTransactionStatus::UnexpectedValue);
+        assert_eq!(status, ReceiptTransactionStatus::FailedAmountDecryption);
+
+        // Now check status with a correct shared secret, but the wrong value
+        let bob_account_key: AccountKey = mc_util_serial::decode(
+            &Account::get(&bob_account_id, &service.wallet_db.get_conn().unwrap())
+                .expect("Could not get bob account")
+                .account_key,
+        )
+        .expect("Could not decode");
+        let public_key: RistrettoPublic = RistrettoPublic::try_from(&receipt0.public_key)
+            .expect("Could not get ristretto public from compressed");
+        let shared_secret =
+            get_tx_out_shared_secret(bob_account_key.view_private_key(), &public_key);
+        receipt0.amount =
+            Amount::new(18 * MOB as u64, &shared_secret).expect("Could not create Amount");
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt0)
+            .expect("Could not check status of receipt");
+        assert_eq!(
+            status,
+            ReceiptTransactionStatus::AmountMismatch(
+                "Expected: 18000000000000, Got: 24000000000000".to_string()
+            )
+        );
 
         // Status for Alice would be pending, because she never received (and never will
         // receive) the Txos.
-        let status = service
-            .check_receiver_receipt_status(
-                &AccountID(alice.account_id_hex),
-                &receipt0,
-                18 * MOB as u64,
-            )
+        let alice_address =
+            &b58_encode(&alice_public_address).expect("Could not encode alice address");
+        let (status, _txo) = service
+            .check_receipt_status(&alice_address, &receipt0)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
     }
@@ -666,7 +741,7 @@ mod tests {
         let bob_addresses = service
             .get_all_addresses_for_account(&AccountID(bob.account_id_hex.clone()))
             .expect("Could not get addresses for Bob");
-        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
         let bob_account_id = AccountID(bob.account_id_hex.to_string());
 
         // Create a TxProposal to Bob
@@ -711,22 +786,20 @@ mod tests {
         let mut bad_proof_bytes = [0u8; 32];
         rng.fill_bytes(&mut bad_proof_bytes);
         let bad_proof = TxOutConfirmationNumber::from(bad_proof_bytes);
-        receipt.proof = bad_proof;
+        receipt.confirmation = bad_proof;
 
         // Bob checks the status, and is expecting an incorrect value
-        let status = service
-            .check_receiver_receipt_status(&bob_account_id, &receipt, 24 * MOB as u64)
+        let (status, _txo) = service
+            .check_receipt_status(&bob_address, &receipt)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::InvalidProof);
 
         // Checking for the sender will be pending because the Txos haven't landed for
         // alice (and never will).
-        let status = service
-            .check_receiver_receipt_status(
-                &AccountID(alice.account_id_hex),
-                &receipt,
-                18 * MOB as u64,
-            )
+        let alice_address =
+            &b58_encode(&alice_public_address).expect("Could not encode alice address");
+        let (status, _txo) = service
+            .check_receipt_status(&alice_address, &receipt)
             .expect("Could not check status of receipt");
         assert_eq!(status, ReceiptTransactionStatus::TransactionPending);
     }

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -165,7 +165,7 @@ pub trait ReceiptService {
     /// Applies the proofs by verifying the proofs once the Txos have landed.
     fn check_receipt_status(
         &self,
-        address: &String,
+        address: &str,
         receiver_receipt: &ReceiverReceipt,
     ) -> Result<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError>;
 
@@ -183,7 +183,7 @@ where
 {
     fn check_receipt_status(
         &self,
-        address: &String,
+        address: &str,
         receiver_receipt: &ReceiverReceipt,
     ) -> Result<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError> {
         let conn = &self.wallet_db.get_conn()?;
@@ -192,7 +192,7 @@ where
             .transaction::<(ReceiptTransactionStatus, Option<TxoDetails>), ReceiptServiceError, _>(
                 || {
                     let assigned_address = AssignedSubaddress::get(address, &conn)?;
-                    let account_id = AccountID(assigned_address.account_id_hex.clone());
+                    let account_id = AccountID(assigned_address.account_id_hex);
                     let account = Account::get(&account_id, &conn)?;
                     // Get the transaction from the database, with status.
                     let txos_and_statuses = Txo::select_by_public_key(


### PR DESCRIPTION
### Motivation

The `check_receipt_status` endpoint was not quite right to meet the needs of receipt verification.

### In this PR
* Uses `mc_api::external.Receipt` as opposed to `mobilecoind_api::ReceiverReceipt`
* Returns Txo along with status
* Verifies on address as opposed to account
* Updates API docs

[FS-174](https://mobilecoin.atlassian.net/browse/FS-174)
