### PR TITLE
Handle database-is-locked more gracefully

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -47,7 +47,6 @@ fn main() {
                 config.wallet_db, err
             )
         });
-
     embedded_migrations::run(&conn).expect("failed running migrations");
 
     let wallet_db = WalletDb::new_from_url(
@@ -55,6 +54,7 @@ fn main() {
             .wallet_db
             .to_str()
             .expect("Could not get wallet_db path"),
+        10,
         logger.clone(),
     )
     .expect("Could not access wallet db");

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -183,11 +183,7 @@ impl APIConfig {
                 let report_responses = conn
                     .fetch_fog_reports(fog_uris.iter().cloned())
                     .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
-                log::debug!(
-                    logger,
-                    "\x1b[1;33mGot report responses {:?}\x1b[0m",
-                    report_responses
-                );
+                log::debug!(logger, "Got report responses {:?}", report_responses);
                 Ok(FogResolver::new(report_responses, verifier)
                     .expect("Could not construct fog resolver"))
             } else {

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -927,11 +927,13 @@ impl TxoModel for Txo {
         proof: &TxOutConfirmationNumber,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<bool, WalletDbError> {
-        let txo_details = Txo::get(txo_id, conn)?;
-        let public_key: RistrettoPublic = mc_util_serial::decode(&txo_details.txo.public_key)?;
-        let account = Account::get(account_id, conn)?;
-        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-        Ok(proof.validate(&public_key, account_key.view_private_key()))
+        Ok(conn.transaction::<bool, WalletDbError, _>(|| {
+            let txo_details = Txo::get(txo_id, conn)?;
+            let public_key: RistrettoPublic = mc_util_serial::decode(&txo_details.txo.public_key)?;
+            let account = Account::get(account_id, conn)?;
+            let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+            Ok(proof.validate(&public_key, account_key.view_private_key()))
+        })?)
     }
 }
 
@@ -952,12 +954,13 @@ mod tests {
             add_block_with_db_txos, add_block_with_tx_outs, add_block_with_tx_proposal,
             create_test_minted_and_change_txos, create_test_received_txo,
             create_test_txo_for_recipient, get_resolver_factory, get_test_ledger,
-            manually_sync_account, random_account_with_seed_values, WalletDbTestContext, MOB,
+            manually_sync_account, random_account_with_seed_values, wait_for_sync,
+            WalletDbTestContext, MOB,
         },
     };
     use mc_account_keys::{AccountKey, RootIdentity};
     use mc_common::{
-        logger::{test_with_logger, Logger},
+        logger::{log, test_with_logger, Logger},
         HashSet,
     };
     use mc_crypto_rand::RngCore;
@@ -966,7 +969,7 @@ mod tests {
     use mc_transaction_core::constants::MINIMUM_FEE;
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use std::iter::FromIterator;
+    use std::{iter::FromIterator, time::Duration};
 
     // The narrative for this test is that Alice receives a Txo, then sends a
     // transaction to Bob. We verify expected qualities of the Txos involved at
@@ -1535,13 +1538,15 @@ mod tests {
         let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
 
         // The account which will receive the Txo
+        log::info!(logger, "Creating account");
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
+        let recipient_account_id = AccountID::from(&recipient_account_key);
         Account::create(
             &root_id.root_entropy,
             Some(0),
             None,
-            "",
+            "Alice",
             None,
             None,
             None,
@@ -1550,18 +1555,22 @@ mod tests {
         .unwrap();
 
         // Start sync thread
+        log::info!(logger, "Starting sync thread");
         let _sync_thread =
             SyncThread::start(ledger_db.clone(), wallet_db.clone(), None, logger.clone());
 
+        log::info!(logger, "Creating a random sender account");
         let sender_account_key = random_account_with_seed_values(
             &wallet_db,
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
         );
+        let sender_account_id = AccountID::from(&sender_account_key);
 
         // Create TxProposal from the sender account, which contains the Confirmation
         // Number
+        log::info!(logger, "Creating transaction builder");
         let mut builder: WalletTransactionBuilder<MockFogPubkeyResolver> =
             WalletTransactionBuilder::new(
                 AccountID::from(&sender_account_key).to_string(),
@@ -1577,27 +1586,35 @@ mod tests {
         builder.set_tombstone(0).unwrap();
         let proposal = builder.build().unwrap();
 
+        // Sleep to make sure that the foreign keys exist
+        std::thread::sleep(Duration::from_secs(3));
+
         // Let's log this submitted Tx for the sender, which will create_minted for the
         // sent Txo
+        log::info!(logger, "Logging submitted transaction");
         let tx_log = TransactionLog::log_submitted(
             proposal.clone(),
             ledger_db.num_blocks().unwrap(),
             "".to_string(),
-            Some(&AccountID::from(&sender_account_key).to_string()),
+            Some(&sender_account_id.to_string()),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
 
         // Now we need to let this txo hit the ledger, which will update sender and
         // receiver
+        log::info!(logger, "Adding block from submitted");
         add_block_with_tx_proposal(&mut ledger_db, proposal.clone());
 
         // Now let our sync thread catch up for both sender and receiver
-        std::thread::sleep(std::time::Duration::from_secs(4));
+        log::info!(logger, "Manually syncing account");
+        wait_for_sync(&ledger_db, &wallet_db, &recipient_account_id, 16);
+        wait_for_sync(&ledger_db, &wallet_db, &sender_account_id, 16);
 
         // Then let's make sure we received the Txo on the recipient account
+        log::info!(logger, "Listing all Txos for recipient account");
         let txos = Txo::list_for_account(
-            &AccountID::from(&recipient_account_key).to_string(),
+            &recipient_account_id.to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1611,8 +1628,9 @@ mod tests {
         assert!(received_txo.txo.proof.is_some());
 
         // Get the txo from the sent perspective
+        log::info!(logger, "Listing all Txos for sender account");
         let sender_txos = Txo::list_for_account(
-            &AccountID::from(&sender_account_key).to_string(),
+            &sender_account_id.to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1622,6 +1640,7 @@ mod tests {
         assert_eq!(sender_txos.len(), 5);
 
         // Get the associated Txos with the transaction log
+        log::info!(logger, "Getting associated Txos with the transaction");
         let associated = tx_log
             .get_associated_txos(&wallet_db.get_conn().unwrap())
             .unwrap();
@@ -1636,6 +1655,7 @@ mod tests {
         assert!(sent_txo_details.txo.proof.is_some());
         let proof: TxOutConfirmationNumber =
             mc_util_serial::decode(&sent_txo_details.txo.proof.unwrap()).unwrap();
+        log::info!(logger, "Verifying the proof");
         let verified = Txo::verify_proof(
             &AccountID::from(&recipient_account_key),
             &received_txo.txo.txo_id_hex,

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -1,9 +1,43 @@
 use crate::db::WalletDbError;
 use diesel::{
+    connection::SimpleConnection,
     prelude::*,
     r2d2::{ConnectionManager, Pool, PooledConnection},
 };
 use mc_common::logger::Logger;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct ConnectionOptions {
+    pub enable_wal: bool,
+    pub enable_foreign_keys: bool,
+    pub busy_timeout: Option<Duration>,
+}
+
+impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
+    for ConnectionOptions
+{
+    fn on_acquire(&self, conn: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+        (|| {
+            if self.enable_wal {
+                conn.batch_execute("
+                    PRAGMA journal_mode = WAL;          -- better write-concurrency
+                    PRAGMA synchronous = NORMAL;        -- fsync only in critical moments
+                    PRAGMA wal_autocheckpoint = 1000;   -- write WAL changes back every 1000 pages, for an in average 1MB WAL file. May affect readers if number is increased
+                    PRAGMA wal_checkpoint(TRUNCATE);    -- free some space by truncating possibly massive WAL files from the last run.
+                ")?;
+            }
+            if self.enable_foreign_keys {
+                conn.batch_execute("PRAGMA foreign_keys = ON;")?;
+            }
+            if let Some(d) = self.busy_timeout {
+                conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d.as_millis()))?;
+            }
+            Ok(())
+        })()
+        .map_err(diesel::r2d2::Error::QueryError)
+    }
+}
 
 #[derive(Clone)]
 pub struct WalletDb {
@@ -16,10 +50,19 @@ impl WalletDb {
         Self { pool, logger }
     }
 
-    pub fn new_from_url(database_url: &str, logger: Logger) -> Result<Self, WalletDbError> {
+    pub fn new_from_url(
+        database_url: &str,
+        db_connections: u32,
+        logger: Logger,
+    ) -> Result<Self, WalletDbError> {
         let manager = ConnectionManager::<SqliteConnection>::new(database_url);
         let pool = Pool::builder()
-            .max_size(1)
+            .max_size(db_connections)
+            .connection_customizer(Box::new(ConnectionOptions {
+                enable_wal: true,
+                enable_foreign_keys: false,
+                busy_timeout: Some(Duration::from_secs(30)),
+            }))
             .test_on_check_out(true)
             .build(manager)?;
         Ok(Self::new(pool, logger))

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -164,10 +164,8 @@ pub fn wait_for_sync(
 ) {
     let mut count = 0;
     loop {
-        // FIXME: FS-122: Use async primitives so that we don't have to sleep for these
-        // tests.
         // Sleep to let the sync thread process the txos
-        std::thread::sleep(Duration::from_secs(2));
+        std::thread::sleep(Duration::from_millis(2000));
 
         // Check that syncing is working
         let body = json!({

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -39,7 +39,7 @@ use mc_transaction_core::{
 };
 use mc_util_from_random::FromRandom;
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt, time::Duration};
 
 #[derive(Display, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -575,7 +575,7 @@ where
             // Note that we now need to allow the sync thread to catch up for this TXO so
             // that we can make sure the subaddress is assigned, rendering the
             // Txo spendable.
-            std::thread::sleep(std::time::Duration::from_secs(3));
+            std::thread::sleep(Duration::from_secs(2));
             let txos =
                 Txo::list_for_account(&gift_code_account_id_hex, &self.wallet_db.get_conn()?)?;
             txo = txos[0].clone();

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -6,8 +6,9 @@ use crate::{
         models::{Account, TransactionLog, Txo, TXO_USED_AS_CHANGE, TXO_USED_AS_OUTPUT},
         transaction_log::TransactionLogModel,
         txo::TxoModel,
-        WalletDb,
+        WalletDb, WalletDbError,
     },
+    error::SyncError,
     service::{sync::sync_account, transaction_builder::WalletTransactionBuilder},
     WalletService,
 };
@@ -42,6 +43,7 @@ use std::{
     convert::TryFrom,
     path::PathBuf,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 use tempdir::TempDir;
 
@@ -72,9 +74,10 @@ impl Default for WalletDbTestContext {
         let base_url = std::env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
 
         // Connect to the database and run the migrations
+        // Note: This should be kept in sync wth how the migrations are run in main.rs
+        // so as to have faithful tests.
         let conn = SqliteConnection::establish(&format!("{}/{}", base_url, db_name))
             .unwrap_or_else(|err| panic!("Cannot connect to {} database: {:?}", db_name, err));
-
         embedded_migrations::run(&conn).expect("failed running migrations");
 
         // Success
@@ -84,7 +87,9 @@ impl Default for WalletDbTestContext {
 
 impl WalletDbTestContext {
     pub fn get_db_instance(&self, logger: Logger) -> WalletDb {
-        WalletDb::new_from_url(&format!("{}/{}", self.base_url, self.db_name), logger)
+        // Note: Setting db_connections too high results in IO Error: Too many open
+        // files.
+        WalletDb::new_from_url(&format!("{}/{}", self.base_url, self.db_name), 7, logger)
             .expect("failed creating new SqlRecoveryDb")
     }
 }
@@ -327,7 +332,15 @@ pub fn manually_sync_account(
 ) -> Account {
     let mut account: Account;
     loop {
-        sync_account(&ledger_db, &wallet_db, &account_id.to_string(), &logger).unwrap();
+        match sync_account(&ledger_db, &wallet_db, &account_id.to_string(), &logger) {
+            Ok(_) => {}
+            Err(SyncError::Database(WalletDbError::Diesel(
+                diesel::result::Error::DatabaseError(_kind, _info),
+            ))) => {
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            Err(e) => panic!("Could not sync account due to {:?}", e),
+        }
         account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
         if account.next_block_index as u64 == ledger_db.num_blocks().unwrap() {
             break;
@@ -335,6 +348,22 @@ pub fn manually_sync_account(
     }
     assert_eq!(account.next_block_index as u64, target_block_index);
     account
+}
+
+pub fn wait_for_sync(
+    ledger_db: &LedgerDB,
+    wallet_db: &WalletDb,
+    account_id: &AccountID,
+    target_block_index: u64,
+) {
+    let mut account: Account;
+    loop {
+        account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
+        if account.next_block_index as u64 == ledger_db.num_blocks().unwrap() {
+            break;
+        }
+    }
+    assert_eq!(account.next_block_index as u64, target_block_index);
 }
 
 pub fn setup_grpc_peer_manager_and_network_state(
@@ -514,17 +543,19 @@ pub fn random_account_with_seed_values(
 ) -> AccountKey {
     let root_id = RootIdentity::from_random(&mut rng);
     let account_key = AccountKey::from(&root_id);
-    Account::create(
-        &root_id.root_entropy,
-        Some(0),
-        None,
-        "",
-        None,
-        None,
-        None,
-        &wallet_db.get_conn().unwrap(),
-    )
-    .unwrap();
+    {
+        Account::create(
+            &root_id.root_entropy,
+            Some(0),
+            None,
+            &format!("SeedAccount{}", rng.next_u32()),
+            None,
+            None,
+            None,
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+    }
 
     for value in seed_values.iter() {
         add_block_to_ledger_db(
@@ -536,19 +567,25 @@ pub fn random_account_with_seed_values(
         );
     }
 
-    // FIXME: FS-122 - should not be sleeping in tests
-    std::thread::sleep(std::time::Duration::from_secs(8));
+    wait_for_sync(
+        &ledger_db,
+        &wallet_db,
+        &AccountID::from(&account_key),
+        ledger_db.num_blocks().unwrap(),
+    );
 
     // Make sure we have all our TXOs
-    assert_eq!(
-        Txo::list_for_account(
-            &AccountID::from(&account_key).to_string(),
-            &wallet_db.get_conn().unwrap(),
-        )
-        .unwrap()
-        .len(),
-        seed_values.len(),
-    );
+    {
+        assert_eq!(
+            Txo::list_for_account(
+                &AccountID::from(&account_key).to_string(),
+                &wallet_db.get_conn().unwrap(),
+            )
+            .unwrap()
+            .len(),
+            seed_values.len(),
+        );
+    }
 
     account_key
 }


### PR DESCRIPTION
Soundtrack of this PR: [Yo-Yo Ma: Hush Little Baby](https://www.youtube.com/watch?v=UTstU-st-7o)

### Motivation

Currently, the max db connections are set at 1, to avoid `database is locked` errors from SQLite. This PR makes some configuration changes and app-level changes to gracefully retry when database is locked.

### In this PR
* Enable WAL
* Gracefully requeue account if syncing fails due to database locked (this also fixes when the sync thread appeared to die and not recover)
* Remove sleeping from tests (except when in the controlled `wait_for_sync` method

[FS-162](https://mobilecoin.atlassian.net/browse/FS-162)
[FS-121](https://mobilecoin.atlassian.net/browse/FS-121)
[FS-156](https://mobilecoin.atlassian.net/browse/FS-156)

