### PR TITLE
Trace database locked log message

### DIFF
--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -319,7 +319,7 @@ fn sync_thread_entry_point(
                     ))) => {
                         match info.message() {
                             "database is locked" => {
-                                log::warn!(logger, "Database locked. Will retry")
+                                log::trace!(logger, "Database locked. Will retry")
                             }
                             _ => log::error!(
                                 logger,


### PR DESCRIPTION
Move Database is locked "warn" message to "trace"

