### PR TITLE
✨ 📝 ✅  Added field for next subaddress index to import_account

### DIFF
--- a/API.md
+++ b/API.md
@@ -116,6 +116,7 @@ curl -s localhost:9090/wallet \
           "entropy": "c593274dc6f6eb94242e34ae5f0ab16bc3085d45d49d9e18b8a8c6f057e6b56b",
           "name": "Bob"
           "first_block_index": 3500,
+          "next_subaddress_index": 2,
         },
         "jsonrpc": "2.0",
         "id": 1

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -411,6 +411,7 @@ mod tests {
                 &root_id.root_entropy,
                 Some(0),
                 None,
+                None,
                 "Alice's Main Account",
                 None,
                 None,
@@ -473,6 +474,7 @@ mod tests {
             &root_id_secondary.root_entropy,
             Some(51),
             Some(50),
+            None,
             "",
             None,
             None,
@@ -547,6 +549,7 @@ mod tests {
             let (account_id_hex, _public_address_b58) = Account::create(
                 &root_id.root_entropy,
                 Some(0),
+                None,
                 None,
                 "Alice's Main Account",
                 None,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -194,13 +194,7 @@ impl AccountModel for Account {
                 for subaddress_index in
                     2..next_subaddress_index.unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
                 {
-                    AssignedSubaddress::create(
-                        &account_key,
-                        None,
-                        subaddress_index,
-                        "From Account Import",
-                        &conn,
-                    )?;
+                    AssignedSubaddress::create(&account_key, None, subaddress_index, "", &conn)?;
                 }
 
                 Ok((account_id, main_subaddress_b58))

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -55,6 +55,7 @@ pub trait AccountModel {
         entropy: &RootEntropy,
         first_block_index: Option<u64>,
         import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         name: &str,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
@@ -69,6 +70,7 @@ pub trait AccountModel {
         name: Option<String>,
         import_block_index: u64,
         first_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,
@@ -128,6 +130,7 @@ impl AccountModel for Account {
         entropy: &RootEntropy,
         first_block_index: Option<u64>,
         import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         name: &str,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
@@ -157,7 +160,9 @@ impl AccountModel for Account {
                     entropy: &entropy.bytes,
                     main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
                     change_subaddress_index: DEFAULT_CHANGE_SUBADDRESS_INDEX as i64,
-                    next_subaddress_index: DEFAULT_NEXT_SUBADDRESS_INDEX as i64,
+                    next_subaddress_index: next_subaddress_index
+                        .unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
+                        as i64,
                     first_block_index: fb as i64,
                     next_block_index: fb as i64,
                     import_block_index: import_block_index.map(|i| i as i64),
@@ -185,6 +190,19 @@ impl AccountModel for Account {
                     "Change",
                     &conn,
                 )?;
+
+                for subaddress_index in
+                    2..next_subaddress_index.unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
+                {
+                    AssignedSubaddress::create(
+                        &account_key,
+                        None,
+                        subaddress_index,
+                        "From Account Import",
+                        &conn,
+                    )?;
+                }
+
                 Ok((account_id, main_subaddress_b58))
             })?,
         )
@@ -195,6 +213,7 @@ impl AccountModel for Account {
         name: Option<String>,
         import_block_index: u64,
         first_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,
@@ -205,6 +224,7 @@ impl AccountModel for Account {
                 entropy,
                 first_block_index,
                 Some(import_block_index),
+                next_subaddress_index,
                 &name.unwrap_or_else(|| "".to_string()),
                 fog_report_url,
                 fog_report_id,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -632,6 +632,7 @@ mod tests {
             &root_id.root_entropy,
             Some(0),
             None,
+            None,
             "",
             None,
             None,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -983,6 +983,7 @@ mod tests {
             &root_id.root_entropy,
             Some(1),
             None,
+            None,
             "Alice's Main Account",
             None,
             None,
@@ -1247,6 +1248,7 @@ mod tests {
             &bob_root_id.root_entropy,
             Some(1),
             None,
+            None,
             "Bob's Main Account",
             None,
             None,
@@ -1307,6 +1309,7 @@ mod tests {
         let (account_id_hex, _public_address_b58) = Account::create(
             &root_id.root_entropy,
             Some(1),
+            None,
             None,
             "Alice's Main Account",
             None,
@@ -1416,6 +1419,7 @@ mod tests {
             &root_id.root_entropy,
             Some(0),
             None,
+            None,
             "Alice's Main Account",
             None,
             None,
@@ -1470,6 +1474,7 @@ mod tests {
         Account::create(
             &root_id.root_entropy,
             Some(0),
+            None,
             None,
             "",
             None,
@@ -1538,6 +1543,7 @@ mod tests {
         Account::create(
             &root_id.root_entropy,
             Some(0),
+            None,
             None,
             "Alice",
             None,

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -63,6 +63,7 @@ pub enum JsonCommandRequest {
         entropy: String,
         name: Option<String>,
         first_block_index: Option<String>,
+        next_subaddress_index: Option<String>,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -114,12 +114,17 @@ where
             entropy,
             name,
             first_block_index,
+            next_subaddress_index,
             fog_report_url,
             fog_report_id,
             fog_authority_spki,
         } => {
             let fb = first_block_index
                 .map(|fb| fb.parse::<u64>())
+                .transpose()
+                .map_err(format_error)?;
+            let ns = next_subaddress_index
+                .map(|ns| ns.parse::<u64>())
                 .transpose()
                 .map_err(format_error)?;
 
@@ -130,6 +135,7 @@ where
                             entropy,
                             name,
                             fb,
+                            ns,
                             fog_report_url,
                             fog_report_id,
                             fog_authority_spki,

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -80,11 +80,13 @@ pub trait AccountService {
     ) -> Result<Account, AccountServiceError>;
 
     /// Import an existing account to the wallet using the entropy.
+    #[allow(clippy::too_many_arguments)]
     fn import_account(
         &self,
         entropy: String,
         name: Option<String>,
         first_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,
@@ -142,6 +144,7 @@ where
             &entropy,
             Some(first_block_index),
             Some(import_block_index),
+            None,
             &name.unwrap_or_else(|| "".to_string()),
             None,
             None,
@@ -158,6 +161,7 @@ where
         entropy: String,
         name: Option<String>,
         first_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,
@@ -182,6 +186,7 @@ where
             name,
             import_block,
             first_block_index,
+            next_subaddress_index,
             fog_report_url,
             fog_report_id,
             fog_authority_spki,

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -342,7 +342,15 @@ mod tests {
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
 
         let account = service
-            .import_account(hex::encode(&entropy.bytes), None, None, None, None, None)
+            .import_account(
+                hex::encode(&entropy.bytes),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .expect("Could not import account entropy");
 
         let address = service

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -553,6 +553,7 @@ pub fn random_account_with_seed_values(
             &root_id.root_entropy,
             Some(0),
             None,
+            None,
             &format!("SeedAccount{}", rng.next_u32()),
             None,
             None,


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Users should be able to dictate their known next subaddress index when importing an account. This will be a small usability fix before the larger recovery feature is designed and implemented.

### In this PR

### Future Work
* Larger recovery mode features

