### PR TITLE
Support SLIP0010 key derivation path from mnemonic

### DIFF
--- a/API.md
+++ b/API.md
@@ -148,7 +148,7 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `mnemonic`      | The secret mnemonic to recover the account  | 24 words  |
-| `key_derivation_version`      | The key derivation version that this mnemonic should be applied to |  |
+| `key_derivation_version`      | The version number of the key derivation path used to derive an account key from this mnemonic. |  |
 
 | Optional Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |

--- a/API.md
+++ b/API.md
@@ -148,13 +148,13 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `mnemonic`      | The secret mnemonic to recover the account  | 24 words  |
-| `key_derivation_version`      | The version number of the key derivation path used to derive an account key from this mnemonic. |  |
+| `key_derivation_version`      | The version number of the key derivation used to derive an account key from this mnemonic. Current version is 2 |  |
 
 | Optional Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `name`         | Label for this account   | Can have duplicates (not recommended) |
 | `first_block_index`  | The block from which to start scanning the ledger |  |
-| `next_subaddress_index`  | The next available known subaddress index for the account |  |
+| `next_subaddress_index`  | The next known unused subaddress index for the account |  |
 
 #### Import Legacy Account - Deprecated
 
@@ -204,7 +204,7 @@ curl -s localhost:9090/wallet \
 | :------------- | :----------------------- | :------------------------ |
 | `name`         | Label for this account   | Can have duplicates (not recommended) |
 | `first_block_index`  | The block from which to start scanning the ledger |  |
-| `next_subaddress_index`  | The next available known subaddress index for the account |  |
+| `next_subaddress_index`  | The next known unused subaddress index for the account |  |
 
 ##### Troubleshooting
 

--- a/API.md
+++ b/API.md
@@ -113,9 +113,10 @@ curl -s localhost:9090/wallet \
         "method": "import_account",
         "params": {
           "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
+          "key_derivation_version": "2",
           "name": "Bob"
           "next_subaddress_index": 2,
-          "first_block_index": "3500",
+          "first_block_index": "3500"
         },
         "jsonrpc": "2.0",
         "id": 1
@@ -146,6 +147,7 @@ curl -s localhost:9090/wallet \
 | Required Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
 | `mnemonic`      | The secret mnemonic to recover the account  | 24 words  |
+| `key_derivation_version`      | The key derivation version that this mnemonic should be applied to |  |
 
 | Optional Param | Purpose                  | Requirements              |
 | :------------- | :----------------------- | :------------------------ |
@@ -411,6 +413,7 @@ curl -s localhost:9090/wallet \
       "object": "account_key",
       "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
       "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
+      "key_derivation_version": "2",
       "account_key": {
         "object": "account_key",
         "view_private_key": "0a20be48e147741246f09adb195b110c4ec39302778c4554cd3c9ff877f8392ce605",

--- a/API.md
+++ b/API.md
@@ -30,7 +30,7 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 * [get_all_transaction_logs_for_block](#get-all-transaction-logs-for-block)
 * [get_all_transaction_logs_ordered_by_block](#get-all-transaction-logs-ordered-by-block)
 * [get_confirmations](#get-confirmations)
-* [validate_confirmation](#validate-confirmations)
+* [validate_confirmation](#validate-confirmation)
 * [check_receiver_receipt_status](#check-receiver-receipt-status)
 * [create_receiver_receipts](#create-receiver-receipts)
 * [build_gift_code](#build-gift-code)
@@ -49,6 +49,7 @@ The Full Service Wallet API provides JSON RPC 2.0 endpoints for interacting with
 The methods above return data representations of wallet contents. The Full Service API Data types are as follows:
 
 * [account](#the-account-object)
+* [account_secrets](#the-account-secrets-object)
 * [balance](#the-balance-object)
 * [wallet_status](#the-wallet-status-object)
 * [address](#the-address-object)
@@ -411,7 +412,7 @@ curl -s localhost:9090/wallet \
   "method": "export_account_secrets",
   "result": {
     "account_secrets": {
-      "object": "account_key",
+      "object": "account_secrets",
       "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
       "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
       "key_derivation_version": "2",
@@ -2360,6 +2361,43 @@ An Account is associated with one AccountKey, containing a View keypair and a Sp
 * [get_all_accounts](#get-all-accounts)
 * [get_account](#get-account)
 * [update_account_name](#update-account-name)
+
+
+### The Account Secrets Object
+
+Secret keys for an account.
+
+This is returned separately from other account information, to enable more careful handling of cryptographically sensitive information.
+
+
+#### Attributes
+
+| *Name* | *Type* | *Description*
+| :--- | :--- | :---
+| object | string, value is "account_secrets" | String representing the object's type. Objects of the same type share the same value
+| account_id | string | Unique identifier for the account.
+| mnemonic | string | A BIP39 encoded mnemonic phrase used to generate the account key.
+| key_derivation_version | string (uint64) | The version number of the key derivation path used to generate the account key from the mnemonic.
+| account_key |  account_key | The view and spend keys used to transact on the mobilecoin network. Also may contain keys to connect to the Fog ledger scanning service.
+
+#### Example Object
+
+```json
+{
+  "object": "account_secrets",
+  "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
+  "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
+  "key_derivation_version": "2",
+  "account_key": {
+    "object": "account_key",
+    "view_private_key": "0a20be48e147741246f09adb195b110c4ec39302778c4554cd3c9ff877f8392ce605",
+    "spend_private_key": "0a201f33b194e13176341b4e696b70be5ba5c4e0021f5a79664ab9a8b128f0d6d40d",
+    "fog_report_url": "",
+    "fog_report_id": "",
+    "fog_authority_spki": ""
+  }
+}
+```
 
 ### The Balance Object
 

--- a/API.md
+++ b/API.md
@@ -246,6 +246,7 @@ curl -s localhost:9090/wallet \
     "account_map": {
       "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52": {
         "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
+        "key_derivation_version:": "1",
         "main_address": "4bgkVAH1hs55dwLTGVpZER8ZayhqXbYqfuyisoRrmQPXoWcYQ3SQRTjsAytCiAgk21CRrVNysVw5qwzweURzDK9HL3rGXFmAAahb364kYe3",
         "name": "Alice",
         "next_subaddress_index": "2",
@@ -255,6 +256,7 @@ curl -s localhost:9090/wallet \
       },
       "b6c9f6f779372ae25e93d68a79d725d71f3767d1bfd1c5fe155f948a2cc5c0a0": {
         "account_id": "b6c9f6f779372ae25e93d68a79d725d71f3767d1bfd1c5fe155f948a2cc5c0a0",
+        "key_derivation_version:": "2",
         "main_address": "7EqduSDpM1R5AfQejbjAqFxpuCoh6zJECtvJB9AZFwjK13dCzZgYbyfLf4TfHcE8LVPjzDdpcxYLkdMBh694mHfftJmsFZuz6xUeRtmsUdc",
         "name": "Alice",
         "next_subaddress_index": "2",
@@ -292,6 +294,7 @@ curl -s localhost:9090/wallet \
     "account": {
       "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
       "main_address": "4bgkVAH1hs55dwLTGVpZER8ZayhqXbYqfuyisoRrmQPXoWcYQ3SQRTjsAytCiAgk21CRrVNysVw5qwzweURzDK9HL3rGXFmAAahb364kYe3",
+      "key_derivation_version:": "2",
       "name": "Alice",
       "next_subaddress_index": "2",
       "first_block_index": "3500",
@@ -663,6 +666,7 @@ curl -s localhost:9090/wallet \
       "account_map": {
         "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470": {
           "account_id": "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470",
+          "key_derivation_version:": "2",
           "main_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
           "name": "Bob",
           "next_subaddress_index": "2",
@@ -672,6 +676,7 @@ curl -s localhost:9090/wallet \
         },
         "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17": {
           "account_id": "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17",
+          "key_derivation_version:": "2",
           "main_address": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
           "name": "Carol",
           "next_subaddress_index": "2",
@@ -2474,6 +2479,7 @@ The balance for an account, as well as some information about syncing status nee
   "account_map": {
     "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470": {
       "account_id": "6ed6b79004032fcfcfa65fa7a307dd004b8ec4ed77660d36d44b67452f62b470",
+      "key_derivation_version:": "2",
       "main_address": "CaE5bdbQxLG2BqAYAz84mhND79iBSs13ycQqN8oZKZtHdr6KNr1DzoX93c6LQWYHEi5b7YLiJXcTRzqhDFB563Kr1uxD6iwERFbw7KLWA6",
       "name": "Bob",
       "next_subaddress_index": "2",
@@ -2483,6 +2489,7 @@ The balance for an account, as well as some information about syncing status nee
     },
     "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17": {
       "account_id": "b0be5377a2f45b1573586ed530b2901a559d9952ea8a02f8c2dbb033a935ac17",
+      "key_derivation_version:": "2",
       "main_address": "7JvajhkAZYGmrpCY7ZpEiXRK5yW1ooTV7EWfDNu3Eyt572mH1wNb37BWiU6JqRUvgopPqSVZRexhXXpjF3wqLQR7HaJrcdbHmULujgFmzav",
       "name": "Brady",
       "next_subaddress_index": "2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274a6bc8a6a4521291b53b9dcb8345e963fe931c3fc462a7d3ead71d7ccd30d"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha512"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
+
+[[package]]
 name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1668,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "blake2",
  "curve25519-dalek",
+ "displaydoc 0.2.1",
  "hkdf",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
@@ -1665,6 +1683,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-account-keys-slip10"
+version = "1.0.1-pre1"
+dependencies = [
+ "curve25519-dalek",
+ "displaydoc 0.2.1",
+ "hkdf",
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "sha2",
+ "slip10_ed25519",
+ "tiny-bip39",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-api"
 version = "1.0.1-pre1"
 dependencies = [
@@ -1672,7 +1705,7 @@ dependencies = [
  "cargo-emit",
  "crc",
  "curve25519-dalek",
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-account-keys",
  "mc-attest-core",
  "mc-crypto-keys",
@@ -1692,7 +1725,7 @@ dependencies = [
  "aead",
  "cargo-emit",
  "digest",
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-attest-core",
  "mc-crypto-keys",
  "mc-crypto-noise",
@@ -1727,12 +1760,15 @@ version = "1.0.1-pre1"
 dependencies = [
  "binascii",
  "bitflags",
+ "cargo-emit",
  "cfg-if 0.1.10",
  "chrono",
  "digest",
- "displaydoc",
+ "displaydoc 0.2.1",
  "failure",
+ "hex",
  "hex_fmt",
+ "lazy_static",
  "mbedtls",
  "mbedtls-sys-auto",
  "mc-common",
@@ -1743,7 +1779,8 @@ dependencies = [
  "mc-sgx-types",
  "mc-util-encodings",
  "prost",
- "rand_core 0.5.1",
+ "rand 0.7.3",
+ "rand_hc 0.2.0",
  "rjson",
  "serde",
  "sha2",
@@ -1754,7 +1791,7 @@ dependencies = [
 name = "mc-attest-enclave-api"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-attest-ake",
  "mc-attest-core",
  "mc-crypto-noise",
@@ -1803,7 +1840,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "aes-gcm",
  "cookie 0.14.3",
- "displaydoc",
+ "displaydoc 0.2.1",
  "grpcio",
  "mc-attest-ake",
  "mc-attest-api",
@@ -2001,7 +2038,7 @@ dependencies = [
 name = "mc-crypto-x509-utils"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-crypto-keys",
  "pem",
  "x509-signature",
@@ -2027,7 +2064,7 @@ dependencies = [
 name = "mc-fog-report-connection"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "grpcio",
  "mc-account-keys",
  "mc-attest-core",
@@ -2044,7 +2081,7 @@ dependencies = [
 name = "mc-fog-report-validation"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-account-keys",
  "mc-attest-core",
  "mc-crypto-keys",
@@ -2068,7 +2105,7 @@ dependencies = [
 name = "mc-fog-sig"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-crypto-x509-utils",
@@ -2092,7 +2129,7 @@ dependencies = [
 name = "mc-fog-sig-report"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-attest-core",
  "mc-crypto-digestible-signature",
  "mc-crypto-keys",
@@ -2120,11 +2157,12 @@ dependencies = [
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
- "displaydoc",
+ "displaydoc 0.1.7",
  "dotenv",
  "grpcio",
  "hex",
  "mc-account-keys",
+ "mc-account-keys-slip10",
  "mc-api",
  "mc-attest-core",
  "mc-common",
@@ -2163,6 +2201,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempdir",
+ "tiny-bip39",
  "uuid 0.7.4",
 ]
 
@@ -2223,7 +2262,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "crossbeam-channel 0.5.0",
- "displaydoc",
+ "displaydoc 0.2.1",
  "failure",
  "grpcio",
  "hex_fmt",
@@ -2320,7 +2359,7 @@ dependencies = [
 name = "mc-sgx-css"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "sha2",
 ]
 
@@ -2335,7 +2374,7 @@ dependencies = [
  "blake2",
  "bulletproofs",
  "curve25519-dalek",
- "displaydoc",
+ "displaydoc 0.2.1",
  "generic-array",
  "hex_fmt",
  "lazy_static",
@@ -2397,7 +2436,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
- "displaydoc",
+ "displaydoc 0.2.1",
  "mbedtls",
  "mbedtls-sys-auto",
  "mc-sgx-css",
@@ -2436,7 +2475,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "cargo-emit",
  "cc",
- "displaydoc",
+ "displaydoc 0.2.1",
  "mc-util-build-script",
  "pkg-config",
 ]
@@ -2447,7 +2486,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "base64 0.12.3",
  "binascii",
- "displaydoc",
+ "displaydoc 0.2.1",
  "hex",
  "mc-util-repr-bytes",
  "serde",
@@ -2466,7 +2505,7 @@ version = "1.0.1-pre1"
 dependencies = [
  "base64 0.12.3",
  "cookie 0.14.3",
- "displaydoc",
+ "displaydoc 0.2.1",
  "futures",
  "grpcio",
  "hex",
@@ -2496,7 +2535,7 @@ version = "1.0.1-pre1"
 name = "mc-util-lmdb"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "lmdb-rkv",
  "mc-util-serial",
  "prost",
@@ -2547,7 +2586,7 @@ name = "mc-util-uri"
 version = "1.0.1-pre1"
 dependencies = [
  "base64 0.12.3",
- "displaydoc",
+ "displaydoc 0.2.1",
  "ed25519",
  "hex",
  "mc-common",
@@ -2562,7 +2601,7 @@ dependencies = [
 name = "mc-watcher"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "grpcio",
  "hex",
  "lmdb-rkv",
@@ -2594,7 +2633,7 @@ dependencies = [
 name = "mc-watcher-api"
 version = "1.0.1-pre1"
 dependencies = [
- "displaydoc",
+ "displaydoc 0.2.1",
  "serde",
 ]
 
@@ -2827,6 +2866,9 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -2873,6 +2915,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac 0.8.0",
 ]
 
 [[package]]
@@ -3907,6 +3958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "slip10_ed25519"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be0ff28bf14f9610a342169084e87a4f435ad798ec528dc7579a3678fa9dc9a"
+dependencies = [
+ "hmac-sha512",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,6 +4384,24 @@ dependencies = [
  "quote 1.0.7",
  "standback",
  "syn 1.0.48",
+]
+
+[[package]]
+name = "tiny-bip39"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2",
+ "thiserror",
+ "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -4884,9 +4962,9 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 dependencies = [
  "zeroize_derive",
 ]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -14,6 +14,7 @@ ip-check = []
 
 [dependencies]
 mc-account-keys = { path = "../mobilecoin/account-keys" }
+mc-account-keys-slip10 = { path = "../mobilecoin/account-keys/slip10" }
 mc-api = { path = "../mobilecoin/api" }
 mc-attest-core = { path = "../mobilecoin/attest/core", default-features = false }
 mc-common = { path = "../mobilecoin/common", default-features = false, features = ["loggers"] }
@@ -59,6 +60,7 @@ serde_derive = "1.0"
 structopt = "0.3"
 strum = { version = "0.20", features = ["derive"] }
 strum_macros = "0.20"
+tiny-bip39 = "0.8.0"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/full-service/migrations/2021-03-30-021521_slip10_account_key/down.sql
+++ b/full-service/migrations/2021-03-30-021521_slip10_account_key/down.sql
@@ -1,0 +1,32 @@
+-- ALTER TABLE accounts REMOVE COLUMN key_derivation_version;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE OLD_accounts (
+    id INTEGER NOT NULL PRIMARY KEY,
+    account_id_hex VARCHAR NOT NULL UNIQUE,
+    account_key BLOB NOT NULL,
+    entropy BLOB NOT NULL,
+    main_subaddress_index UNSIGNED BIG INT NOT NULL,
+    change_subaddress_index UNSIGNED BIG INT NOT NULL,
+    next_subaddress_index UNSIGNED BIG INT NOT NULL,
+    first_block_index UNSIGNED BIG INT NOT NULL,
+    next_block_index UNSIGNED BIG INT NOT NULL,
+    import_block_index UNSIGNED BIG INT,
+    name VARCHAR NOT NULL DEFAULT ''
+);
+INSERT INTO OLD_accounts SELECT
+    id,
+    account_id_hex,
+    account_key,
+    entropy,
+    main_subaddress_index,
+    change_subaddress_index,
+    next_subaddress_index,
+    first_block_index,
+    next_block_index,
+    import_block_index,
+    name
+FROM accounts;
+DROP TABLE accounts;
+ALTER TABLE OLD_accounts RENAME TO accounts;
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-30-021521_slip10_account_key/up.sql
+++ b/full-service/migrations/2021-03-30-021521_slip10_account_key/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE accounts
+ADD COLUMN key_derivation_version INTEGER NOT NULL DEFAULT 1;

--- a/full-service/migrations/2021-03-30-143827_key_derivation_version/down.sql
+++ b/full-service/migrations/2021-03-30-143827_key_derivation_version/down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE accounts
-DROP COLUMN key_derivation_version;

--- a/full-service/migrations/2021-03-30-143827_key_derivation_version/up.sql
+++ b/full-service/migrations/2021-03-30-143827_key_derivation_version/up.sql
@@ -1,2 +1,0 @@
-ALTER TABLE accounts
-ADD key_derivation_version INTEGER NOT NULL DEFAULT 1;

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -200,7 +200,7 @@ impl AccountModel for Account {
 
         Account::create(
             mnemonic.entropy(),
-            KEY_DERIVATION_FROM_MNEMONIC,
+            MNEMONIC_KEY_DERIVATION_VERSION,
             &account_key,
             first_block_index,
             import_block_index,
@@ -232,7 +232,7 @@ impl AccountModel for Account {
 
         Account::create(
             &entropy.bytes,
-            KEY_DERIVATION_FROM_ROOT_ENTROPY,
+            ROOT_ENTROPY_KEY_DERIVATION_VERSION,
             &account_key,
             first_block_index,
             import_block_index,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -93,7 +93,7 @@ pub trait AccountModel {
 
     /// Import account.
     #[allow(clippy::too_many_arguments)]
-    fn import(
+    fn import_legacy(
         entropy: &RootEntropy,
         name: Option<String>,
         import_block_index: u64,
@@ -286,7 +286,7 @@ impl AccountModel for Account {
         )
     }
 
-    fn import(
+    fn import_legacy(
         root_entropy: &RootEntropy,
         name: Option<String>,
         import_block_index: u64,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -30,8 +30,8 @@ pub const DEFAULT_CHANGE_SUBADDRESS_INDEX: u64 = 1;
 pub const DEFAULT_NEXT_SUBADDRESS_INDEX: u64 = 2;
 pub const DEFAULT_FIRST_BLOCK_INDEX: u64 = 0;
 
-pub const KEY_DERIVATION_FROM_ROOT_ENTROPY: u8 = 1;
-pub const KEY_DERIVATION_FROM_MNEMONIC: u8 = 2;
+pub const ROOT_ENTROPY_KEY_DERIVATION_VERSION: u8 = 1;
+pub const MNEMONIC_KEY_DERIVATION_VERSION: u8 = 2;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct AccountID(pub String);

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -14,9 +14,11 @@ use crate::db::{
 };
 
 use mc_account_keys::{AccountKey, RootEntropy, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
+use mc_account_keys_slip10::Slip10KeyGenerator;
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_transaction_core::ring_signature::KeyImage;
 
+use bip39::Mnemonic;
 use diesel::{
     prelude::*,
     r2d2::{ConnectionManager, PooledConnection},
@@ -27,6 +29,9 @@ use std::fmt;
 pub const DEFAULT_CHANGE_SUBADDRESS_INDEX: u64 = 1;
 pub const DEFAULT_NEXT_SUBADDRESS_INDEX: u64 = 2;
 pub const DEFAULT_FIRST_BLOCK_INDEX: u64 = 0;
+
+pub const KEY_DERIVATION_FROM_ROOT_ENTROPY: u8 = 1;
+pub const KEY_DERIVATION_FROM_MNEMONIC: u8 = 2;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct AccountID(pub String);
@@ -46,12 +51,19 @@ impl fmt::Display for AccountID {
 }
 
 pub trait AccountModel {
-    /// Create an account.
-    ///
-    /// Returns:
-    /// * (account_id, main_subaddress_b58)
-    #[allow(clippy::too_many_arguments)]
-    fn create(
+    fn create_from_mnemonic(
+        mnemonic: &Mnemonic,
+        first_block_index: Option<u64>,
+        import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
+        name: &str,
+        fog_report_url: Option<String>,
+        fog_report_id: Option<String>,
+        fog_authority_spki: Option<String>,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(AccountID, String), WalletDbError>;
+
+    fn create_from_root_entropy(
         entropy: &RootEntropy,
         first_block_index: Option<u64>,
         import_block_index: Option<u64>,
@@ -60,6 +72,22 @@ pub trait AccountModel {
         fog_report_url: Option<String>,
         fog_report_id: Option<String>,
         fog_authority_spki: Option<String>,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(AccountID, String), WalletDbError>;
+
+    /// Create an account.
+    ///
+    /// Returns:
+    /// * (account_id, main_subaddress_b58)
+    #[allow(clippy::too_many_arguments)]
+    fn create(
+        entropy: &[u8],
+        key_derivation_version: u8,
+        account_key: &AccountKey,
+        first_block_index: Option<u64>,
+        import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
+        name: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -126,7 +154,40 @@ pub trait AccountModel {
 }
 
 impl AccountModel for Account {
-    fn create(
+    fn create_from_mnemonic(
+        mnemonic: &Mnemonic,
+        first_block_index: Option<u64>,
+        import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
+        name: &str,
+        fog_report_url: Option<String>,
+        fog_report_id: Option<String>,
+        fog_authority_spki: Option<String>,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(AccountID, String), WalletDbError> {
+        let slip10_key = mnemonic.clone().derive_slip10_key(&[0]).unwrap();
+        let account_key = slip10_key
+            .try_into_account_key(
+                &fog_report_url.unwrap_or_else(|| "".to_string()),
+                &fog_report_id.unwrap_or_else(|| "".to_string()),
+                &hex::decode(fog_authority_spki.unwrap_or_else(|| "".to_string()))
+                    .expect("invalid spki"),
+            )
+            .unwrap();
+
+        Account::create(
+            mnemonic.entropy(),
+            KEY_DERIVATION_FROM_MNEMONIC,
+            &account_key,
+            first_block_index,
+            import_block_index,
+            next_subaddress_index,
+            name,
+            conn,
+        )
+    }
+
+    fn create_from_root_entropy(
         entropy: &RootEntropy,
         first_block_index: Option<u64>,
         import_block_index: Option<u64>,
@@ -137,8 +198,6 @@ impl AccountModel for Account {
         fog_authority_spki: Option<String>,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        use crate::db::schema::accounts;
-
         let root_id = RootIdentity {
             root_entropy: entropy.clone(),
             fog_report_url: fog_report_url.unwrap_or_else(|| "".to_string()),
@@ -148,16 +207,41 @@ impl AccountModel for Account {
         };
         let account_key = AccountKey::from(&root_id);
 
-        let account_id = AccountID::from(&account_key);
+        Account::create(
+            &entropy.bytes,
+            KEY_DERIVATION_FROM_ROOT_ENTROPY,
+            &account_key,
+            first_block_index,
+            import_block_index,
+            next_subaddress_index,
+            name,
+            conn,
+        )
+    }
+
+    fn create(
+        entropy: &[u8],
+        key_derivation_version: u8,
+        account_key: &AccountKey,
+        first_block_index: Option<u64>,
+        import_block_index: Option<u64>,
+        next_subaddress_index: Option<u64>,
+        name: &str,
+        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    ) -> Result<(AccountID, String), WalletDbError> {
+        use crate::db::schema::accounts;
+
+        let account_id = AccountID::from(account_key);
         let fb = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
 
         Ok(
             conn.transaction::<(AccountID, String), WalletDbError, _>(|| {
                 let new_account = NewAccount {
                     account_id_hex: &account_id.to_string(),
-                    account_key: &mc_util_serial::encode(&account_key), /* FIXME: WS-6 - add
-                                                                         * encryption */
-                    entropy: &entropy.bytes,
+                    account_key: &mc_util_serial::encode(account_key), /* FIXME: WS-6 - add
+                                                                        * encryption */
+                    entropy: &entropy,
+                    key_derivation_version: key_derivation_version as i32,
                     main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
                     change_subaddress_index: DEFAULT_CHANGE_SUBADDRESS_INDEX as i64,
                     next_subaddress_index: next_subaddress_index
@@ -203,7 +287,7 @@ impl AccountModel for Account {
     }
 
     fn import(
-        entropy: &RootEntropy,
+        root_entropy: &RootEntropy,
         name: Option<String>,
         import_block_index: u64,
         first_block_index: Option<u64>,
@@ -214,8 +298,8 @@ impl AccountModel for Account {
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
         Ok(conn.transaction::<Account, WalletDbError, _>(|| {
-            let (account_id, _public_address_b58) = Account::create(
-                entropy,
+            let (account_id, _public_address_b58) = Account::create_from_root_entropy(
+                root_entropy,
                 first_block_index,
                 Some(import_block_index),
                 next_subaddress_index,
@@ -401,7 +485,7 @@ mod tests {
         let account_key = AccountKey::from(&root_id);
         let account_id_hex = {
             let conn = wallet_db.get_conn().unwrap();
-            let (account_id_hex, _public_address_b58) = Account::create(
+            let (account_id_hex, _public_address_b58) = Account::create_from_root_entropy(
                 &root_id.root_entropy,
                 Some(0),
                 None,
@@ -428,6 +512,7 @@ mod tests {
             account_id_hex: account_id_hex.to_string(),
             account_key: mc_util_serial::encode(&account_key),
             entropy: root_id.root_entropy.bytes.to_vec(),
+            key_derivation_version: 1,
             main_subaddress_index: 0,
             change_subaddress_index: 1,
             next_subaddress_index: 2,
@@ -464,18 +549,19 @@ mod tests {
         // Add another account with no name, scanning from later
         let root_id_secondary = RootIdentity::from_random(&mut rng);
         let account_key_secondary = AccountKey::from(&root_id_secondary);
-        let (account_id_hex_secondary, _public_address_b58_secondary) = Account::create(
-            &root_id_secondary.root_entropy,
-            Some(51),
-            Some(50),
-            None,
-            "",
-            None,
-            None,
-            None,
-            &wallet_db.get_conn().unwrap(),
-        )
-        .unwrap();
+        let (account_id_hex_secondary, _public_address_b58_secondary) =
+            Account::create_from_root_entropy(
+                &root_id_secondary.root_entropy,
+                Some(51),
+                Some(50),
+                None,
+                "",
+                None,
+                None,
+                None,
+                &wallet_db.get_conn().unwrap(),
+            )
+            .unwrap();
         let res = Account::list_all(&wallet_db.get_conn().unwrap()).unwrap();
         assert_eq!(res.len(), 2);
 
@@ -486,6 +572,7 @@ mod tests {
             account_id_hex: account_id_hex_secondary.to_string(),
             account_key: mc_util_serial::encode(&account_key_secondary),
             entropy: root_id_secondary.root_entropy.bytes.to_vec(),
+            key_derivation_version: 1,
             main_subaddress_index: 0,
             change_subaddress_index: 1,
             next_subaddress_index: 2,
@@ -540,7 +627,7 @@ mod tests {
         let account_key = AccountKey::from(&root_id);
         let account_id = {
             let conn = wallet_db.get_conn().unwrap();
-            let (account_id_hex, _public_address_b58) = Account::create(
+            let (account_id_hex, _public_address_b58) = Account::create_from_root_entropy(
                 &root_id.root_entropy,
                 Some(0),
                 None,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -14,7 +14,7 @@ use crate::db::{
 };
 
 use mc_account_keys::{AccountKey, RootEntropy, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
-use mc_account_keys_slip10::Slip10KeyGenerator;
+use mc_account_keys_slip10::Slip10Key;
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_transaction_core::ring_signature::KeyImage;
 
@@ -189,8 +189,7 @@ impl AccountModel for Account {
         fog_authority_spki: Option<String>,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        let slip10_key = mnemonic.clone().derive_slip10_key(&[0]).unwrap();
-        let account_key = slip10_key
+        let account_key = Slip10Key::from(mnemonic.clone())
             .try_into_account_key(
                 &fog_report_url.unwrap_or_else(|| "".to_string()),
                 &fog_report_id.unwrap_or_else(|| "".to_string()),

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -77,7 +77,7 @@ pub struct Account {
     /// The private entropy for this account, used to derive the view and send
     /// keys which comprise the account_key.
     pub entropy: Vec<u8>,
-    /// Which version of key derivation path we are using.
+    /// Which version of key derivation we are using.
     pub key_derivation_version: i32,
     /// Default subadress that is given out to refer to this account.
     pub main_subaddress_index: i64,

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -77,6 +77,8 @@ pub struct Account {
     /// The private entropy for this account, used to derive the view and send
     /// keys which comprise the account_key.
     pub entropy: Vec<u8>,
+    /// Which version of key derivation path we are using.
+    pub key_derivation_version: i32,
     /// Default subadress that is given out to refer to this account.
     pub main_subaddress_index: i64,
     /// Subaddress used to return transaction "change" to self.
@@ -105,6 +107,7 @@ pub struct NewAccount<'a> {
     pub account_id_hex: &'a str,
     pub account_key: &'a [u8],
     pub entropy: &'a [u8],
+    pub key_derivation_version: i32,
     pub main_subaddress_index: i64,
     pub change_subaddress_index: i64,
     pub next_subaddress_index: i64,

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -13,6 +13,7 @@ table! {
         account_id_hex -> Text,
         account_key -> Binary,
         entropy -> Binary,
+        key_derivation_version -> Integer,
         main_subaddress_index -> BigInt,
         change_subaddress_index -> BigInt,
         next_subaddress_index -> BigInt,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -628,7 +628,7 @@ mod tests {
         }
 
         // Now we'll ingest them.
-        let (account_id, _address) = Account::create(
+        let (account_id, _address) = Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(0),
             None,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -979,7 +979,7 @@ mod tests {
 
         let root_id = RootIdentity::from_random(&mut rng);
         let alice_account_key = AccountKey::from(&root_id);
-        let (alice_account_id, _public_address_b58) = Account::create(
+        let (alice_account_id, _public_address_b58) = Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(1),
             None,
@@ -1244,7 +1244,7 @@ mod tests {
         // Create a new account and send some MOB to it
         let bob_root_id = RootIdentity::from_random(&mut rng);
         let bob_account_key = AccountKey::from(&bob_root_id);
-        let (bob_account_id, _public_address_b58) = Account::create(
+        let (bob_account_id, _public_address_b58) = Account::create_from_root_entropy(
             &bob_root_id.root_entropy,
             Some(1),
             None,
@@ -1306,7 +1306,7 @@ mod tests {
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
-        let (account_id_hex, _public_address_b58) = Account::create(
+        let (account_id_hex, _public_address_b58) = Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(1),
             None,
@@ -1415,7 +1415,7 @@ mod tests {
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
-        let (account_id_hex, _public_address_b58) = Account::create(
+        let (account_id_hex, _public_address_b58) = Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(0),
             None,
@@ -1471,7 +1471,7 @@ mod tests {
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger.clone());
 
-        Account::create(
+        Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(0),
             None,
@@ -1540,7 +1540,7 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
         let recipient_account_id = AccountID::from(&recipient_account_key);
-        Account::create(
+        Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(0),
             None,

--- a/full-service/src/json_rpc/account.rs
+++ b/full-service/src/json_rpc/account.rs
@@ -23,10 +23,6 @@ pub struct Account {
     /// Display name for the account.
     pub name: String,
 
-    /// The key derivation version this account uses to generate its account
-    /// keys
-    pub key_derivation_version: String,
-
     /// B58 Address Code for the account's main address. The main address is
     /// determined by the seed subaddress. It is not assigned to a single
     /// recipient, and should be consider a free-for-all address.
@@ -60,7 +56,6 @@ impl TryFrom<&db::models::Account> for Account {
             object: "account".to_string(),
             account_id: src.account_id_hex.clone(),
             name: src.name.clone(),
-            key_derivation_version: src.key_derivation_version.to_string(),
             main_address,
             next_subaddress_index: src.next_subaddress_index.to_string(),
             first_block_index: src.first_block_index.to_string(),

--- a/full-service/src/json_rpc/account.rs
+++ b/full-service/src/json_rpc/account.rs
@@ -23,6 +23,9 @@ pub struct Account {
     /// Display name for the account.
     pub name: String,
 
+    /// Key Derivation Version
+    pub key_derivation_version: String,
+
     /// B58 Address Code for the account's main address. The main address is
     /// determined by the seed subaddress. It is not assigned to a single
     /// recipient, and should be consider a free-for-all address.
@@ -55,6 +58,7 @@ impl TryFrom<&db::models::Account> for Account {
         Ok(Account {
             object: "account".to_string(),
             account_id: src.account_id_hex.clone(),
+            key_derivation_version: src.key_derivation_version.to_string(),
             name: src.name.clone(),
             main_address,
             next_subaddress_index: src.next_subaddress_index.to_string(),

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -2,7 +2,10 @@
 
 //! API definition for the Account Secrets object.
 
-use crate::{db::models::Account, json_rpc::account_key::AccountKey};
+use crate::{
+    db::{account::KEY_DERIVATION_FROM_ROOT_ENTROPY, models::Account},
+    json_rpc::account_key::AccountKey,
+};
 
 use bip39::{Language, Mnemonic};
 use serde_derive::{Deserialize, Serialize};
@@ -23,8 +26,7 @@ pub struct AccountSecrets {
     /// words.
     pub mnemonic: String,
 
-    /// The version number of the key derivation path used to derive the account
-    /// key from this mnemonic.
+    /// The key derivation version that this mnemonic goes with
     pub key_derivation_version: String,
 
     ///  Private keys for receiving and spending MobileCoin.
@@ -35,7 +37,7 @@ impl TryFrom<&Account> for AccountSecrets {
     type Error = String;
 
     fn try_from(src: &Account) -> Result<AccountSecrets, String> {
-        if src.key_derivation_version == 1 {
+        if src.key_derivation_version == KEY_DERIVATION_FROM_ROOT_ENTROPY as i32 {
             Err("Not allowed to export secrets for legacy account".to_string())
         } else {
             let account_key: mc_account_keys::AccountKey = mc_util_serial::decode(&src.account_key)

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -23,6 +23,9 @@ pub struct AccountSecrets {
     /// words.
     pub mnemonic: String,
 
+    /// The key derivation version that this mnemonic goes with
+    pub key_derivation_version: String,
+
     ///  Private keys for receiving and spending MobileCoin.
     pub account_key: AccountKey,
 }
@@ -44,6 +47,7 @@ impl TryFrom<&Account> for AccountSecrets {
                     .unwrap()
                     .phrase()
                     .to_string(),
+                key_derivation_version: src.key_derivation_version.to_string(),
                 account_key: AccountKey::try_from(&account_key).map_err(|err| {
                     format!(
                         "Could not convert account_key to json_rpc representation: {:?}",

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -18,12 +18,11 @@ pub struct AccountSecrets {
     /// The account ID for this account key in the wallet database.
     pub account_id: String,
 
-    /// The entropy from which this account key was derived, hex-encoded.
-    ///
-    /// Optional because an account can be created from only the AccountKey.
-    pub entropy: String,
+    /// The mnemonic from which this account key was derived, as a list of BIP39
+    /// words.
+    pub mnemonic: String,
 
-    ///  Private key for receiving and spending MobileCoin.
+    ///  Private keys for receiving and spending MobileCoin.
     pub account_key: AccountKey,
 }
 

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -3,7 +3,7 @@
 //! API definition for the Account Secrets object.
 
 use crate::{
-    db::{account::KEY_DERIVATION_FROM_ROOT_ENTROPY, models::Account},
+    db::{account::ROOT_ENTROPY_KEY_DERIVATION_VERSION, models::Account},
     json_rpc::account_key::AccountKey,
 };
 
@@ -37,7 +37,7 @@ impl TryFrom<&Account> for AccountSecrets {
     type Error = String;
 
     fn try_from(src: &Account) -> Result<AccountSecrets, String> {
-        if src.key_derivation_version == KEY_DERIVATION_FROM_ROOT_ENTROPY as i32 {
+        if src.key_derivation_version == ROOT_ENTROPY_KEY_DERIVATION_VERSION as i32 {
             Err("Not allowed to export secrets for legacy account".to_string())
         } else {
             let account_key: mc_account_keys::AccountKey = mc_util_serial::decode(&src.account_key)

--- a/full-service/src/json_rpc/account_secrets.rs
+++ b/full-service/src/json_rpc/account_secrets.rs
@@ -23,7 +23,8 @@ pub struct AccountSecrets {
     /// words.
     pub mnemonic: String,
 
-    /// The key derivation version that this mnemonic goes with
+    /// The version number of the key derivation path used to derive the account
+    /// key from this mnemonic.
     pub key_derivation_version: String,
 
     ///  Private keys for receiving and spending MobileCoin.

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -14,7 +14,7 @@ mod e2e {
         test_utils::{add_block_to_ledger_db, add_block_with_tx_proposal, MOB},
     };
     use bip39::{Language, Mnemonic};
-    use mc_account_keys_slip10::Slip10KeyGenerator;
+    use mc_account_keys_slip10::Slip10Key;
     use mc_common::logger::{test_with_logger, Logger};
     use mc_crypto_rand::rand_core::RngCore;
     use mc_ledger_db::Ledger;
@@ -158,11 +158,11 @@ mod e2e {
         let result = res.get("result").unwrap();
         let account_obj = result.get("account").unwrap();
         let public_address = account_obj.get("main_address").unwrap().as_str().unwrap();
-        assert_eq!(public_address, "8peJ2on3r9o7TC9y5Z1a5vH3gM6rtDQZjHvEB5TKwXzetHKiBCSWmK7gGsEKrhpN9xTpWjZncG1jfTw7QZL6ouME215jo8CKZiQpKXoDVag");
+        assert_eq!(public_address, "3CnfxAc2LvKw4FDNRVgj3GndwAhgQDd7v2Cne66GTUJyzBr3WzSikk9nJ5sCAb1jgSSKaqpWQtcEjV1nhoadVKjq2Soa8p3XZy6u2tpHdor");
         let account_id = account_obj.get("account_id").unwrap().as_str().unwrap();
         assert_eq!(
             account_id,
-            "a1d298fd819d91420210eb6dab0495cd3b9063552b2f4e9b8b3e688ed96c5a61"
+            "7872edf0d4094643213aabc92aa0d07379cfb58eda0722b21a44868f22f75b4e"
         );
 
         assert_eq!(
@@ -318,8 +318,7 @@ mod e2e {
 
         // Test that the mnemonic serializes correctly back to an AccountKey object
         let mnemonic = Mnemonic::from_phrase(phrase, Language::English).unwrap();
-        let slip_10_key = mnemonic.derive_slip10_key(&[0]).unwrap();
-        let account_key = slip_10_key
+        let account_key = Slip10Key::from(mnemonic.clone())
             .try_into_account_key(
                 &"".to_string(),
                 &"".to_string(),
@@ -388,11 +387,11 @@ mod e2e {
         let result = res.get("result").unwrap();
         let account_obj = result.get("account").unwrap();
         let public_address = account_obj.get("main_address").unwrap().as_str().unwrap();
-        assert_eq!(public_address, "V6qwRLUBogn9B4Wh9mupGhQ3vECKRetPFJwL8JGAggBhnp674a6a5eb4oLudJZC8atrD1v1fSVXDYdTVmf1qrC99M3VWg9GF8VxVBQdKo6PYSd4JmGxg2ZAroj5hzBSY5GrBPbdRq8Ww6cBdAyhAXpYE8WN3VijHXPkBZjgHTcBu8vnEdS97MBHssVWfQQzdpavuedBrt1oVzdKFG5Qbi2afmqQCAxAms62k8d4qoPmQtWq");
+        assert_eq!(public_address, "mpcKQqPcgbB2oPneTAuLiZu9ZHp9qNkQo9k6949dupe89HruwmEgvcyVRFFNQccsurgMaZBykWAR1tGwbZqw4FGckqJsAcs2Fc1912Bf84S2am1kLKiRdQWfWUm6rQ8LCw75k14htjiD4u1PfYxwEvXWHXPK2R7PpzfWv5xc8129J5DykCC6wRDUZiqDcesjf7zi91frhfWvX3E6QPnc6kKZj4mfZQPjFVkHdcXWAuQoaJc");
         let account_id = account_obj.get("account_id").unwrap().as_str().unwrap();
         assert_eq!(
             account_id,
-            "e98f1708f865005dc54cc43ddbfe2dfd8ab1759e4813ec83154cf1001e7915bc"
+            "e260179ba2bed78ed47266a55106a7365f96329203cd95edfc0915f08b7947ce"
         );
 
         // Export account secrets and check fog info.

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -60,6 +60,7 @@ pub enum JsonCommandRequest {
     },
     import_account {
         mnemonic: String,
+        key_derivation_version: String,
         name: Option<String>,
         first_block_index: Option<String>,
         next_subaddress_index: Option<String>,

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -59,6 +59,15 @@ pub enum JsonCommandRequest {
         name: Option<String>,
     },
     import_account {
+        mnemonic: String,
+        name: Option<String>,
+        first_block_index: Option<String>,
+        next_subaddress_index: Option<String>,
+        fog_report_url: Option<String>,
+        fog_report_id: Option<String>,
+        fog_authority_spki: Option<String>,
+    },
+    import_account_from_legacy_root_entropy {
         entropy: String,
         name: Option<String>,
         first_block_index: Option<String>,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -136,6 +136,9 @@ pub enum JsonCommandResponse {
     import_account {
         account: Account,
     },
+    import_account_from_legacy_root_entropy {
+        account: Account,
+    },
     export_account_secrets {
         account_secrets: AccountSecrets,
     },

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -120,12 +120,14 @@ where
                 .map(|ns| ns.parse::<u64>())
                 .transpose()
                 .map_err(format_error)?;
+            let kdv = key_derivation_version.parse::<u8>().map_err(format_error)?;
 
             JsonCommandResponse::import_account {
                 account: json_rpc::account::Account::try_from(
                     &service
                         .import_account(
                             mnemonic,
+                            kdv,
                             name,
                             fb,
                             ns,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -103,6 +103,41 @@ where
             }
         }
         JsonCommandRequest::import_account {
+            mnemonic,
+            name,
+            first_block_index,
+            next_subaddress_index,
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+        } => {
+            let fb = first_block_index
+                .map(|fb| fb.parse::<u64>())
+                .transpose()
+                .map_err(format_error)?;
+            let ns = next_subaddress_index
+                .map(|ns| ns.parse::<u64>())
+                .transpose()
+                .map_err(format_error)?;
+
+            JsonCommandResponse::import_account {
+                account: json_rpc::account::Account::try_from(
+                    &service
+                        .import_account(
+                            mnemonic,
+                            name,
+                            fb,
+                            ns,
+                            fog_report_url,
+                            fog_report_id,
+                            fog_authority_spki,
+                        )
+                        .map_err(format_error)?,
+                )
+                .map_err(format_error)?,
+            }
+        }
+        JsonCommandRequest::import_account_from_legacy_root_entropy {
             entropy,
             name,
             first_block_index,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -104,6 +104,7 @@ where
         }
         JsonCommandRequest::import_account {
             mnemonic,
+            key_derivation_version,
             name,
             first_block_index,
             next_subaddress_index,

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     db::{
-        account::{AccountID, AccountModel, KEY_DERIVATION_FROM_MNEMONIC},
+        account::{AccountID, AccountModel, MNEMONIC_KEY_DERIVATION_VERSION},
         models::Account,
         WalletDbError,
     },
@@ -177,7 +177,7 @@ where
             first_block_index,
         );
 
-        if key_derivation_version != KEY_DERIVATION_FROM_MNEMONIC {
+        if key_derivation_version != MNEMONIC_KEY_DERIVATION_VERSION {
             return Err(AccountServiceError::UnknownKeyDerivation(
                 key_derivation_version,
             ));

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -549,7 +549,7 @@ pub fn random_account_with_seed_values(
     let root_id = RootIdentity::from_random(&mut rng);
     let account_key = AccountKey::from(&root_id);
     {
-        Account::create(
+        Account::create_from_root_entropy(
             &root_id.root_entropy,
             Some(0),
             None,


### PR DESCRIPTION
* Support new SLIP0010 key derivation path.
* Implement this work: https://github.com/mobilecoinfoundation/mobilecoin/pull/776
* Turn root entropy into a legacy system.
* Support new key derivation path for account create, import, and export.
* Only support old key derivation path for import.