### PR TITLE
Display u64 in Origin Block

### DIFF
--- a/full-service/src/json_rpc/account.rs
+++ b/full-service/src/json_rpc/account.rs
@@ -61,8 +61,8 @@ impl TryFrom<&db::models::Account> for Account {
             key_derivation_version: src.key_derivation_version.to_string(),
             name: src.name.clone(),
             main_address,
-            next_subaddress_index: src.next_subaddress_index.to_string(),
-            first_block_index: src.first_block_index.to_string(),
+            next_subaddress_index: (src.next_subaddress_index as u64).to_string(),
+            first_block_index: (src.first_block_index as u64).to_string(),
             recovery_mode: false,
         })
     }

--- a/full-service/src/json_rpc/address.rs
+++ b/full-service/src/json_rpc/address.rs
@@ -43,7 +43,7 @@ impl From<&AssignedSubaddress> for Address {
             public_address: src.assigned_subaddress_b58.clone(),
             account_id: src.account_id_hex.clone(),
             metadata: src.comment.clone(),
-            subaddress_index: src.subaddress_index.to_string(),
+            subaddress_index: (src.subaddress_index as u64).to_string(),
             offset_count: src.id.to_string(),
         }
     }

--- a/full-service/src/json_rpc/balance.rs
+++ b/full-service/src/json_rpc/balance.rs
@@ -49,7 +49,7 @@ pub struct Balance {
     /// been created in the wallet for outgoing transactions.
     pub secreted_pmob: String,
 
-    /// rphaned pico MOB. The orphaned value represents the Txos which were
+    /// Orphaned pico MOB. The orphaned value represents the Txos which were
     /// view-key matched, but which can not be spent until their subaddress
     /// index is recovered.
     pub orphaned_pmob: String,

--- a/full-service/src/json_rpc/transaction_log.rs
+++ b/full-service/src/json_rpc/transaction_log.rs
@@ -113,10 +113,14 @@ impl TransactionLog {
             } else {
                 Some(assigned_address_id)
             },
-            value_pmob: transaction_log.value.to_string(),
-            fee_pmob: transaction_log.fee.map(|x| x.to_string()),
-            submitted_block_index: transaction_log.submitted_block_index.map(|b| b.to_string()),
-            finalized_block_index: transaction_log.finalized_block_index.map(|b| b.to_string()),
+            value_pmob: (transaction_log.value as u64).to_string(),
+            fee_pmob: transaction_log.fee.map(|x| (x as u64).to_string()),
+            submitted_block_index: transaction_log
+                .submitted_block_index
+                .map(|b| (b as u64).to_string()),
+            finalized_block_index: transaction_log
+                .finalized_block_index
+                .map(|b| (b as u64).to_string()),
             status: transaction_log.status.clone(),
             input_txo_ids: associated_txos.inputs.clone(),
             output_txo_ids: associated_txos.outputs.clone(),

--- a/full-service/src/json_rpc/txo.rs
+++ b/full-service/src/json_rpc/txo.rs
@@ -115,8 +115,14 @@ impl From<&TxoDetails> for Txo {
             object: "txo".to_string(),
             txo_id_hex: txo_details.txo.txo_id_hex.clone(),
             value_pmob: (txo_details.txo.value as u64).to_string(),
-            received_block_index: txo_details.txo.received_block_index.map(|x| x.to_string()),
-            spent_block_index: txo_details.txo.spent_block_index.map(|x| x.to_string()),
+            received_block_index: txo_details
+                .txo
+                .received_block_index
+                .map(|x| (x as u64).to_string()),
+            spent_block_index: txo_details
+                .txo
+                .spent_block_index
+                .map(|x| (x as u64).to_string()),
             is_spent_recovered: false,
             received_account_id: txo_details
                 .received_to_account
@@ -131,7 +137,10 @@ impl From<&TxoDetails> for Txo {
             target_key: hex::encode(&txo_details.txo.target_key),
             public_key: hex::encode(&txo_details.txo.public_key),
             e_fog_hint: hex::encode(&txo_details.txo.e_fog_hint),
-            subaddress_index: txo_details.txo.subaddress_index.map(|s| s.to_string()),
+            subaddress_index: txo_details
+                .txo
+                .subaddress_index
+                .map(|s| (s as u64).to_string()),
             assigned_address: txo_details
                 .received_to_assigned_subaddress
                 .clone()

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -722,7 +722,7 @@ mod tests {
         let balance = service
             .get_balance_for_account(&AccountID(alice.account_id_hex.clone()))
             .unwrap();
-        assert_eq!(balance.unspent, 100 * MOB as u64);
+        assert_eq!(balance.unspent, 100 * MOB as u128);
 
         // Create a gift code for Bob
         let (tx_proposal, gift_code_b58) = service
@@ -897,7 +897,7 @@ mod tests {
         let balance = service
             .get_balance_for_account(&AccountID(alice.account_id_hex.clone()))
             .unwrap();
-        assert_eq!(balance.unspent, 100 * MOB as u64);
+        assert_eq!(balance.unspent, 100 * MOB as u128);
 
         // Create a gift code for Bob
         let (tx_proposal, gift_code_b58) = service

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -526,7 +526,7 @@ pub fn process_txos(
 mod tests {
     use super::*;
     use crate::{
-        service::account::AccountService,
+        service::{account::AccountService, balance::BalanceService},
         test_utils::{add_block_to_ledger_db, get_test_ledger, setup_wallet_service, MOB},
     };
     use mc_account_keys::{AccountKey, RootEntropy, RootIdentity};
@@ -608,6 +608,10 @@ mod tests {
             assert_eq!(txo.txo.value as u64, expected_value);
         }
 
-        // Now verify that the service gets the Txos with the correct value
+        // Now verify that the service gets the balance with the correct value
+        let balance = service
+            .get_balance_for_account(&AccountID::from(&account_key))
+            .expect("Could not get balance");
+        assert_eq!(balance.unspent, 250_000_000 * MOB as u128);
     }
 }

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -607,5 +607,7 @@ mod tests {
             let txo = Txo::get(&txo_id, &wallet_db.get_conn().unwrap()).expect("Could not get txo");
             assert_eq!(txo.txo.value as u64, expected_value);
         }
+
+        // Now verify that the service gets the Txos with the correct value
     }
 }

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -335,7 +335,7 @@ mod tests {
         let balance = service
             .get_balance_for_account(&AccountID(alice.account_id_hex.clone()))
             .unwrap();
-        assert_eq!(balance.unspent, 100 * MOB as u64);
+        assert_eq!(balance.unspent, 100 * MOB as u128);
 
         // Add an account for Bob
         let bob = service

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -136,7 +136,7 @@ mod tests {
         // Verify balance for Alice
         let balance = service.get_balance_for_account(&alice_account_id).unwrap();
 
-        assert_eq!(balance.unspent, 100 * MOB as u64);
+        assert_eq!(balance.unspent, 100 * MOB as u128);
 
         // Verify that we have 1 txo
         let txos = service.list_txos(&alice_account_id).unwrap();


### PR DESCRIPTION
### Motivation

When investigating the origin block for an upcoming blog post, it became apparent that the jsonrpc layer was not displaying the value correct for a large u64. This PR fixes that.

### In this PR
* casts the DB's i64 to u64 before displaying
* Adds tests for sync and jsonrpc display of txo

