### PR TITLE
Assigning Next Subaddress Now Checks For Any Owned Orphaned TXOs

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -692,7 +692,6 @@ mod tests {
             account_id_hex
         };
         let account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-        // let decoded_entropy = RootEntropy::try_from(&account.entropy).unwrap();
         let decoded_entropy = RootEntropy::try_from(account.entropy.as_slice()).unwrap();
         assert_eq!(decoded_entropy, root_id.root_entropy);
         let decoded_account_key: AccountKey = mc_util_serial::decode(&account.account_key).unwrap();

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -158,7 +158,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
                 .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
                 .execute(conn)?;
 
-            // Find and repair orphaned txos at this subaddress. 
+            // Find and repair orphaned txos at this subaddress.
             let orphaned_txos = Txo::list_by_status(&account_id_hex, &TXO_STATUS_ORPHANED, &conn)?;
 
             for orphaned_txo in orphaned_txos.iter() {

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -5,8 +5,18 @@
 
 use crate::db::{
     account::{AccountID, AccountModel},
+    account_txo_status::AccountTxoStatusModel,
     b58_encode,
-    models::{Account, AssignedSubaddress, NewAssignedSubaddress},
+    models::{
+        Account, AccountTxoStatus, AssignedSubaddress, NewAssignedSubaddress, Txo,
+        TXO_STATUS_ORPHANED,
+    },
+    txo::TxoModel,
+};
+
+use mc_transaction_core::{
+    onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
+    ring_signature::KeyImage,
 };
 
 use mc_account_keys::AccountKey;
@@ -123,6 +133,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
             let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
 
             let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+            let account_view_key = account_key.view_key();
             let subaddress_index = account.next_subaddress_index;
             let subaddress = account_key.subaddress(subaddress_index as u64);
 
@@ -146,6 +157,49 @@ impl AssignedSubaddressModel for AssignedSubaddress {
             diesel::update(accounts.filter(dsl_account_id_hex.eq(account_id_hex)))
                 .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
                 .execute(conn)?;
+
+            let orphaned_txos = Txo::list_by_status(&account_id_hex, &TXO_STATUS_ORPHANED, &conn)?;
+
+            for orphaned_txo in orphaned_txos.iter() {
+                let tx_out_target_key: RistrettoPublic =
+                    mc_util_serial::decode(&orphaned_txo.target_key).unwrap();
+                let tx_public_key: RistrettoPublic =
+                    mc_util_serial::decode(&orphaned_txo.public_key).unwrap();
+
+                let txo_subaddress_spk: RistrettoPublic = recover_public_subaddress_spend_key(
+                    &account_view_key.view_private_key,
+                    &tx_out_target_key,
+                    &tx_public_key,
+                );
+
+                if txo_subaddress_spk == *subaddress.spend_public_key() {
+                    // get the current account status mapping
+                    let account_txo_status =
+                        AccountTxoStatus::get(&account_id_hex, &orphaned_txo.txo_id_hex, &conn)
+                            .unwrap();
+
+                    // update the status to unspent
+                    account_txo_status.set_unspent(&conn)?;
+
+                    let onetime_private_key = recover_onetime_private_key(
+                        &tx_public_key,
+                        account_key.view_private_key(),
+                        &account_key.subaddress_spend_private(subaddress_index as u64),
+                    );
+
+                    let key_image = KeyImage::from(&onetime_private_key);
+
+                    let key_image_bytes = mc_util_serial::encode(&key_image);
+
+                    // update the account status mapping
+                    diesel::update(orphaned_txo)
+                        .set((
+                            crate::db::schema::txos::subaddress_index.eq(subaddress_index),
+                            crate::db::schema::txos::key_image.eq(key_image_bytes),
+                        ))
+                        .execute(conn)?;
+                }
+            }
 
             Ok((subaddress_b58, subaddress_index))
         })?)

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1208,7 +1208,7 @@ mod tests {
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
-        assert_eq!(unspent.len(), 1);
+        assert_eq!(unspent.len(), 2);
 
         // The type should still be "minted"
         let minted = Txo::list_by_type(
@@ -1267,7 +1267,7 @@ mod tests {
                 logger.clone(),
             );
         assert_eq!(output_value, 72 * MOB);
-        assert_eq!(change_value, (894.98 * (MOB as f64)) as i64);
+        assert_eq!(change_value, (927.98 * (MOB as f64)) as i64);
 
         // Add the minted Txos to the ledger
         add_block_with_db_txos(

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -1054,6 +1054,35 @@ mod e2e {
         assert_eq!("0", unspent_pmob);
         assert_eq!("100000000000000", orphaned_pmob);
 
+        // assign next subaddress for account
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "assign_address_for_account",
+            "params": {
+                "account_id": account_id,
+                "metadata": "subaddress_index_2",
+            }
+        });
+        dispatch(&client, body, &logger);
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_balance_for_account",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance = result.get("balance").unwrap();
+        let unspent_pmob = balance.get("unspent_pmob").unwrap().as_str().unwrap();
+        let orphaned_pmob = balance.get("orphaned_pmob").unwrap().as_str().unwrap();
+
+        assert_eq!("100000000000000", unspent_pmob);
+        assert_eq!("0", orphaned_pmob);
+
         let body = json!({
             "jsonrpc": "2.0",
             "id": 1,


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=VuNIsY6JdUw](You Belong With Me)

### Motivation

When assigning an new subaddress, we always want to check to see if there are any orphaned txos that belong to it.

### In this PR
* see above.

### Future Work
* A full recovery mode

### To Do
- [ ] Add tests to cover specifics
- [ ] Update API for getting txo's to optionally include a status field, to only get TXO's of that status for an account