### PR TITLE
Updated Assigned Subaddress B58 of transaction log when orphaned TXO is picked up by a subaddress

### DIFF
--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -129,6 +129,10 @@ impl AssignedSubaddressModel for AssignedSubaddress {
         use crate::db::schema::{
             accounts::dsl::{account_id_hex as dsl_account_id_hex, accounts},
             assigned_subaddresses,
+            transaction_logs::dsl::{
+                account_id_hex as tx_log_account_id_hex,
+                transaction_id_hex as tx_log_transaction_id_hex, transaction_logs,
+            },
         };
 
         Ok(conn.transaction::<(String, i64), WalletDbError, _>(|| {
@@ -201,6 +205,17 @@ impl AssignedSubaddressModel for AssignedSubaddress {
                             crate::db::schema::txos::key_image.eq(key_image_bytes),
                         ))
                         .execute(conn)?;
+
+                    diesel::update(
+                        transaction_logs
+                            .filter(tx_log_transaction_id_hex.eq(&orphaned_txo.txo_id_hex))
+                            .filter(tx_log_account_id_hex.eq(account_id_hex)),
+                    )
+                    .set(
+                        (crate::db::schema::transaction_logs::assigned_subaddress_b58
+                            .eq(&subaddress_b58),),
+                    )
+                    .execute(conn)?;
                 }
             }
 

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -71,7 +71,6 @@ where
         &self,
         account_id: &AccountID,
         metadata: Option<&str>,
-        // FIXME: WS-32 - add "sync from block"
     ) -> Result<AssignedSubaddress, AddressServiceError> {
         let conn = &self.wallet_db.get_conn()?;
 


### PR DESCRIPTION
Quick fix for bug with transaction logs assigned subaddress index not updating when an orphaned txo was claimed by a subaddress