### PR TITLE
uprev mobilecoin, add bip39 entropy support to giftcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.1",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.1",
+ "lazy_static",
+ "loom",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1081,19 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061d3be1afec479d56fa3bd182bf966c7999ec175fcfdb87ac14d417241366c6"
+dependencies = [
+ "cc",
+ "libc",
+ "log 0.4.11",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1612,6 +1650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "loom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a6650b2f722ae8c0e2ebc46d07f80c9923464fc206d962332f1eff83143530"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -2269,6 +2318,7 @@ dependencies = [
  "libz-sys",
  "lmdb-rkv",
  "mc-account-keys",
+ "mc-account-keys-slip10",
  "mc-api",
  "mc-attest-core",
  "mc-common",
@@ -2303,6 +2353,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempdir",
+ "tiny-bip39",
 ]
 
 [[package]]
@@ -2623,6 +2674,7 @@ dependencies = [
  "mc-util-uri",
  "mc-watcher-api",
  "prost",
+ "rayon",
  "serde",
  "structopt",
  "toml 0.5.8",
@@ -2642,6 +2694,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg 1.0.1",
+]
 
 [[package]]
 name = "merlin"
@@ -3171,15 +3232,15 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.22.0"
+version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f72884896d22e0da0e5b266cb9a780b791f6c3b2f5beab6368d6cd4f0dbb86"
+checksum = "1b7f4a129bb3754c25a4e04032a90173c68f85168f77118ac4cb4936e7f06f92"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.22.0"
+version = "2.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8217a1652dbc91d19c509c558234145faed729191a966896414e5889f62d543"
+checksum = "e5d2fa3a461857508103b914da60dd7b489c1a834967c2e214ecc1496f0c486a"
 dependencies = [
  "protobuf",
 ]
@@ -3419,6 +3480,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg 1.0.1",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel 0.5.0",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.1",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3670,6 +3756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3805,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/down.sql
+++ b/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/down.sql
@@ -1,0 +1,31 @@
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE OLD_gift_codes (
+  id INTEGER NOT NULL PRIMARY KEY,
+  gift_code_b58 VARCHAR NOT NULL,
+  entropy BLOB NOT NULL,
+  txo_public_key BLOB NOT NULL,
+  value UNSIGNED BIG INT NOT NULL,
+  memo TEXT NOT NULL DEFAULT '',
+  account_id_hex VARCHAR NOT NULL DEFAULT '',
+  txo_id_hex VARCHAR NOT NULL,
+  FOREIGN KEY (account_id_hex) REFERENCES accounts(account_id_hex),
+  FOREIGN KEY (txo_id_hex) REFERENCES txos(txo_id_hex)
+);
+
+INSERT INTO OLD_gift_codes SELECT
+  id,
+  gift_code_b58,
+  root_entropy,
+  txo_public_key,
+  value,
+  memo,
+  account_id_hex,
+  txo_id_hex
+FROM gift_codes;
+
+DROP TABLE gift_codes;
+ALTER TABLE OLD_gift_codes RENAME TO gift_codes;
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/up.sql
+++ b/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/up.sql
@@ -1,0 +1,33 @@
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE NEW_gift_codes (
+  id INTEGER NOT NULL PRIMARY KEY,
+  gift_code_b58 VARCHAR NOT NULL,
+  root_entropy BLOB,
+  bip39_entropy BLOB,
+  txo_public_key BLOB NOT NULL,
+  value UNSIGNED BIG INT NOT NULL,
+  memo TEXT NOT NULL DEFAULT '',
+  account_id_hex VARCHAR NOT NULL DEFAULT '',
+  txo_id_hex VARCHAR NOT NULL,
+  FOREIGN KEY (account_id_hex) REFERENCES accounts(account_id_hex),
+  FOREIGN KEY (txo_id_hex) REFERENCES txos(txo_id_hex)
+);
+
+INSERT INTO NEW_gift_codes SELECT
+  id,
+  gift_code_b58,
+  entropy,
+  NULL,
+  txo_public_key,
+  value,
+  memo,
+  account_id_hex,
+  txo_id_hex
+FROM gift_codes;
+
+DROP TABLE gift_codes;
+ALTER TABLE NEW_gift_codes RENAME TO gift_codes;
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -235,7 +235,7 @@ impl APIConfig {
         transactions_fetcher: &ReqwestTransactionsFetcher,
     ) -> LedgerDB {
         // Attempt to open the ledger and see if it has anything in it.
-        if let Ok(ledger_db) = LedgerDB::open(self.ledger_db.clone()) {
+        if let Ok(ledger_db) = LedgerDB::open(&self.ledger_db) {
             if let Ok(num_blocks) = ledger_db.num_blocks() {
                 if num_blocks > 0 {
                     // Successfully opened a ledger that has blocks in it.
@@ -283,7 +283,7 @@ impl APIConfig {
             None => {
                 std::fs::create_dir_all(self.ledger_db.clone())
                     .expect("Could not create ledger dir");
-                LedgerDB::create(self.ledger_db.clone()).expect("Could not create ledger_db");
+                LedgerDB::create(&self.ledger_db).expect("Could not create ledger_db");
                 if !self.offline {
                     log::info!(
                         logger,
@@ -293,8 +293,7 @@ impl APIConfig {
                     let block_data = transactions_fetcher
                         .get_origin_block_and_transactions()
                         .expect("Failed to download initial transactions");
-                    let mut db =
-                        LedgerDB::open(self.ledger_db.clone()).expect("Could not open ledger_db");
+                    let mut db = LedgerDB::open(&self.ledger_db).expect("Could not open ledger_db");
                     db.append_block(
                         block_data.block(),
                         block_data.contents(),
@@ -308,7 +307,7 @@ impl APIConfig {
 
         // Open ledger and verify it has (at least) the origin block.
         log::debug!(logger, "Opening Ledger DB {:?}", self.ledger_db);
-        let ledger_db = LedgerDB::open(self.ledger_db.clone())
+        let ledger_db = LedgerDB::open(&self.ledger_db)
             .unwrap_or_else(|_| panic!("Could not open ledger db inside {:?}", self.ledger_db));
 
         let num_blocks = ledger_db

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -291,7 +291,8 @@ pub struct NewTransactionTxoType<'a> {
 pub struct GiftCode {
     pub id: i32,
     pub gift_code_b58: String,
-    pub entropy: Vec<u8>,
+    pub root_entropy: Option<Vec<u8>>,
+    pub bip39_entropy: Option<Vec<u8>>,
     pub txo_public_key: Vec<u8>,
     pub value: i64,
     pub memo: String,
@@ -303,7 +304,8 @@ pub struct GiftCode {
 #[table_name = "gift_codes"]
 pub struct NewGiftCode<'a> {
     pub gift_code_b58: &'a str,
-    pub entropy: &'a Vec<u8>,
+    pub root_entropy: Option<Vec<u8>>,
+    pub bip39_entropy: Option<Vec<u8>>,
     pub txo_public_key: &'a Vec<u8>,
     pub value: i64,
     pub memo: &'a str,

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -41,7 +41,8 @@ table! {
     gift_codes (id) {
         id -> Integer,
         gift_code_b58 -> Text,
-        entropy -> Binary,
+        root_entropy -> Nullable<Binary>,
+        bip39_entropy -> Nullable<Binary>,
         txo_public_key -> Binary,
         value -> BigInt,
         memo -> Text,

--- a/full-service/src/json_rpc/gift_code.rs
+++ b/full-service/src/json_rpc/gift_code.rs
@@ -18,8 +18,11 @@ pub struct GiftCode {
     /// The base58-encoded gift code string to share.
     pub gift_code_b58: String,
 
-    /// The entropy for the account in this gift code.
-    pub entropy: String,
+    /// The root entropy for the account in this gift code.
+    pub root_entropy: String,
+
+    /// The root entropy for the account in this gift code.
+    pub bip39_entropy: String,
 
     /// The amount of MOB contained in the gift code account.
     pub value_pmob: String,
@@ -40,7 +43,16 @@ impl From<&db::models::GiftCode> for GiftCode {
         GiftCode {
             object: "gift_code".to_string(),
             gift_code_b58: src.gift_code_b58.clone(),
-            entropy: hex::encode(&src.entropy),
+            root_entropy: src
+                .root_entropy
+                .as_ref()
+                .map(hex::encode)
+                .unwrap_or_default(),
+            bip39_entropy: src
+                .bip39_entropy
+                .as_ref()
+                .map(hex::encode)
+                .unwrap_or_default(),
             value_pmob: src.value.to_string(),
             memo: src.memo.clone(),
             account_id: src.account_id_hex.to_string(),

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -151,8 +151,8 @@ pub fn get_test_ledger(
 pub fn generate_ledger_db(path: &str) -> LedgerDB {
     // DELETE the old database if it already exists.
     let _ = std::fs::remove_file(format!("{}/data.mdb", path));
-    LedgerDB::create(PathBuf::from(path)).expect("Could not create ledger_db");
-    let db = LedgerDB::open(PathBuf::from(path)).expect("Could not open ledger_db");
+    LedgerDB::create(&PathBuf::from(path)).expect("Could not create ledger_db");
+    let db = LedgerDB::open(&PathBuf::from(path)).expect("Could not open ledger_db");
     db
 }
 


### PR DESCRIPTION
### Motivation

As part of my work on upgrading our Rust version I tried upreving `mobilecoin` in this repo in order to bring in some `clippy` fixes but ran into issues that arise from the gift codes changing to support two entropy types (the old root and the new bip39).

### In this PR
* Uprev `mobilecoin` and get `full-service` to support the new bip39-entropied gift codes.

