### PR TITLE
Statically link the correct version of sqlite3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,8 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
+version = "1.4.6"
+source = "git+https://github.com/eranrund/diesel?rev=25592f0383a1d1628db7d2db6c1fb02614a978c1#25592f0383a1d1628db7d2db6c1fb02614a978c1"
 dependencies = [
  "byteorder",
  "diesel_derives",
@@ -1582,10 +1581,11 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
+checksum = "19cb1effde5f834799ac5e5ef0e40d45027cd74f271b1de786ba8abb30e2164d"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2210,6 +2210,7 @@ dependencies = [
  "dotenv",
  "grpcio",
  "hex",
+ "libsqlite3-sys",
  "mc-account-keys",
  "mc-account-keys-slip10",
  "mc-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
-source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
+source = "git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
 dependencies = [
  "aead",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b
 bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
 
 # We need to patch aes-gcm so we can make some fields/functions/structs pub in order to have a constant time decrypt
-aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
+aes-gcm = { git = "https://github.com/mobilecoinofficial/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
 
 # grpcio patched with metadata
 grpcio = { git = "https://github.com/jcape/grpc-rs", rev = "2ad042e9e65ecb664a60e034d0a899a8760d81d3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c57
 grpcio = { git = "https://github.com/jcape/grpc-rs", rev = "2ad042e9e65ecb664a60e034d0a899a8760d81d3" }
 # Code gen patched with metadata
 grpcio-compiler = { git = "https://github.com/jcape/grpc-rs", rev = "2ad042e9e65ecb664a60e034d0a899a8760d81d3" }
+
+# Overridden in order to bump libsqlite3-sys. This allows us to statically link a more recent version of SQLite3.
+diesel = { git = "https://github.com/eranrund/diesel", rev = "25592f0383a1d1628db7d2db6c1fb02614a978c1" }

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ See [CONTRIBUTING](./CONTRIBUTING.md).
 
 To add or edit tables:
 
+1. Ensure that you have `diesel_cli` installed and that it is using the current sqlite version: `cargo install diesel_cli --no-default-features --features "sqlite sqlite-bundled" --git https://github.com/eranrund/diesel --rev 25592f0383a1d1628db7d2db6c1fb02614a978c1`
 1. `cd full-service`
 1. Create a migration with `diesel migration generate <migration_name>`
 1. Edit the migrations/<migration_name>/up.sql and down.sql.

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -40,13 +40,14 @@ mc-util-uri = { path = "../mobilecoin/util/uri" }
 
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 crossbeam-channel = "0.4"
-diesel = { version = "1.4", features = ["sqlite"] }
+diesel = { version = "1.4.6", features = ["sqlite"] }
 diesel-derive-enum = { version = "1", features = ["sqlite"] }
 diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
 displaydoc = {version = "0.1", default-features = false }
 dotenv = "0.15.0"
 grpcio = "0.6.0"
 hex = {version = "0.4", default-features = false }
+libsqlite3-sys = { version = ">=0.8.0, <=0.22.1", features = ["min_sqlite_version_3_7_16", "bundled"] }
 num_cpus = "1.12"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.7", default-features = false }
@@ -55,8 +56,8 @@ retry = "1.2"
 rocket = { version = "0.4.5", default-features = false }
 rocket_contrib = { version = "0.4.5", default-features = false, features = ["json", "diesel_sqlite_pool"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_derive = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 structopt = "0.3"
 strum = { version = "0.20", features = ["derive"] }
 strum_macros = "0.20"
@@ -72,4 +73,4 @@ bs58 = "0.3.0"
 
 [build-dependencies]
 # clippy fails to run without this.
-diesel = { version = "1.4.5", features = ["sqlite"] }
+diesel = { version = "1.4.6", features = ["sqlite"] }

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -29,6 +29,8 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
             }
             if self.enable_foreign_keys {
                 conn.batch_execute("PRAGMA foreign_keys = ON;")?;
+            } else {
+                conn.batch_execute("PRAGMA foreign_keys = OFF;")?;
             }
             if let Some(d) = self.busy_timeout {
                 conn.batch_execute(&format!("PRAGMA busy_timeout = {};", d.as_millis()))?;


### PR DESCRIPTION
### Motivation

Statically linking sqlite3 means we will have an easier time distributing binaries. Ensuring that all users are running with the same version would make debugging easier if any issues arise. 

### In this PR
* Switch to a fork of `diesel` that allows using a newer version of the `libsqlite3-sys` crate. That version has the required sqlite3 3.35.4 bundled.

