### PR TITLE
Clean up usage of database transactions.

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -257,54 +257,49 @@ impl AccountModel for Account {
         let account_id = AccountID::from(account_key);
         let fb = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
 
-        conn.transaction::<(AccountID, String), WalletDbError, _>(|| {
-            let new_account = NewAccount {
-                account_id_hex: &account_id.to_string(),
-                account_key: &mc_util_serial::encode(account_key), /* FIXME: WS-6 - add
-                                                                    * encryption */
-                entropy: &entropy,
-                key_derivation_version: key_derivation_version as i32,
-                main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
-                change_subaddress_index: DEFAULT_CHANGE_SUBADDRESS_INDEX as i64,
-                next_subaddress_index: next_subaddress_index
-                    .unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
-                    as i64,
-                first_block_index: fb as i64,
-                next_block_index: fb as i64,
-                import_block_index: import_block_index.map(|i| i as i64),
-                name,
-            };
+        let new_account = NewAccount {
+            account_id_hex: &account_id.to_string(),
+            account_key: &mc_util_serial::encode(account_key), /* FIXME: WS-6 - add
+                                                                * encryption */
+            entropy: &entropy,
+            key_derivation_version: key_derivation_version as i32,
+            main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
+            change_subaddress_index: DEFAULT_CHANGE_SUBADDRESS_INDEX as i64,
+            next_subaddress_index: next_subaddress_index.unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
+                as i64,
+            first_block_index: fb as i64,
+            next_block_index: fb as i64,
+            import_block_index: import_block_index.map(|i| i as i64),
+            name,
+        };
 
-            diesel::insert_into(accounts::table)
-                .values(&new_account)
-                .execute(conn)?;
+        diesel::insert_into(accounts::table)
+            .values(&new_account)
+            .execute(conn)?;
 
-            let main_subaddress_b58 = AssignedSubaddress::create(
-                &account_key,
-                None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
-                       * always for main? */
-                DEFAULT_SUBADDRESS_INDEX,
-                "Main",
-                &conn,
-            )?;
+        let main_subaddress_b58 = AssignedSubaddress::create(
+            &account_key,
+            None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
+                   * always for main? */
+            DEFAULT_SUBADDRESS_INDEX,
+            "Main",
+            &conn,
+        )?;
 
-            let _change_subaddress_b58 = AssignedSubaddress::create(
-                &account_key,
-                None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
-                       * always for main? */
-                DEFAULT_CHANGE_SUBADDRESS_INDEX,
-                "Change",
-                &conn,
-            )?;
+        let _change_subaddress_b58 = AssignedSubaddress::create(
+            &account_key,
+            None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
+                   * always for main? */
+            DEFAULT_CHANGE_SUBADDRESS_INDEX,
+            "Change",
+            &conn,
+        )?;
 
-            for subaddress_index in
-                2..next_subaddress_index.unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX)
-            {
-                AssignedSubaddress::create(&account_key, None, subaddress_index, "", &conn)?;
-            }
+        for subaddress_index in 2..next_subaddress_index.unwrap_or(DEFAULT_NEXT_SUBADDRESS_INDEX) {
+            AssignedSubaddress::create(&account_key, None, subaddress_index, "", &conn)?;
+        }
 
-            Ok((account_id, main_subaddress_b58))
-        })
+        Ok((account_id, main_subaddress_b58))
     }
 
     fn import(
@@ -318,20 +313,18 @@ impl AccountModel for Account {
         fog_authority_spki: Option<String>,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
-        conn.transaction::<Account, WalletDbError, _>(|| {
-            let (account_id, _public_address_b58) = Account::create_from_mnemonic(
-                mnemonic,
-                first_block_index,
-                Some(import_block_index),
-                next_subaddress_index,
-                &name.unwrap_or_else(|| "".to_string()),
-                fog_report_url,
-                fog_report_id,
-                fog_authority_spki,
-                conn,
-            )?;
-            Account::get(&account_id, &conn)
-        })
+        let (account_id, _public_address_b58) = Account::create_from_mnemonic(
+            mnemonic,
+            first_block_index,
+            Some(import_block_index),
+            next_subaddress_index,
+            &name.unwrap_or_else(|| "".to_string()),
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+            conn,
+        )?;
+        Account::get(&account_id, &conn)
     }
 
     fn import_legacy(
@@ -345,20 +338,18 @@ impl AccountModel for Account {
         fog_authority_spki: Option<String>,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
-        conn.transaction::<Account, WalletDbError, _>(|| {
-            let (account_id, _public_address_b58) = Account::create_from_root_entropy(
-                root_entropy,
-                first_block_index,
-                Some(import_block_index),
-                next_subaddress_index,
-                &name.unwrap_or_else(|| "".to_string()),
-                fog_report_url,
-                fog_report_id,
-                fog_authority_spki,
-                conn,
-            )?;
-            Account::get(&account_id, &conn)
-        })
+        let (account_id, _public_address_b58) = Account::create_from_root_entropy(
+            root_entropy,
+            first_block_index,
+            Some(import_block_index),
+            next_subaddress_index,
+            &name.unwrap_or_else(|| "".to_string()),
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+            conn,
+        )?;
+        Account::get(&account_id, &conn)
     }
 
     fn list_all(
@@ -438,56 +429,52 @@ impl AccountModel for Account {
             txos::dsl::{txo_id_hex, txos},
         };
 
-        conn.transaction::<(), WalletDbError, _>(|| {
-            for key_image in key_images {
-                // Get the txo by key_image
-                let matches = crate::db::schema::txos::table
-                    .select(crate::db::schema::txos::all_columns)
-                    .filter(
-                        crate::db::schema::txos::key_image.eq(mc_util_serial::encode(&key_image)),
-                    )
-                    .load::<Txo>(conn)?;
+        for key_image in key_images {
+            // Get the txo by key_image
+            let matches = crate::db::schema::txos::table
+                .select(crate::db::schema::txos::all_columns)
+                .filter(crate::db::schema::txos::key_image.eq(mc_util_serial::encode(&key_image)))
+                .load::<Txo>(conn)?;
 
-                if matches.is_empty() {
-                    // Not Found is ok - this means it's a key_image not associated with any of our
-                    // txos
-                    continue;
-                } else if matches.len() > 1 {
-                    return Err(WalletDbError::DuplicateEntries(format!(
-                        "Key Image: {:?}",
-                        key_image
-                    )));
-                } else {
-                    // Update the TXO
-                    diesel::update(txos.filter(txo_id_hex.eq(&matches[0].txo_id_hex)))
-                        .set(crate::db::schema::txos::spent_block_index.eq(Some(spent_block_index)))
-                        .execute(conn)?;
-
-                    // Update the AccountTxoStatus
-                    diesel::update(
-                        account_txo_statuses.find((&self.account_id_hex, &matches[0].txo_id_hex)),
-                    )
-                    .set(
-                        crate::db::schema::account_txo_statuses::txo_status
-                            .eq(TXO_STATUS_SPENT.to_string()),
-                    )
+            if matches.is_empty() {
+                // Not Found is ok - this means it's a key_image not associated with any of our
+                // txos
+                continue;
+            } else if matches.len() > 1 {
+                return Err(WalletDbError::DuplicateEntries(format!(
+                    "Key Image: {:?}",
+                    key_image
+                )));
+            } else {
+                // Update the TXO
+                diesel::update(txos.filter(txo_id_hex.eq(&matches[0].txo_id_hex)))
+                    .set(crate::db::schema::txos::spent_block_index.eq(Some(spent_block_index)))
                     .execute(conn)?;
 
-                    // FIXME: WS-13 - make sure the path for all txo_statuses and txo_types exist
-                    // and are tested Update the transaction status if the txos
-                    // are all spent
-                    TransactionLog::update_transactions_associated_to_txo(
-                        &matches[0].txo_id_hex,
-                        spent_block_index,
-                        conn,
-                    )?;
-                }
-            }
-            diesel::update(accounts.filter(account_id_hex.eq(&self.account_id_hex)))
-                .set(crate::db::schema::accounts::next_block_index.eq(spent_block_index + 1))
+                // Update the AccountTxoStatus
+                diesel::update(
+                    account_txo_statuses.find((&self.account_id_hex, &matches[0].txo_id_hex)),
+                )
+                .set(
+                    crate::db::schema::account_txo_statuses::txo_status
+                        .eq(TXO_STATUS_SPENT.to_string()),
+                )
                 .execute(conn)?;
-            Ok(())
-        })
+
+                // FIXME: WS-13 - make sure the path for all txo_statuses and txo_types exist
+                // and are tested Update the transaction status if the txos
+                // are all spent
+                TransactionLog::update_transactions_associated_to_txo(
+                    &matches[0].txo_id_hex,
+                    spent_block_index,
+                    conn,
+                )?;
+            }
+        }
+        diesel::update(accounts.filter(account_id_hex.eq(&self.account_id_hex)))
+            .set(crate::db::schema::accounts::next_block_index.eq(spent_block_index + 1))
+            .execute(conn)?;
+        Ok(())
     }
 
     /// Delete an account.

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -143,92 +143,90 @@ impl AssignedSubaddressModel for AssignedSubaddress {
             },
         };
 
-        conn.transaction::<(String, i64), WalletDbError, _>(|| {
-            let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
+        let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
 
-            let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-            let account_view_key = account_key.view_key();
-            let subaddress_index = account.next_subaddress_index;
-            let subaddress = account_key.subaddress(subaddress_index as u64);
+        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+        let account_view_key = account_key.view_key();
+        let subaddress_index = account.next_subaddress_index;
+        let subaddress = account_key.subaddress(subaddress_index as u64);
 
-            let subaddress_b58 = b58_encode(&subaddress)?;
-            let subaddress_entry = NewAssignedSubaddress {
-                assigned_subaddress_b58: &subaddress_b58,
-                account_id_hex,
-                address_book_entry: None, /* FIXME: WS-8 - Address Book Entry if details
-                                           * provided, or None always for main? */
-                public_address: &mc_util_serial::encode(&subaddress),
-                subaddress_index: subaddress_index as i64,
-                comment,
-                subaddress_spend_key: &mc_util_serial::encode(subaddress.spend_public_key()),
-            };
+        let subaddress_b58 = b58_encode(&subaddress)?;
+        let subaddress_entry = NewAssignedSubaddress {
+            assigned_subaddress_b58: &subaddress_b58,
+            account_id_hex,
+            address_book_entry: None, /* FIXME: WS-8 - Address Book Entry if details
+                                       * provided, or None always for main? */
+            public_address: &mc_util_serial::encode(&subaddress),
+            subaddress_index: subaddress_index as i64,
+            comment,
+            subaddress_spend_key: &mc_util_serial::encode(subaddress.spend_public_key()),
+        };
 
-            diesel::insert_into(assigned_subaddresses::table)
-                .values(&subaddress_entry)
-                .execute(conn)?;
+        diesel::insert_into(assigned_subaddresses::table)
+            .values(&subaddress_entry)
+            .execute(conn)?;
 
-            // Update the next subaddress index for the account
-            diesel::update(accounts.filter(dsl_account_id_hex.eq(account_id_hex)))
-                .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
-                .execute(conn)?;
+        // Update the next subaddress index for the account
+        diesel::update(accounts.filter(dsl_account_id_hex.eq(account_id_hex)))
+            .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
+            .execute(conn)?;
 
-            // Find and repair orphaned txos at this subaddress.
-            let orphaned_txos = Txo::list_by_status(&account_id_hex, &TXO_STATUS_ORPHANED, &conn)?;
+        // Find and repair orphaned txos at this subaddress.
+        let orphaned_txos = Txo::list_by_status(&account_id_hex, &TXO_STATUS_ORPHANED, &conn)?;
 
-            for orphaned_txo in orphaned_txos.iter() {
-                let tx_out_target_key: RistrettoPublic =
-                    mc_util_serial::decode(&orphaned_txo.target_key).unwrap();
-                let tx_public_key: RistrettoPublic =
-                    mc_util_serial::decode(&orphaned_txo.public_key).unwrap();
+        for orphaned_txo in orphaned_txos.iter() {
+            let tx_out_target_key: RistrettoPublic =
+                mc_util_serial::decode(&orphaned_txo.target_key).unwrap();
+            let tx_public_key: RistrettoPublic =
+                mc_util_serial::decode(&orphaned_txo.public_key).unwrap();
 
-                let txo_subaddress_spk: RistrettoPublic = recover_public_subaddress_spend_key(
-                    &account_view_key.view_private_key,
-                    &tx_out_target_key,
+            let txo_subaddress_spk: RistrettoPublic = recover_public_subaddress_spend_key(
+                &account_view_key.view_private_key,
+                &tx_out_target_key,
+                &tx_public_key,
+            );
+
+            if txo_subaddress_spk == *subaddress.spend_public_key() {
+                // Get the current account status mapping.
+                let account_txo_status =
+                    AccountTxoStatus::get(&account_id_hex, &orphaned_txo.txo_id_hex, &conn)
+                        .unwrap();
+
+                // Update the status to unspent.
+                account_txo_status.set_unspent(&conn)?;
+
+                let onetime_private_key = recover_onetime_private_key(
                     &tx_public_key,
+                    account_key.view_private_key(),
+                    &account_key.subaddress_spend_private(subaddress_index as u64),
                 );
 
-                if txo_subaddress_spk == *subaddress.spend_public_key() {
-                    // Get the current account status mapping.
-                    let account_txo_status =
-                        AccountTxoStatus::get(&account_id_hex, &orphaned_txo.txo_id_hex, &conn)
-                            .unwrap();
+                let key_image = KeyImage::from(&onetime_private_key);
 
-                    // Update the status to unspent.
-                    account_txo_status.set_unspent(&conn)?;
+                let key_image_bytes = mc_util_serial::encode(&key_image);
 
-                    let onetime_private_key = recover_onetime_private_key(
-                        &tx_public_key,
-                        account_key.view_private_key(),
-                        &account_key.subaddress_spend_private(subaddress_index as u64),
-                    );
-
-                    let key_image = KeyImage::from(&onetime_private_key);
-
-                    let key_image_bytes = mc_util_serial::encode(&key_image);
-
-                    // Update the account status mapping.
-                    diesel::update(orphaned_txo)
-                        .set((
-                            crate::db::schema::txos::subaddress_index.eq(subaddress_index),
-                            crate::db::schema::txos::key_image.eq(key_image_bytes),
-                        ))
-                        .execute(conn)?;
-
-                    diesel::update(
-                        transaction_logs
-                            .filter(tx_log_transaction_id_hex.eq(&orphaned_txo.txo_id_hex))
-                            .filter(tx_log_account_id_hex.eq(account_id_hex)),
-                    )
-                    .set(
-                        (crate::db::schema::transaction_logs::assigned_subaddress_b58
-                            .eq(&subaddress_b58),),
-                    )
+                // Update the account status mapping.
+                diesel::update(orphaned_txo)
+                    .set((
+                        crate::db::schema::txos::subaddress_index.eq(subaddress_index),
+                        crate::db::schema::txos::key_image.eq(key_image_bytes),
+                    ))
                     .execute(conn)?;
-                }
-            }
 
-            Ok((subaddress_b58, subaddress_index))
-        })
+                diesel::update(
+                    transaction_logs
+                        .filter(tx_log_transaction_id_hex.eq(&orphaned_txo.txo_id_hex))
+                        .filter(tx_log_account_id_hex.eq(account_id_hex)),
+                )
+                .set(
+                    (crate::db::schema::transaction_logs::assigned_subaddress_b58
+                        .eq(&subaddress_b58),),
+                )
+                .execute(conn)?;
+            }
+        }
+
+        Ok((subaddress_b58, subaddress_index))
     }
 
     fn get(

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -350,50 +350,48 @@ impl TransactionLogModel for TransactionLog {
     ) -> Result<(), WalletDbError> {
         use crate::db::schema::transaction_logs::dsl::{transaction_id_hex, transaction_logs};
 
-        conn.transaction::<(), WalletDbError, _>(|| {
-            let associated_transaction_logs = Self::select_for_txo(txo_id_hex, conn)?;
+        let associated_transaction_logs = Self::select_for_txo(txo_id_hex, conn)?;
 
-            for transaction_log in associated_transaction_logs {
-                let associated = transaction_log.get_associated_txos(conn)?;
+        for transaction_log in associated_transaction_logs {
+            let associated = transaction_log.get_associated_txos(conn)?;
 
-                // Only update transaction_log status if built or pending
-                if transaction_log.status != TX_STATUS_BUILT
-                    && transaction_log.status != TX_STATUS_PENDING
-                {
-                    continue;
-                }
-
-                // Check whether all the inputs have been spent or if any failed, and update
-                // accordingly
-                let input_txo_ids: Vec<String> = associated
-                    .inputs
-                    .iter()
-                    .map(|t| t.txo_id_hex.clone())
-                    .collect();
-                if Txo::are_all_spent(&input_txo_ids, conn)? {
-                    diesel::update(
-                        transaction_logs
-                            .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
-                    )
-                    .set((
-                        crate::db::schema::transaction_logs::status.eq(TX_STATUS_SUCCEEDED),
-                        crate::db::schema::transaction_logs::finalized_block_index
-                            .eq(Some(cur_block_index)),
-                    ))
-                    .execute(conn)?;
-                } else if Txo::any_failed(&input_txo_ids, cur_block_index, conn)? {
-                    // FIXME: WS-18, WS-17 - Do we want to store and update the "failed_block_index"
-                    // as min(tombstones)?
-                    diesel::update(
-                        transaction_logs
-                            .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
-                    )
-                    .set(crate::db::schema::transaction_logs::status.eq(TX_STATUS_FAILED))
-                    .execute(conn)?;
-                }
+            // Only update transaction_log status if built or pending
+            if transaction_log.status != TX_STATUS_BUILT
+                && transaction_log.status != TX_STATUS_PENDING
+            {
+                continue;
             }
-            Ok(())
-        })
+
+            // Check whether all the inputs have been spent or if any failed, and update
+            // accordingly
+            let input_txo_ids: Vec<String> = associated
+                .inputs
+                .iter()
+                .map(|t| t.txo_id_hex.clone())
+                .collect();
+            if Txo::are_all_spent(&input_txo_ids, conn)? {
+                diesel::update(
+                    transaction_logs
+                        .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
+                )
+                .set((
+                    crate::db::schema::transaction_logs::status.eq(TX_STATUS_SUCCEEDED),
+                    crate::db::schema::transaction_logs::finalized_block_index
+                        .eq(Some(cur_block_index)),
+                ))
+                .execute(conn)?;
+            } else if Txo::any_failed(&input_txo_ids, cur_block_index, conn)? {
+                // FIXME: WS-18, WS-17 - Do we want to store and update the "failed_block_index"
+                // as min(tombstones)?
+                diesel::update(
+                    transaction_logs
+                        .filter(transaction_id_hex.eq(&transaction_log.transaction_id_hex)),
+                )
+                .set(crate::db::schema::transaction_logs::status.eq(TX_STATUS_FAILED))
+                .execute(conn)?;
+            }
+        }
+        Ok(())
     }
 
     fn log_received(
@@ -404,62 +402,60 @@ impl TransactionLogModel for TransactionLog {
     ) -> Result<(), WalletDbError> {
         use crate::db::schema::transaction_txo_types;
 
-        conn.transaction::<(), WalletDbError, _>(|| {
-            for (subaddress_index, output_txo_ids) in subaddress_to_output_txo_ids {
-                let txos = Txo::select_by_id(&output_txo_ids, conn)?;
-                for (txo, _account_txo_status) in txos {
-                    let transaction_id = TransactionID::from(txo.txo_id_hex.clone());
+        for (subaddress_index, output_txo_ids) in subaddress_to_output_txo_ids {
+            let txos = Txo::select_by_id(&output_txo_ids, conn)?;
+            for (txo, _account_txo_status) in txos {
+                let transaction_id = TransactionID::from(txo.txo_id_hex.clone());
 
-                    // Check that we haven't already logged this transaction on a previous sync
-                    match TransactionLog::get(&transaction_id.to_string(), conn) {
-                        Ok(_) => continue, // Processed this transaction on a previous sync.
-                        Err(WalletDbError::TransactionLogNotFound(_)) => {} // Insert below
-                        Err(e) => return Err(e),
-                    }
-
-                    // Get the public address for the subaddress that received these TXOs
-                    let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-                    let subaddress = account_key.subaddress(*subaddress_index as u64);
-                    let b58_subaddress = b58_encode(&subaddress)?;
-                    let assigned_subaddress_b58: Option<&str> = if *subaddress_index >= 0 {
-                        Some(&b58_subaddress)
-                    } else {
-                        None
-                    };
-
-                    // Create a TransactionLogs entry for every TXO
-                    let new_transaction_log = NewTransactionLog {
-                        transaction_id_hex: &transaction_id.to_string(),
-                        account_id_hex: &account.account_id_hex,
-                        assigned_subaddress_b58,
-                        value: txo.value,
-                        fee: None, // Impossible to recover fee from received transaction
-                        status: TX_STATUS_SUCCEEDED,
-                        sent_time: None, // NULL for received
-                        submitted_block_index: None,
-                        finalized_block_index: Some(block_index as i64),
-                        comment: "", // NULL for received
-                        direction: TX_DIRECTION_RECEIVED,
-                        tx: None, // NULL for received
-                    };
-                    diesel::insert_into(crate::db::schema::transaction_logs::table)
-                        .values(&new_transaction_log)
-                        .execute(conn)?;
-
-                    // Create an entry per TXO for the TransactionTxoTypes
-                    let new_transaction_txo = NewTransactionTxoType {
-                        transaction_id_hex: &transaction_id.to_string(),
-                        txo_id_hex: &txo.txo_id_hex,
-                        transaction_txo_type: TXO_USED_AS_OUTPUT,
-                    };
-                    // Note: SQLite backend does not support batch insert, so within iter is fine
-                    diesel::insert_into(transaction_txo_types::table)
-                        .values(&new_transaction_txo)
-                        .execute(conn)?;
+                // Check that we haven't already logged this transaction on a previous sync
+                match TransactionLog::get(&transaction_id.to_string(), conn) {
+                    Ok(_) => continue, // Processed this transaction on a previous sync.
+                    Err(WalletDbError::TransactionLogNotFound(_)) => {} // Insert below
+                    Err(e) => return Err(e),
                 }
+
+                // Get the public address for the subaddress that received these TXOs
+                let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+                let subaddress = account_key.subaddress(*subaddress_index as u64);
+                let b58_subaddress = b58_encode(&subaddress)?;
+                let assigned_subaddress_b58: Option<&str> = if *subaddress_index >= 0 {
+                    Some(&b58_subaddress)
+                } else {
+                    None
+                };
+
+                // Create a TransactionLogs entry for every TXO
+                let new_transaction_log = NewTransactionLog {
+                    transaction_id_hex: &transaction_id.to_string(),
+                    account_id_hex: &account.account_id_hex,
+                    assigned_subaddress_b58,
+                    value: txo.value,
+                    fee: None, // Impossible to recover fee from received transaction
+                    status: TX_STATUS_SUCCEEDED,
+                    sent_time: None, // NULL for received
+                    submitted_block_index: None,
+                    finalized_block_index: Some(block_index as i64),
+                    comment: "", // NULL for received
+                    direction: TX_DIRECTION_RECEIVED,
+                    tx: None, // NULL for received
+                };
+                diesel::insert_into(crate::db::schema::transaction_logs::table)
+                    .values(&new_transaction_log)
+                    .execute(conn)?;
+
+                // Create an entry per TXO for the TransactionTxoTypes
+                let new_transaction_txo = NewTransactionTxoType {
+                    transaction_id_hex: &transaction_id.to_string(),
+                    txo_id_hex: &txo.txo_id_hex,
+                    transaction_txo_type: TXO_USED_AS_OUTPUT,
+                };
+                // Note: SQLite backend does not support batch insert, so within iter is fine
+                diesel::insert_into(transaction_txo_types::table)
+                    .values(&new_transaction_txo)
+                    .execute(conn)?;
             }
-            Ok(())
-        })
+        }
+        Ok(())
     }
 
     fn log_submitted(
@@ -472,80 +468,77 @@ impl TransactionLogModel for TransactionLog {
         // Verify that the account exists.
         Account::get(&AccountID(account_id_hex.to_string()), &conn)?;
 
-        let transaction_log_id = conn.transaction::<String, WalletDbError, _>(|| {
-            // Store the txo_id_hex -> transaction_txo_type
-            let mut txo_ids: Vec<(String, String)> = Vec::new();
+        // Store the txo_id_hex -> transaction_txo_type
+        let mut txo_ids: Vec<(String, String)> = Vec::new();
 
-            // Verify that the TxProposal is well-formed according to our assumptions about
-            // how to store the sent data in our wallet.
-            if tx_proposal.tx.prefix.outputs.len() - tx_proposal.outlays.len() > 1 {
-                return Err(WalletDbError::UnexpectedNumberOfChangeOutputs);
-            }
+        // Verify that the TxProposal is well-formed according to our assumptions about
+        // how to store the sent data in our wallet.
+        if tx_proposal.tx.prefix.outputs.len() - tx_proposal.outlays.len() > 1 {
+            return Err(WalletDbError::UnexpectedNumberOfChangeOutputs);
+        }
 
-            // First update all inputs to "pending." They will remain pending until their
-            // key_image hits the ledger or their tombstone block is exceeded.
-            for utxo in tx_proposal.utxos.iter() {
-                let txo_id = TxoID::from(&utxo.tx_out);
-                Txo::update_to_pending(&txo_id, conn)?;
-                txo_ids.push((txo_id.to_string(), TXO_USED_AS_INPUT.to_string()));
-            }
+        // First update all inputs to "pending." They will remain pending until their
+        // key_image hits the ledger or their tombstone block is exceeded.
+        for utxo in tx_proposal.utxos.iter() {
+            let txo_id = TxoID::from(&utxo.tx_out);
+            Txo::update_to_pending(&txo_id, conn)?;
+            txo_ids.push((txo_id.to_string(), TXO_USED_AS_INPUT.to_string()));
+        }
 
-            // Next, add all of our minted outputs to the Txo Table
-            for (i, output) in tx_proposal.tx.prefix.outputs.iter().enumerate() {
-                let processed_output =
-                    Txo::create_minted(account_id_hex, &output, &tx_proposal, i, conn)?;
-                txo_ids.push((
-                    processed_output.txo_id_hex,
-                    processed_output.txo_type.to_string(),
-                ));
-            }
+        // Next, add all of our minted outputs to the Txo Table
+        for (i, output) in tx_proposal.tx.prefix.outputs.iter().enumerate() {
+            let processed_output =
+                Txo::create_minted(account_id_hex, &output, &tx_proposal, i, conn)?;
+            txo_ids.push((
+                processed_output.txo_id_hex,
+                processed_output.txo_type.to_string(),
+            ));
+        }
 
-            // Enforce maximum value.
-            let transaction_value = tx_proposal
-                .outlays
-                .iter()
-                .map(|o| o.value as u128)
-                .sum::<u128>();
-            if transaction_value > i64::MAX as u128 {
-                return Err(WalletDbError::TransactionValueExceedsMax);
-            }
+        // Enforce maximum value.
+        let transaction_value = tx_proposal
+            .outlays
+            .iter()
+            .map(|o| o.value as u128)
+            .sum::<u128>();
+        if transaction_value > i64::MAX as u128 {
+            return Err(WalletDbError::TransactionValueExceedsMax);
+        }
 
-            let transaction_id = TransactionID::from(&tx_proposal.tx);
-            let tx = mc_util_serial::encode(&tx_proposal.tx);
+        let transaction_id = TransactionID::from(&tx_proposal.tx);
+        let tx = mc_util_serial::encode(&tx_proposal.tx);
 
-            // Create a TransactionLogs entry
-            let new_transaction_log = NewTransactionLog {
+        // Create a TransactionLogs entry
+        let new_transaction_log = NewTransactionLog {
+            transaction_id_hex: &transaction_id.to_string(),
+            account_id_hex, // Can be null if submitting an "unowned" proposal.
+            assigned_subaddress_b58: None, // NULL for sent
+            value: transaction_value as i64,
+            fee: Some(tx_proposal.tx.prefix.fee as i64),
+            status: TX_STATUS_PENDING,
+            sent_time: Some(Utc::now().timestamp()),
+            submitted_block_index: Some(block_index as i64),
+            finalized_block_index: None,
+            comment: &comment,
+            direction: TX_DIRECTION_SENT,
+            tx: Some(&tx),
+        };
+        diesel::insert_into(crate::db::schema::transaction_logs::table)
+            .values(&new_transaction_log)
+            .execute(conn)?;
+
+        // Create an entry per TXO for the TransactionTxoTypes
+        for (txo_id_hex, transaction_txo_type) in txo_ids {
+            let new_transaction_txo = NewTransactionTxoType {
                 transaction_id_hex: &transaction_id.to_string(),
-                account_id_hex, // Can be null if submitting an "unowned" proposal.
-                assigned_subaddress_b58: None, // NULL for sent
-                value: transaction_value as i64,
-                fee: Some(tx_proposal.tx.prefix.fee as i64),
-                status: TX_STATUS_PENDING,
-                sent_time: Some(Utc::now().timestamp()),
-                submitted_block_index: Some(block_index as i64),
-                finalized_block_index: None,
-                comment: &comment,
-                direction: TX_DIRECTION_SENT,
-                tx: Some(&tx),
+                txo_id_hex: &txo_id_hex,
+                transaction_txo_type: &transaction_txo_type,
             };
-            diesel::insert_into(crate::db::schema::transaction_logs::table)
-                .values(&new_transaction_log)
+            diesel::insert_into(crate::db::schema::transaction_txo_types::table)
+                .values(&new_transaction_txo)
                 .execute(conn)?;
-
-            // Create an entry per TXO for the TransactionTxoTypes
-            for (txo_id_hex, transaction_txo_type) in txo_ids {
-                let new_transaction_txo = NewTransactionTxoType {
-                    transaction_id_hex: &transaction_id.to_string(),
-                    txo_id_hex: &txo_id_hex,
-                    transaction_txo_type: &transaction_txo_type,
-                };
-                diesel::insert_into(crate::db::schema::transaction_txo_types::table)
-                    .values(&new_transaction_txo)
-                    .execute(conn)?;
-            }
-            Ok(transaction_id.to_string())
-        })?;
-        TransactionLog::get(&transaction_log_id, conn)
+        }
+        TransactionLog::get(&transaction_id.to_string(), conn)
     }
 
     fn delete_all_for_account(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -234,161 +234,158 @@ impl TxoModel for Txo {
         Account::get(&AccountID(account_id_hex.to_string()), &conn)?;
 
         let txo_id = TxoID::from(&txo);
-        conn.transaction::<(), WalletDbError, _>(|| {
-            match Txo::get(&txo_id.to_string(), conn) {
-                // If we already have this TXO for this account (e.g. from minting in a previous
-                // transaction), we need to update it
-                Ok(txo_details) => {
-                    // Check if this txo/pairing already exists for this account.
-                    match AccountTxoStatus::get(account_id_hex, &txo_id.to_string(), conn) {
-                        // The txo/pairing exists for this account in this wallet.
-                        Ok(account_txo_status) => {
-                            match account_txo_status.txo_status.as_str() {
-                                TXO_STATUS_SECRETED => {
-                                    match account_txo_status.txo_type.as_str() {
-                                        // We minted this TXO and sent it to ourselves. It's
-                                        // either change that we're now recovering as unspent,
-                                        // or it's a new Txo that we sent to ourselves.
-                                        TXO_TYPE_MINTED => {
-                                            if subaddress_index.is_some() {
-                                                // Transition from [Minted, Secreted] ->
-                                                // [Minted,
-                                                // Unspent]
-                                                // This occurs when an account receives a
-                                                // transaction from itself at a subaddress.
-                                                txo_details.txo.update_to_spendable(
-                                                    subaddress_index,
-                                                    key_image,
-                                                    received_block_index,
-                                                    &conn,
-                                                )?;
-                                                account_txo_status.set_unspent(conn)?;
-                                            } else {
-                                                // Transition from [Minted, Secreted] ->
-                                                // [Minted,
-                                                // Orphaned]
-                                                // This occurs when an account receives a
-                                                // transaction from itself at an unknown
-                                                // subaddress.
-                                                txo_details.txo.update_received_block_index(
-                                                    received_block_index,
-                                                    conn,
-                                                )?;
-                                                account_txo_status.set_orphaned(conn)?;
-                                            }
-                                        }
-                                        // Should not get [Received, Secreted]
-                                        _ => {
-                                            return Err(WalletDbError::UnexpectedAccountTxoStatus(
-                                                account_txo_status.txo_status,
-                                            ));
+        match Txo::get(&txo_id.to_string(), conn) {
+            // If we already have this TXO for this account (e.g. from minting in a previous
+            // transaction), we need to update it
+            Ok(txo_details) => {
+                // Check if this txo/pairing already exists for this account.
+                match AccountTxoStatus::get(account_id_hex, &txo_id.to_string(), conn) {
+                    // The txo/pairing exists for this account in this wallet.
+                    Ok(account_txo_status) => {
+                        match account_txo_status.txo_status.as_str() {
+                            TXO_STATUS_SECRETED => {
+                                match account_txo_status.txo_type.as_str() {
+                                    // We minted this TXO and sent it to ourselves. It's
+                                    // either change that we're now recovering as unspent,
+                                    // or it's a new Txo that we sent to ourselves.
+                                    TXO_TYPE_MINTED => {
+                                        if subaddress_index.is_some() {
+                                            // Transition from [Minted, Secreted] ->
+                                            // [Minted,
+                                            // Unspent]
+                                            // This occurs when an account receives a
+                                            // transaction from itself at a subaddress.
+                                            txo_details.txo.update_to_spendable(
+                                                subaddress_index,
+                                                key_image,
+                                                received_block_index,
+                                                &conn,
+                                            )?;
+                                            account_txo_status.set_unspent(conn)?;
+                                        } else {
+                                            // Transition from [Minted, Secreted] ->
+                                            // [Minted,
+                                            // Orphaned]
+                                            // This occurs when an account receives a
+                                            // transaction from itself at an unknown
+                                            // subaddress.
+                                            txo_details.txo.update_received_block_index(
+                                                received_block_index,
+                                                conn,
+                                            )?;
+                                            account_txo_status.set_orphaned(conn)?;
                                         }
                                     }
-                                }
-                                TXO_STATUS_ORPHANED => {
-                                    // If we have a subaddress for this account and this Txo, we
-                                    // can update to spendable. True for [Minted, Orphaned] and
-                                    // [Received, Orphaned]
-                                    if subaddress_index.is_some() {
-                                        txo_details.txo.update_to_spendable(
-                                            subaddress_index,
-                                            key_image,
-                                            received_block_index,
-                                            &conn,
-                                        )?;
-                                        account_txo_status.set_unspent(conn)?;
+                                    // Should not get [Received, Secreted]
+                                    _ => {
+                                        return Err(WalletDbError::UnexpectedAccountTxoStatus(
+                                            account_txo_status.txo_status,
+                                        ));
                                     }
-                                }
-                                TXO_STATUS_UNSPENT => {}
-                                TXO_STATUS_PENDING => {}
-                                TXO_STATUS_SPENT => {}
-                                _ => {
-                                    return Err(WalletDbError::UnexpectedAccountTxoStatus(
-                                        account_txo_status.txo_status,
-                                    ));
                                 }
                             }
+                            TXO_STATUS_ORPHANED => {
+                                // If we have a subaddress for this account and this Txo, we
+                                // can update to spendable. True for [Minted, Orphaned] and
+                                // [Received, Orphaned]
+                                if subaddress_index.is_some() {
+                                    txo_details.txo.update_to_spendable(
+                                        subaddress_index,
+                                        key_image,
+                                        received_block_index,
+                                        &conn,
+                                    )?;
+                                    account_txo_status.set_unspent(conn)?;
+                                }
+                            }
+                            TXO_STATUS_UNSPENT => {}
+                            TXO_STATUS_PENDING => {}
+                            TXO_STATUS_SPENT => {}
+                            _ => {
+                                return Err(WalletDbError::UnexpectedAccountTxoStatus(
+                                    account_txo_status.txo_status,
+                                ));
+                            }
                         }
-                        // The txo/pairing exists for another account currently in the wallet.
-                        // We also want to set it as unspent, but we need to create a new
-                        // AccountTxoStatus entry.
-                        Err(WalletDbError::AccountTxoStatusNotFound(_)) => {
-                            let status = if subaddress_index.is_some() {
-                                // If the Txo was already in the DB, but not for this account,
-                                // we need to update to spendable with the subaddress and
-                                // key_image
-                                txo_details.txo.update_to_spendable(
-                                    subaddress_index,
-                                    key_image,
-                                    received_block_index,
-                                    &conn,
-                                )?;
-                                TXO_STATUS_UNSPENT
-                            } else {
-                                // Note: An orphaned Txo cannot be spent until the subaddress is
-                                // recovered.
-                                txo_details
-                                    .txo
-                                    .update_received_block_index(received_block_index, conn)?;
-                                TXO_STATUS_ORPHANED
-                            };
-                            AccountTxoStatus::create(
-                                account_id_hex,
-                                &txo_id.to_string(),
-                                status,
-                                TXO_TYPE_RECEIVED,
-                                conn,
-                            )?;
-                        }
-                        Err(e) => return Err(e),
                     }
+                    // The txo/pairing exists for another account currently in the wallet.
+                    // We also want to set it as unspent, but we need to create a new
+                    // AccountTxoStatus entry.
+                    Err(WalletDbError::AccountTxoStatusNotFound(_)) => {
+                        let status = if subaddress_index.is_some() {
+                            // If the Txo was already in the DB, but not for this account,
+                            // we need to update to spendable with the subaddress and
+                            // key_image
+                            txo_details.txo.update_to_spendable(
+                                subaddress_index,
+                                key_image,
+                                received_block_index,
+                                &conn,
+                            )?;
+                            TXO_STATUS_UNSPENT
+                        } else {
+                            // Note: An orphaned Txo cannot be spent until the subaddress is
+                            // recovered.
+                            txo_details
+                                .txo
+                                .update_received_block_index(received_block_index, conn)?;
+                            TXO_STATUS_ORPHANED
+                        };
+                        AccountTxoStatus::create(
+                            account_id_hex,
+                            &txo_id.to_string(),
+                            status,
+                            TXO_TYPE_RECEIVED,
+                            conn,
+                        )?;
+                    }
+                    Err(e) => return Err(e),
                 }
+            }
 
-                // If we don't already have this TXO, create a new entry
-                Err(WalletDbError::TxoNotFound(_)) => {
-                    let key_image_bytes = key_image.map(|k| mc_util_serial::encode(&k));
-                    let new_txo = NewTxo {
-                        txo_id_hex: &txo_id.to_string(),
-                        value: value as i64,
-                        target_key: &mc_util_serial::encode(&txo.target_key),
-                        public_key: &mc_util_serial::encode(&txo.public_key),
-                        e_fog_hint: &mc_util_serial::encode(&txo.e_fog_hint),
-                        txo: &mc_util_serial::encode(&txo),
-                        subaddress_index,
-                        key_image: key_image_bytes.as_deref(),
-                        received_block_index: Some(received_block_index as i64),
-                        pending_tombstone_block_index: None,
-                        spent_block_index: None,
-                        confirmation: None,
-                        recipient_public_address_b58: "".to_string(), // NULL for received
-                    };
+            // If we don't already have this TXO, create a new entry
+            Err(WalletDbError::TxoNotFound(_)) => {
+                let key_image_bytes = key_image.map(|k| mc_util_serial::encode(&k));
+                let new_txo = NewTxo {
+                    txo_id_hex: &txo_id.to_string(),
+                    value: value as i64,
+                    target_key: &mc_util_serial::encode(&txo.target_key),
+                    public_key: &mc_util_serial::encode(&txo.public_key),
+                    e_fog_hint: &mc_util_serial::encode(&txo.e_fog_hint),
+                    txo: &mc_util_serial::encode(&txo),
+                    subaddress_index,
+                    key_image: key_image_bytes.as_deref(),
+                    received_block_index: Some(received_block_index as i64),
+                    pending_tombstone_block_index: None,
+                    spent_block_index: None,
+                    confirmation: None,
+                    recipient_public_address_b58: "".to_string(), // NULL for received
+                };
 
-                    diesel::insert_into(crate::db::schema::txos::table)
-                        .values(&new_txo)
-                        .execute(conn)?;
+                diesel::insert_into(crate::db::schema::txos::table)
+                    .values(&new_txo)
+                    .execute(conn)?;
 
-                    let status = if subaddress_index.is_some() {
-                        TXO_STATUS_UNSPENT
-                    } else {
-                        // Note: An orphaned Txo cannot be spent until the subaddress is recovered.
-                        TXO_STATUS_ORPHANED
-                    };
+                let status = if subaddress_index.is_some() {
+                    TXO_STATUS_UNSPENT
+                } else {
+                    // Note: An orphaned Txo cannot be spent until the subaddress is recovered.
+                    TXO_STATUS_ORPHANED
+                };
 
-                    // We should get a unique violation if this AccountTxoStatus already exists.
-                    AccountTxoStatus::create(
-                        account_id_hex,
-                        &txo_id.to_string(),
-                        status,
-                        TXO_TYPE_RECEIVED,
-                        conn,
-                    )?;
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            };
-            Ok(())
-        })?;
+                // We should get a unique violation if this AccountTxoStatus already exists.
+                AccountTxoStatus::create(
+                    account_id_hex,
+                    &txo_id.to_string(),
+                    status,
+                    TXO_TYPE_RECEIVED,
+                    conn,
+                )?;
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
         Ok(txo_id.to_string())
     }
 
@@ -441,42 +438,39 @@ impl TxoModel for Txo {
         let encoded_confirmation = confirmation
             .map(|p| mc_util_serial::encode(&tx_proposal.outlay_confirmation_numbers[p]));
 
-        conn.transaction::<(), WalletDbError, _>(|| {
-            let new_txo = NewTxo {
-                txo_id_hex: &txo_id.to_string(),
-                value: value as i64,
-                target_key: &mc_util_serial::encode(&output.target_key),
-                public_key: &mc_util_serial::encode(&output.public_key),
-                e_fog_hint: &mc_util_serial::encode(&output.e_fog_hint),
-                txo: &mc_util_serial::encode(output),
-                subaddress_index: None, /* Minted set subaddress_index to None. If later
-                                         * received, updates. */
-                key_image: None, // Only the recipient can calculate the KeyImage
-                received_block_index: None,
-                pending_tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
-                spent_block_index: None,
-                confirmation: encoded_confirmation.as_deref(),
-                recipient_public_address_b58,
-            };
+        let new_txo = NewTxo {
+            txo_id_hex: &txo_id.to_string(),
+            value: value as i64,
+            target_key: &mc_util_serial::encode(&output.target_key),
+            public_key: &mc_util_serial::encode(&output.public_key),
+            e_fog_hint: &mc_util_serial::encode(&output.e_fog_hint),
+            txo: &mc_util_serial::encode(output),
+            subaddress_index: None, /* Minted set subaddress_index to None. If later
+                                     * received, updates. */
+            key_image: None, // Only the recipient can calculate the KeyImage
+            received_block_index: None,
+            pending_tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
+            spent_block_index: None,
+            confirmation: encoded_confirmation.as_deref(),
+            recipient_public_address_b58,
+        };
 
-            diesel::insert_into(txos::table)
-                .values(&new_txo)
-                .execute(conn)?;
+        diesel::insert_into(txos::table)
+            .values(&new_txo)
+            .execute(conn)?;
 
-            // Log a relationship between the account and the TXO.
-            let new_account_txo_status = NewAccountTxoStatus {
-                account_id_hex: &account_id_hex,
-                txo_id_hex: &txo_id.to_string(),
-                // The lifecycle of this txo starts at secreted. If it is change, then it will
-                // become unspent when it is received.
-                txo_status: TXO_STATUS_SECRETED,
-                txo_type: TXO_TYPE_MINTED,
-            };
-            diesel::insert_into(account_txo_statuses::table)
-                .values(&new_account_txo_status)
-                .execute(conn)?;
-            Ok(())
-        })?;
+        // Log a relationship between the account and the TXO.
+        let new_account_txo_status = NewAccountTxoStatus {
+            account_id_hex: &account_id_hex,
+            txo_id_hex: &txo_id.to_string(),
+            // The lifecycle of this txo starts at secreted. If it is change, then it will
+            // become unspent when it is received.
+            txo_status: TXO_STATUS_SECRETED,
+            txo_type: TXO_TYPE_MINTED,
+        };
+        diesel::insert_into(account_txo_statuses::table)
+            .values(&new_account_txo_status)
+            .execute(conn)?;
 
         Ok(ProcessedTxProposalOutput {
             recipient: outlay_receiver,
@@ -532,7 +526,7 @@ impl TxoModel for Txo {
     ) -> Result<(), WalletDbError> {
         use crate::db::schema::account_txo_statuses::dsl::account_txo_statuses;
 
-        let result = conn.transaction::<(), WalletDbError, _>(|| {
+        let result = {
             // Find the account associated with this Txo.
             // Note: We should only be calling update_to_pending on inputs, which we had to
             // own to spend.
@@ -564,7 +558,7 @@ impl TxoModel for Txo {
                 }
             }
             Ok(())
-        });
+        };
 
         match result {
             Ok(()) => Ok(()),
@@ -936,13 +930,11 @@ impl TxoModel for Txo {
         confirmation: &TxOutConfirmationNumber,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<bool, WalletDbError> {
-        conn.transaction::<bool, WalletDbError, _>(|| {
-            let txo_details = Txo::get(txo_id_hex, conn)?;
-            let public_key: RistrettoPublic = mc_util_serial::decode(&txo_details.txo.public_key)?;
-            let account = Account::get(account_id, conn)?;
-            let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-            Ok(confirmation.validate(&public_key, account_key.view_private_key()))
-        })
+        let txo_details = Txo::get(txo_id_hex, conn)?;
+        let public_key: RistrettoPublic = mc_util_serial::decode(&txo_details.txo.public_key)?;
+        let account = Account::get(account_id, conn)?;
+        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+        Ok(confirmation.validate(&public_key, account_key.view_private_key()))
     }
 }
 

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -79,8 +79,7 @@ where
         metadata: Option<&str>,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
         let conn = &self.wallet_db.get_conn()?;
-
-        conn.transaction::<AssignedSubaddress, AddressServiceError, _>(|| {
+        conn.transaction(|| {
             let (public_address_b58, _subaddress_index) =
                 AssignedSubaddress::create_next_for_account(
                     &account_id.to_string(),
@@ -98,12 +97,15 @@ where
         offset: Option<i64>,
         limit: Option<i64>,
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError> {
-        Ok(AssignedSubaddress::list_all(
-            &account_id.to_string(),
-            offset,
-            limit,
-            &self.wallet_db.get_conn()?,
-        )?)
+        let conn = self.wallet_db.get_conn()?;
+        conn.transaction(|| {
+            Ok(AssignedSubaddress::list_all(
+                &account_id.to_string(),
+                offset,
+                limit,
+                &conn,
+            )?)
+        })
     }
 
     fn get_address_for_account(
@@ -111,11 +113,14 @@ where
         account_id: &AccountID,
         index: i64,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
-        Ok(AssignedSubaddress::get_for_account_by_index(
-            &account_id.to_string(),
-            index,
-            &self.wallet_db.get_conn()?,
-        )?)
+        let conn = self.wallet_db.get_conn()?;
+        conn.transaction(|| {
+            Ok(AssignedSubaddress::get_for_account_by_index(
+                &account_id.to_string(),
+                index,
+                &conn,
+            )?)
+        })
     }
 
     fn verify_address(&self, public_address: &str) -> Result<bool, AddressServiceError> {

--- a/full-service/src/service/confirmation_number.rs
+++ b/full-service/src/service/confirmation_number.rs
@@ -22,6 +22,8 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::tx::TxOutConfirmationNumber;
 
+use diesel::Connection;
+
 /// Errors for the Txo Service.
 #[derive(Display, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -158,13 +160,15 @@ where
         confirmation_hex: &str,
     ) -> Result<bool, ConfirmationServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        let confirmation: TxOutConfirmationNumber =
-            mc_util_serial::decode(&hex::decode(confirmation_hex)?)?;
-        Ok(Txo::validate_confirmation(
-            &AccountID(account_id.to_string()),
-            &txo_id.to_string(),
-            &confirmation,
-            &conn,
-        )?)
+        conn.transaction(|| {
+            let confirmation: TxOutConfirmationNumber =
+                mc_util_serial::decode(&hex::decode(confirmation_hex)?)?;
+            Ok(Txo::validate_confirmation(
+                &AccountID(account_id.to_string()),
+                &txo_id.to_string(),
+                &confirmation,
+                &conn,
+            )?)
+        })
     }
 }

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -81,12 +81,15 @@ where
         offset: Option<i64>,
         limit: Option<i64>,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
-        Ok(TransactionLog::list_all(
-            &account_id.to_string(),
-            offset,
-            limit,
-            &self.wallet_db.get_conn()?,
-        )?)
+        let conn = &self.wallet_db.get_conn()?;
+        conn.transaction(|| {
+            Ok(TransactionLog::list_all(
+                &account_id.to_string(),
+                offset,
+                limit,
+                &conn,
+            )?)
+        })
     }
 
     fn get_transaction_log(
@@ -94,8 +97,7 @@ where
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos), TransactionLogServiceError> {
         let conn = self.wallet_db.get_conn()?;
-
-        conn.transaction::<(TransactionLog, AssociatedTxos), TransactionLogServiceError, _>(|| {
+        conn.transaction(|| {
             let transaction_log = TransactionLog::get(transaction_id_hex, &conn)?;
             let associated = transaction_log.get_associated_txos(&conn)?;
 
@@ -108,8 +110,7 @@ where
         block_index: u64,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
-
-        conn.transaction::<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError, _>(|| {
+        conn.transaction(|| {
             let transaction_logs = TransactionLog::get_all_for_block_index(block_index, &conn)?;
             let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
             for transaction_log in transaction_logs {
@@ -126,8 +127,7 @@ where
         &self,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
-
-        conn.transaction::<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError, _>(|| {
+        conn.transaction(|| {
             let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
             let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
             for transaction_log in transaction_logs {


### PR DESCRIPTION
* Move all usage of transactions out of the db layer and into the service
layer.
* Every time we create a connection with get_conn(), start a db transaction.

