### PR TITLE
Don't cache production.json 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,11 @@ ENV CONSENSUS_ENCLAVE_CSS=/app/consensus-enclave.css
 
 WORKDIR /app
 
+ADD https://${SIGNED_ENCLAVE_BASE}/${SIGSTRUCT_JSON_LOCATION} /app/${SIGSTRUCT_JSON_LOCATION}
+
 # Get enclave sigstruct
-RUN  export SIGSTRUCT_JSON=$(curl -sSL https://${SIGNED_ENCLAVE_BASE}/${SIGSTRUCT_JSON_LOCATION}) \
-  && export CONSENSUS_CSS_URL=$(echo ${SIGSTRUCT_JSON} | jq -r .consensus.sigstruct) \
-  && export INGEST_CSS_URL=$(echo ${SIGSTRUCT_JSON} | jq -r .ingest.sigstruct) \
+RUN  export CONSENSUS_CSS_URL=$(cat /app/${SIGSTRUCT_JSON_LOCATION} | jq -r .consensus.sigstruct) \
+  && export INGEST_CSS_URL=$(cat /app/${SIGSTRUCT_JSON_LOCATION} | jq -r .ingest.sigstruct) \
   && curl https://${SIGNED_ENCLAVE_BASE}/${CONSENSUS_CSS_URL} -o ${CONSENSUS_ENCLAVE_CSS} \
   && curl https://${SIGNED_ENCLAVE_BASE}/${INGEST_CSS_URL} -o ${INGEST_ENCLAVE_CSS}
 
@@ -86,6 +87,6 @@ ENV RUST_LOG=info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,r
 ENV INGEST_ENCLAVE_CSS=/usr/local/bin/ingest-enclave.css
 ENV CONSENSUS_ENCLAVE_CSS=/usr/local/bin/consensus-enclave.css
 
-ENTRYPOINT [ "/usr/local/bin/full-service", "--wallet-db=/data/wallet.db", "--ledger-db=/data/ledger.db", "--listen-host=0.0.0.0" ]
+ENTRYPOINT ["/usr/local/bin/full-service", "--wallet-db=/data/wallet.db", "--ledger-db=/data/ledger.db", "--listen-host=0.0.0.0" ]
 
 CMD [ "--help" ]


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Docker runs that use cache will not pick up changes to https://enclave-distribution.[test|prod].mobilecoin.com/production.json since nothing will change in the `RUN` line. 

Solution: use `ADD` to pull down the json.  This should check for server side changes and invalidate cache as necessary.

### In this PR
* Use `ADD` instead of pulling production.json with curl.

