### PR TITLE
Wallet database encryption via SQLCipher.

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,0 +1,28 @@
+# Database Usage
+
+The MobileCoin wallet service stores its data in two places:
+- The first database is the ledger database, which is an append-only data store, recording the state of the public ledger. This contains no readable secret information, because all transaction outputs are stored on the ledger in an encrypted format. Its location is specified with the command line option `--ledger_db`.
+- The second database is the wallet database, which stores the private keys and private transaction information for the accounts in the wallet. It should be encrypted using our password features, or stored on an encrypted partition. Its location is specified with `--wallet-db`.
+
+## Database Encryption
+The wallet database can be encrypted using SQLCipher, an open source plugin for encrypting SQLite databases.
+
+Please keep in mind that there is no way to recover the contents of an encrypted database without the password. Always backup your database password and the recovery mnemonic of your accounts in a secure location.
+
+### Setting and changing the password
+In order to enable encryption, set the password for the database with the environment variable `MC_PASSWORD`. In order to re-encrypt the database with a new password, also set the environment variable `MC_CHANGE_PASSWORD`.
+
+### Encrypting an unencrypted database
+When migrating an existing plain-text wallet database to the encrypted format, there is a manual process using the SQLCipher command line tool. The following commands open the unencrypted database in `sqlcipher`, export an encrypted copy of the database, then replace the original database with the encrypted copy.
+
+    $ cp wallet.db wallet.db.backup
+    $ sqlcipher wallet.db
+    sqlite> ATTACH DATABASE 'encrypted.db' AS encrypted KEY '<your password here>';
+    sqlite> SELECT sqlcipher_export('encrypted');
+    sqlite> DETACH DATABASE encrypted;
+    sqlite> .exit
+    $ mv encrypted.db wallet.db
+
+Once you have verified that you can access the encrypted database, then you can safely delete the unencrypted backup `wallet.db.backup`.
+
+For more information, look at the [SQLCipher documentation](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlcipher_export) about this process.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -14,9 +14,8 @@ In order to enable encryption, set the password for the database with the enviro
 
 To manually set an environment variable without writing it to the shell history, you can do the following:
 
-    $ set +o history
-    $ export MC_PASSWORD='<your password here>'
-    $ set -o history
+    $ read -rs MC_PASSWORD
+    $ export MC_PASSWORD
 
 ### Encrypting an unencrypted database
 When migrating an existing plain-text wallet database to the encrypted format, there is a manual process using the SQLCipher command line tool. The following commands open the unencrypted database in `sqlcipher`, export an encrypted copy of the database, then replace the original database with the encrypted copy.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,7 +1,7 @@
 # Database Usage
 
 The MobileCoin wallet service stores its data in two places:
-- The first database is the ledger database, which is an append-only data store, recording the state of the public ledger. This contains no readable secret information, because all transaction outputs are stored on the ledger in an encrypted format. Its location is specified with the command line option `--ledger_db`.
+- The first database is the ledger database, which is an append-only data store, recording the state of the public ledger. This contains no readable secret information, because all transaction outputs are stored on the ledger in an encrypted format. Its location is specified with the command line option `--ledger-db`.
 - The second database is the wallet database, which stores the private keys and private transaction information for the accounts in the wallet. It should be encrypted using our password features, or stored on an encrypted partition. Its location is specified with `--wallet-db`.
 
 ## Database Encryption

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -12,6 +12,12 @@ Please keep in mind that there is no way to recover the contents of an encrypted
 ### Setting and changing the password
 In order to enable encryption, set the password for the database with the environment variable `MC_PASSWORD`. In order to re-encrypt the database with a new password, also set the environment variable `MC_CHANGE_PASSWORD`.
 
+To manually set an environment variable without writing it to the shell history, you can do the following:
+
+    $ set +o history
+    $ export MC_PASSWORD='<your password here>'
+    $ set -o history
+
 ### Encrypting an unencrypted database
 When migrating an existing plain-text wallet database to the encrypted format, there is a manual process using the SQLCipher command line tool. The following commands open the unencrypted database in `sqlcipher`, export an encrypted copy of the database, then replace the original database with the encrypted copy.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ MobileCoin Full Service is available under open-source licenses. Look for the [L
 
 For usage and API specification, see [API.md](API.md).
 
+For database encryption features, see [DATABASE.md](DATABASE.md).
+
+
 ### Offline (Cold-Wallet) Transaction Flow
 
 Full Service supports offline transactions. This flow is recommended to keep an account key on an air-gapped machine which has never connected to the internet.

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -40,7 +40,7 @@ mc-util-uri = { path = "../mobilecoin/util/uri" }
 
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 crossbeam-channel = "0.4"
-diesel = { version = "1.4.6", features = ["sqlite-bundled"] }
+diesel = { version = "1.4.6", features = ["sqlcipher-bundled"] }
 diesel-derive-enum = { version = "1", features = ["sqlite"] }
 diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
 displaydoc = {version = "0.1", default-features = false }

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -54,9 +54,10 @@ fn main() {
             )
         });
     WalletDb::set_db_encryption_key_from_env(&conn);
-    log::info!(logger, "Successfully decrypted database.");
     WalletDb::try_change_db_encryption_key_from_env(&conn);
+    WalletDb::check_database_connectivity(&conn);
     embedded_migrations::run(&conn).expect("failed running migrations");
+    log::info!(logger, "Connected to database.");
 
     let wallet_db = WalletDb::new_from_url(
         config

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -54,6 +54,8 @@ fn main() {
             )
         });
     WalletDb::set_db_encryption_key_from_env(&conn);
+    log::info!(logger, "Successfully decrypted database.");
+    WalletDb::try_change_db_encryption_key_from_env(&conn);
     embedded_migrations::run(&conn).expect("failed running migrations");
 
     let wallet_db = WalletDb::new_from_url(

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -126,13 +126,5 @@ impl WalletDb {
 /// This function doubles all single quote characters within the string, then
 /// wraps the string in single quotes on the front and back.
 fn sql_escape_string(s: &str) -> String {
-    let mut s_escaped = String::new();
-    for c in s.chars() {
-        if c == '\'' {
-            s_escaped.push_str("''");
-        } else {
-            s_escaped.push(c);
-        }
-    }
-    format!("'{}'", s_escaped)
+    format!("'{}'", s.replace("'", "''"))
 }

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -99,7 +99,10 @@ impl WalletDb {
         let encryption_key = env::var("MC_PASSWORD").unwrap_or_else(|_| "".to_string());
         let changed_encryption_key =
             env::var("MC_CHANGED_PASSWORD").unwrap_or_else(|_| "".to_string());
-        if !changed_encryption_key.is_empty() && encryption_key != changed_encryption_key {
+        if !encryption_key.is_empty()
+            && !changed_encryption_key.is_empty()
+            && encryption_key != changed_encryption_key
+        {
             let result = conn.batch_execute(&format!(
                 "PRAGMA rekey = {};",
                 sql_escape_string(&changed_encryption_key)

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -86,7 +86,7 @@ impl WalletDb {
         if !encryption_key.is_empty() {
             let result = conn.batch_execute(&format!(
                 "PRAGMA key = {};",
-                sql_escape_string(encryption_key.clone())
+                sql_escape_string(&encryption_key)
             ));
             if result.is_err() {
                 panic!("Could not decrypt database.");
@@ -102,14 +102,14 @@ impl WalletDb {
         if !changed_encryption_key.is_empty() && encryption_key != changed_encryption_key {
             let result = conn.batch_execute(&format!(
                 "PRAGMA rekey = {};",
-                sql_escape_string(changed_encryption_key.clone())
+                sql_escape_string(&changed_encryption_key)
             ));
             if result.is_err() {
                 panic!("Could not set new password.");
             }
             // Set the new password in the environment, so other threads can decrypt
             // correctly.
-            env::set_var("MC_PASSWORD", changed_encryption_key.clone());
+            env::set_var("MC_PASSWORD", changed_encryption_key);
             global_log::info!("Re-encrypted database with new password.");
         }
     }
@@ -125,7 +125,7 @@ impl WalletDb {
 /// Escape a string for consumption by SQLite.
 /// This function doubles all single quote characters within the string, then
 /// wraps the string in single quotes on the front and back.
-fn sql_escape_string(s: String) -> String {
+fn sql_escape_string(s: &str) -> String {
     let mut s_escaped = String::new();
     for c in s.chars() {
         if c == '\'' {

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -2411,7 +2411,7 @@ mod e2e {
     #[test_with_logger]
     fn test_get_all_txos(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, mut ledger_db, _db_ctx, network_state) = setup(&mut rng, logger.clone());
+        let (client, mut ledger_db, db_ctx, _network_state) = setup(&mut rng, logger.clone());
 
         // Add an account
         let body = json!({
@@ -2438,7 +2438,12 @@ mod e2e {
             &mut rng,
         );
 
-        wait_for_sync(&client, &ledger_db, &network_state, &logger);
+        wait_for_account_sync(
+            &ledger_db,
+            &db_ctx.get_db_instance(logger.clone()),
+            &AccountID(account_id.to_string()),
+            13,
+        );
 
         let body = json!({
             "jsonrpc": "2.0",

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -41,6 +41,7 @@ use mc_util_uri::{ConnectionUri, FogUri};
 use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng, SeedableRng};
 use std::{
     convert::TryFrom,
+    env,
     path::PathBuf,
     sync::{Arc, RwLock},
     time::Duration,
@@ -75,6 +76,9 @@ impl Default for WalletDbTestContext {
         // Connect to the database and run the migrations
         // Note: This should be kept in sync wth how the migrations are run in main.rs
         // so as to have faithful tests.
+        // Clear environment variables for db encryption.
+        env::set_var("MC_PASSWORD", "".to_string());
+        env::set_var("MC_CHANGE_PASSWORD", "".to_string());
         let conn = SqliteConnection::establish(&format!("{}/{}", base_url, db_name))
             .unwrap_or_else(|err| panic!("Cannot connect to {} database: {:?}", db_name, err));
         embedded_migrations::run(&conn).expect("failed running migrations");


### PR DESCRIPTION
* Embed SQLCipher library by static linking.
* Use MC_PASSWORD environment variable to set a password and activate database
  encryption.
* Use MC_CHANGE_PASSWORD environment variable to change database password.
