### PR TITLE
Fix issues with foreign key migrations

### DIFF
--- a/full-service/migrations/2021-03-03-035127_api_v2/down.sql
+++ b/full-service/migrations/2021-03-03-035127_api_v2/down.sql
@@ -3,7 +3,6 @@ DROP INDEX idx_transaction_logs__finalized_block_index;
 -- ALTER TABLE accounts RENAME COLUMN first_block_index TO first_block;
 -- ALTER TABLE accounts RENAME COLUMN next_block_index TO next_block;
 -- ALTER TABLE accounts RENAME COLUMN import_block_index TO import_block;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_accounts (
   id INTEGER NOT NULL PRIMARY KEY,
   account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -20,14 +19,11 @@ CREATE TABLE NEW_accounts (
 INSERT INTO NEW_accounts SELECT * FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE NEW_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 
 -- ALTER TABLE txos RENAME COLUMN received_block_index TO received_block_count;
 -- ALTER TABLE txos RENAME COLUMN pending_tombstone_block_index TO pending_tombstone_block_count;
 -- ALTER TABLE txos RENAME COLUMN spent_block_index TO pending_tombstone_block_count;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_txos (
   id INTEGER NOT NULL PRIMARY KEY,
   txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -46,12 +42,9 @@ CREATE TABLE NEW_txos (
 INSERT INTO NEW_txos SELECT * FROM txos;
 DROP TABLE txos;
 ALTER TABLE NEW_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 -- ALTER TABLE transaction_logs RENAME COLUMN submitted_block_index TO submitted_block_count;
 -- ALTER TABLE transaction_logs RENAME COLUMN finalized_block_index TO finalized_block_count;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -73,5 +66,3 @@ CREATE TABLE NEW_transaction_logs (
 INSERT INTO NEW_transaction_logs SELECT * FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE NEW_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-03-035127_api_v2/up.sql
+++ b/full-service/migrations/2021-03-03-035127_api_v2/up.sql
@@ -1,7 +1,6 @@
 -- ALTER TABLE accounts RENAME COLUMN first_block TO first_block_index;
 -- ALTER TABLE accounts RENAME COLUMN next_block TO next_block_index;
 -- ALTER TABLE accounts RENAME COLUMN import_block TO import_block_index;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_accounts (
   id INTEGER NOT NULL PRIMARY KEY,
   account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -18,13 +17,10 @@ CREATE TABLE NEW_accounts (
 INSERT INTO NEW_accounts SELECT * FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE NEW_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 -- ALTER TABLE txos RENAME COLUMN received_block_count TO received_block_index;
 -- ALTER TABLE txos RENAME COLUMN pending_tombstone_block_count TO pending_tombstone_block_index;
 -- ALTER TABLE txos RENAME COLUMN spent_block_count TO pending_tombstone_block_count;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_txos (
   id INTEGER NOT NULL PRIMARY KEY,
   txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -43,12 +39,9 @@ CREATE TABLE NEW_txos (
 INSERT INTO NEW_txos SELECT * FROM txos;
 DROP TABLE txos;
 ALTER TABLE NEW_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 -- ALTER TABLE transaction_logs RENAME COLUMN submitted_block_count TO submitted_block_index;
 -- ALTER TABLE transaction_logs RENAME COLUMN finalized_block_count TO finalized_block_index;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -70,7 +63,5 @@ CREATE TABLE NEW_transaction_logs (
 INSERT INTO NEW_transaction_logs SELECT * FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE NEW_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 CREATE INDEX idx_transaction_logs__finalized_block_index ON transaction_logs (finalized_block_index);

--- a/full-service/migrations/2021-03-25-042338_proof_to_confirmation/down.sql
+++ b/full-service/migrations/2021-03-25-042338_proof_to_confirmation/down.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE txos RENAME COLUMN confirmation TO proof;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_txos (
     id INTEGER NOT NULL PRIMARY KEY,
     txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -18,5 +17,3 @@ CREATE TABLE OLD_txos (
 INSERT INTO OLD_txos SELECT * FROM txos;
 DROP TABLE txos;
 ALTER TABLE OLD_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-25-042338_proof_to_confirmation/up.sql
+++ b/full-service/migrations/2021-03-25-042338_proof_to_confirmation/up.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE txos RENAME COLUMN proof TO confirmation;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_txos (
     id INTEGER NOT NULL PRIMARY KEY,
     txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -18,5 +17,3 @@ CREATE TABLE NEW_txos (
 INSERT INTO NEW_txos SELECT * FROM txos;
 DROP TABLE txos;
 ALTER TABLE NEW_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-30-021521_slip10_account_key/down.sql
+++ b/full-service/migrations/2021-03-30-021521_slip10_account_key/down.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE accounts REMOVE COLUMN key_derivation_version;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_accounts (
     id INTEGER NOT NULL PRIMARY KEY,
     account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -28,5 +27,3 @@ INSERT INTO OLD_accounts SELECT
 FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE OLD_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-30-021521_slip10_account_key/up.sql
+++ b/full-service/migrations/2021-03-30-021521_slip10_account_key/up.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE accounts ADD COLUMN key_derivation_version INTEGER NOT NULL DEFAULT 1;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_accounts (
     id INTEGER NOT NULL PRIMARY KEY,
     account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -30,5 +29,3 @@ INSERT INTO NEW_accounts SELECT
 FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE NEW_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-31-220723_nullable_transaction_log_address/down.sql
+++ b/full-service/migrations/2021-03-31-220723_nullable_transaction_log_address/down.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE transaction_logs ALTER COLUMN assigned_subaddress_b58 SET NOT NULL;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -21,5 +20,3 @@ CREATE TABLE OLD_transaction_logs (
 INSERT INTO OLD_transaction_logs SELECT * FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE OLD_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-03-31-220723_nullable_transaction_log_address/up.sql
+++ b/full-service/migrations/2021-03-31-220723_nullable_transaction_log_address/up.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE transaction_logs ALTER COLUMN assigned_subaddress_b58 DROP NOT NULL;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -21,5 +20,3 @@ CREATE TABLE NEW_transaction_logs (
 INSERT INTO NEW_transaction_logs SELECT * FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE NEW_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-03-183001_reorder_account_fields/down.sql
+++ b/full-service/migrations/2021-04-03-183001_reorder_account_fields/down.sql
@@ -1,4 +1,3 @@
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_accounts (
     id INTEGER NOT NULL PRIMARY KEY,
     account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -29,5 +28,3 @@ INSERT INTO OLD_accounts SELECT
 FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE OLD_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-03-183001_reorder_account_fields/up.sql
+++ b/full-service/migrations/2021-04-03-183001_reorder_account_fields/up.sql
@@ -1,4 +1,3 @@
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_accounts (
     id INTEGER NOT NULL PRIMARY KEY,
     account_id_hex VARCHAR NOT NULL UNIQUE,
@@ -29,5 +28,3 @@ INSERT INTO NEW_accounts SELECT
 FROM accounts;
 DROP TABLE accounts;
 ALTER TABLE NEW_accounts RENAME TO accounts;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-09-050201_multi_outlay_transaction_logs/down.sql
+++ b/full-service/migrations/2021-04-09-050201_multi_outlay_transaction_logs/down.sql
@@ -1,5 +1,4 @@
 -- ALTER TABLE transaction_logs ADD COLUMN recipient_public_address_b58 VARCHAR NOT NULL DEFAULT '';
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -36,8 +35,6 @@ INSERT INTO OLD_transaction_logs SELECT
 FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE OLD_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 -- Update the transaction_logs table from txos.recipient_public_address_b58.
 UPDATE transaction_logs
@@ -52,7 +49,6 @@ FROM (
 WHERE transaction_logs.transaction_id_hex = q.transaction_id_hex;
 
 -- ALTER TABLE txos REMOVE COLUMN recipient_public_address_b58;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE OLD_txos (
     id INTEGER NOT NULL PRIMARY KEY,
     txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -85,5 +81,3 @@ INSERT INTO OLD_txos SELECT
 FROM txos;
 DROP TABLE txos;
 ALTER TABLE OLD_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-09-050201_multi_outlay_transaction_logs/up.sql
+++ b/full-service/migrations/2021-04-09-050201_multi_outlay_transaction_logs/up.sql
@@ -1,6 +1,5 @@
 -- Add the recipient address column to txos.
 -- ALTER TABLE txos ADD COLUMN recipient_public_address_b58 TEXT NOT NULL DEFAULT '';
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_txos (
     id INTEGER NOT NULL PRIMARY KEY,
     txo_id_hex VARCHAR NOT NULL UNIQUE,
@@ -35,8 +34,6 @@ INSERT INTO NEW_txos SELECT
 FROM txos;
 DROP TABLE txos;
 ALTER TABLE NEW_txos RENAME TO txos;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;
 
 -- Update the txos table with the relevant values from transaction_logs for recipient_public_address_b58.
 UPDATE txos
@@ -52,7 +49,6 @@ WHERE txos.txo_id_hex = q.txo_id_hex;
 
 -- Remove the recipient address column from transaction logs.
 -- ALTER TABLE transaction_logs REMOVE COLUMN recipient_public_address_b58;
-PRAGMA foreign_keys=OFF;
 CREATE TABLE NEW_transaction_logs (
     id INTEGER NOT NULL PRIMARY KEY,
     transaction_id_hex VARCHAR NOT NULL UNIQUE,
@@ -87,5 +83,3 @@ INSERT INTO NEW_transaction_logs SELECT
 FROM transaction_logs;
 DROP TABLE transaction_logs;
 ALTER TABLE NEW_transaction_logs RENAME TO transaction_logs;
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/down.sql
+++ b/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/down.sql
@@ -1,5 +1,3 @@
-PRAGMA foreign_keys=OFF;
-
 CREATE TABLE OLD_gift_codes (
   id INTEGER NOT NULL PRIMARY KEY,
   gift_code_b58 VARCHAR NOT NULL,
@@ -26,6 +24,3 @@ FROM gift_codes;
 
 DROP TABLE gift_codes;
 ALTER TABLE OLD_gift_codes RENAME TO gift_codes;
-
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/up.sql
+++ b/full-service/migrations/2021-04-20-182449_gift_code_two_entropies/up.sql
@@ -1,5 +1,3 @@
-PRAGMA foreign_keys=OFF;
-
 CREATE TABLE NEW_gift_codes (
   id INTEGER NOT NULL PRIMARY KEY,
   gift_code_b58 VARCHAR NOT NULL,
@@ -28,6 +26,3 @@ FROM gift_codes;
 
 DROP TABLE gift_codes;
 ALTER TABLE NEW_gift_codes RENAME TO gift_codes;
-
-PRAGMA foreign_key_check;
-PRAGMA foreign_keys=ON;

--- a/full-service/migrations/2021-06-25-225113_transaction_logs_nullable_assigned_subaddress_b58/down.sql
+++ b/full-service/migrations/2021-06-25-225113_transaction_logs_nullable_assigned_subaddress_b58/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/full-service/migrations/2021-06-25-225113_transaction_logs_nullable_assigned_subaddress_b58/up.sql
+++ b/full-service/migrations/2021-06-25-225113_transaction_logs_nullable_assigned_subaddress_b58/up.sql
@@ -1,0 +1,4 @@
+-- Old versions of the database used an empty string to indicate no assigned_subaddress_b58 but that violates
+-- foreign key constraints. A previous migration changed the assigned_subaddress_b58 field to be NULLable bue
+-- forgot to update existing rows.
+UPDATE transaction_logs SET assigned_subaddress_b58=NULL where assigned_subaddress_b58='';


### PR DESCRIPTION
### Motivation

SQLite has a bunch of limitations surrounding table altering. When creating migrations that alter tables, we sometime have to make changes that temporarily violate foreign key constraints. For example, quoting [this](https://www.techonthenet.com/sqlite/foreign_keys/foreign_keys.php) page: "You can not use the ALTER TABLE statement to add a foreign key in SQLite. Instead you will need to rename the table, create a new table with the foreign key, and then copy the data into the new table.". However, this renaming/copying eventually involves deleting the original table, which then breaks foreign keys. The workaround is to temporary disable foreign key checks.

The migrations SQL files mistakenly tried to do that, but according to the [manual](https://www.sqlite.org/pragma.html#pragma_foreign_keys) "This pragma is a no-op within a transaction; foreign key constraint enforcement may only be enabled or disabled when there is no pending BEGIN or SAVEPOINT. ".

As such, we need to disable foreign key checks before applying migrations, apply them, and then re-enable it. Unfortunately, a side effect of this entire thing is that migrations can actually result in foreign key violations and a weird database state. We should auto-backup the database before applying any migrations to reduce chances of things going wrong, but that is outside the scope of this (time-sensitive) PR.

### In this PR
* As described above, move the foreign key enabling/disabling to happen outside of the migration transactions.
* Add a test for foreign key violations so that if something is wrong, we abort until the user fixes it.
* Remove unnecessary `PRAGMA` calls from the migration files.

### Future Work
* Automate creating a copy of the database before applying any migrations.

