### PR TITLE
Mac vi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ version: 2.1
 
 defaults:
   builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_22
+  default-xcode-version: &default-xcode-version "12.0.0"
 
   default-environment: &default-environment
     # sccache config
@@ -30,6 +31,16 @@ executors:
     docker:
       - image: *builder-install
     resource_class: xlarge
+
+  macos:
+    parameters:
+      xcode-version: { type: string, default: *default-xcode-version }
+    macos:
+      xcode: << parameters.xcode-version >>
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      HOMEBREW_BUNDLE_NO_LOCK: "1"
 
 commands:
   print_versions:
@@ -214,11 +225,52 @@ commands:
             time cargo fetch --locked
             (cd mobilecoin/consensus/enclave/trusted && time cargo fetch --locked)
 
+  restore-homebrew-cache:
+    steps:
+      - restore_cache:
+          name: Restore Homebrew cache
+          key: v0-homebrew-{{ arch }}
+      - run:
+          name: Update Homebrew
+          command: |
+            brew --version
+            brew update --preinstall
+            brew --version
+      - run:
+          name: Install Homebrew dependencies
+          command: |
+            rm "/usr/local/lib/python3.8/site-packages/six.py"
+            brew bundle --no-upgrade
+
+  save-homebrew-cache:
+    steps:
+      - run:
+          name: Prepare Homebrew cache for saving
+          command: |
+            # Make sure latest versions are installed
+            time brew bundle
+
+            # Remove all dependencies except those in the Brewfile
+            time brew bundle cleanup --force
+
+            brew info
+      - save_cache:
+          name: Save Homebrew cache
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: v0-homebrew-{{ arch }}-{{ .Revision }}
+          paths:
+            - /usr/local/Cellar
+
   prepare-for-build:
+    parameters:
+      os: { type: enum, enum: ["linux", "macos", "windows"], default: linux }
     steps:
       - checkout
       - git_submodule
       - rust_version_check
+      - when:
+          condition: { equal: [ << parameters.os >>, macos ] }
+          steps: [ restore-homebrew-cache ]
       - install-rust
       - restore-cargo-cache
       - env_setup
@@ -348,6 +400,34 @@ jobs:
           steps: [ save-cargo-cache, save-sccache-cache ]
       - post-build
 
+  # Build using macOS
+  build-macos:
+    parameters:
+      xcode-version: { type: string, default: *default-xcode-version }
+    executor:
+      name: macos
+      xcode-version: << parameters.xcode-version >>
+    environment:
+      <<: *default-build-environment
+      SCCACHE_CACHE_SIZE: 450M
+      RUSTFLAGS: -D warnings -C target-cpu=penryn
+      CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/mobilecoin/sgx/css/src/valid.css
+      INGEST_ENCLAVE_CSS: /Users/distiller/project/mobilecoin/sgx/css/src/valid.css
+      LEDGER_ENCLAVE_CSS: /Users/distiller/project/mobilecoin/sgx/css/src/valid.css
+      VIEW_ENCLAVE_CSS: /Users/distiller/project/mobilecoin/sgx/css/src/valid.css
+    steps:
+      - prepare-for-build:
+          os: macos
+      - run:
+          name: Cargo build
+          command: |
+            cargo build --frozen --target "$HOST_TARGET_TRIPLE"
+      - check-dirty-git
+      - when:
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          steps: [ save-sccache-cache, save-cargo-cache, save-homebrew-cache ]
+      - post-build
+
   # Build in release mode
   build-release:
     executor: build-executor
@@ -373,6 +453,13 @@ workflows:
 
       # Build everything in debug
       - build-and-lint-debug
+
+      # Build using macOS
+      - build-macos:
+          name: build-macos-xcode-<< matrix.xcode-version >>
+          matrix:
+            parameters:
+              xcode-version: ["11.7.0", *default-xcode-version]
 
       # build everything in release - currently disabled since it's a waste of CPU/$
       # - build-release

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,5 @@
+# Build dependencies
+brew 'cmake'
+brew 'go'
+brew 'llvm'
+brew 'protobuf'


### PR DESCRIPTION
This PR adds Mac targets similar to `libmobilecoin` targets on the `fog` repo. This ensures `full-service` can build successfully for Mac.