### PR TITLE
Optionally return tx_proposal with build_and_submit_transaction

### DIFF
--- a/cli/mobilecoin/cli.py
+++ b/cli/mobilecoin/cli.py
@@ -496,7 +496,9 @@ class CommandLineInterface:
             print('Cancelled.')
             return
 
-        transaction_log = self.client.build_and_submit_transaction(account_id, amount, to_address)
+        transaction_log, tx_proposal = self.client.build_and_submit_transaction_with_proposal(account_id, amount, to_address)
+        print("TX Proposal:")
+        print(tx_proposal.keys())
 
         print('Sent {}, with a transaction fee of {}'.format(
             _format_mob(pmob2mob(transaction_log['value_pmob'])),

--- a/cli/mobilecoin/cli.py
+++ b/cli/mobilecoin/cli.py
@@ -497,8 +497,6 @@ class CommandLineInterface:
             return
 
         transaction_log, tx_proposal = self.client.build_and_submit_transaction_with_proposal(account_id, amount, to_address)
-        print("TX Proposal:")
-        print(tx_proposal.keys())
 
         print('Sent {}, with a transaction fee of {}'.format(
             _format_mob(pmob2mob(transaction_log['value_pmob'])),

--- a/cli/mobilecoin/client.py
+++ b/cli/mobilecoin/client.py
@@ -228,7 +228,7 @@ class Client:
 
     def build_and_submit_transaction_with_proposal(self, account_id, amount, to_address):
         r = self._build_and_submit_transaction(account_id, amount, to_address)
-        return r['transaction_log'], r['proposal']
+        return r['transaction_log'], r['tx_proposal']
 
     def build_transaction(self, account_id, amount, to_address, tombstone_block=None):
         amount = str(mob2pmob(amount))

--- a/cli/mobilecoin/client.py
+++ b/cli/mobilecoin/client.py
@@ -211,7 +211,7 @@ class Client:
         })
         return r['address_map']
 
-    def build_and_submit_transaction(self, account_id, amount, to_address, return_proposal=False):
+    def _build_and_submit_transaction(self, account_id, amount, to_address):
         amount = str(mob2pmob(amount))
         r = self._req({
             "method": "build_and_submit_transaction",
@@ -220,9 +220,15 @@ class Client:
                 "addresses_and_values": [(to_address, amount)],
             }
         })
-        if return_proposal:
-            return r['transaction_log'], r['proposal']
+        return r
+
+    def build_and_submit_transaction(self, account_id, amount, to_address):
+        r = self._build_and_submit_transaction(account_id, amount, to_address)
         return r['transaction_log']
+
+    def build_and_submit_transaction_with_proposal(self, account_id, amount, to_address):
+        r = self._build_and_submit_transaction(account_id, amount, to_address)
+        return r['transaction_log'], r['proposal']
 
     def build_transaction(self, account_id, amount, to_address, tombstone_block=None):
         amount = str(mob2pmob(amount))

--- a/cli/mobilecoin/client.py
+++ b/cli/mobilecoin/client.py
@@ -211,7 +211,7 @@ class Client:
         })
         return r['address_map']
 
-    def build_and_submit_transaction(self, account_id, amount, to_address):
+    def build_and_submit_transaction(self, account_id, amount, to_address, return_proposal=False):
         amount = str(mob2pmob(amount))
         r = self._req({
             "method": "build_and_submit_transaction",
@@ -220,6 +220,8 @@ class Client:
                 "addresses_and_values": [(to_address, amount)],
             }
         })
+        if return_proposal:
+            return r['transaction_log'], r['proposal']
         return r['transaction_log']
 
     def build_transaction(self, account_id, amount, to_address, tombstone_block=None):

--- a/cli/test/client_tests.py
+++ b/cli/test/client_tests.py
@@ -227,7 +227,7 @@ def test_subaddresses(c, source_account_id):
     assert addresses[dest_address]['metadata'] == 'Address Name'
 
     # Send the subaddress some money.
-    transaction_log, tx_proposal = c.build_and_submit_transaction(source_account_id, 0.1, dest_address, return_proposal=True)
+    transaction_log, tx_proposal = c.build_and_submit_transaction_with_proposal(source_account_id, 0.1, dest_address)
     tx_index = int(transaction_log['submitted_block_index'])
     balance = c.poll_balance(dest_account_id, tx_index + 1)
     assert pmob2mob(balance['unspent_pmob']) == Decimal('0.1')

--- a/cli/test/client_tests.py
+++ b/cli/test/client_tests.py
@@ -227,10 +227,13 @@ def test_subaddresses(c, source_account_id):
     assert addresses[dest_address]['metadata'] == 'Address Name'
 
     # Send the subaddress some money.
-    transaction_log = c.build_and_submit_transaction(source_account_id, 0.1, dest_address)
+    transaction_log, tx_proposal = c.build_and_submit_transaction(source_account_id, 0.1, dest_address, return_proposal=True)
     tx_index = int(transaction_log['submitted_block_index'])
     balance = c.poll_balance(dest_account_id, tx_index + 1)
     assert pmob2mob(balance['unspent_pmob']) == Decimal('0.1')
+    assert len(tx_proposal['outlay_list']) == 1
+    receipts = c.create_receiver_receipts(tx_proposal)
+    assert len(receipts) == 1
 
     # The second address has money credited to it, but the main one doesn't.
     balance = c.get_balance_for_address(dest_address)


### PR DESCRIPTION
### Motivation

Currently, we use the python CLI to build and submit in two separate actions because we need a tx_proposal. For throughput and to allow multithreading without accidentally sending the same uTXO, we would like to pull the tx_proposal from build_and_submit_transaction.

### In this PR
* added to `build_and_submit_transaction_with_proposal` in the python client

[Python client: get tx_proposal from build_and_submit_transactions](https://app.asana.com/0/1200175610893108/1200918570741698) 

### Future Work
* [MOBot: Migrate to new python client for full-service API](https://app.asana.com/0/1200175610893108/1201002142005233)

