### PR TITLE
Api key guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ ingest-enclave.css
 *.mdb
 
 release/
+
+.env

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ sudo xcode-select -s /Applications/<name of xcode application>.app/Contents/Deve
 | `offline` | Use Full Service in offline mode. This mode does not download new blocks or submit transactions. | |
 | `fog-ingest-enclave-css` | Path to the Fog ingest enclave sigstruct CSS file. | Needed in order to enable sending transactions to fog addresses. |
 
+## API Key
+
+You can add an optional API key to full service by adding a `.env` file to the root of this repo. The variable you need to set is: `MC_API_KEY="<api key of your choosing>"`. If you set this env var, you must provide the `X-API-KEY` header in your requests to full-service.
 
 ## Exit Codes
 

--- a/docs/tutorials/environment-setup.md
+++ b/docs/tutorials/environment-setup.md
@@ -52,3 +52,7 @@ Replace our default peers or tx-source-urls if you would prefer to establish you
 
 1. Install a service, such as [Postman](https://www.postman.com/), to send HTTP requests.
 
+## API Key
+
+You can add an optional API key to full service by adding a `.env` file to the root of this repo. The variable you need to set is: `MC_API_KEY="<api key of your choosing>"`. If you set this env var, you must provide the `X-API-KEY` header in your requests to full-service.
+

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -82,8 +82,7 @@ impl WalletDb {
 
     pub fn set_db_encryption_key_from_env(conn: &SqliteConnection) {
         // Send the encryption key to SQLCipher, if it is not the empty string.
-        // Then check that it worked, or else panic.
-        let encryption_key = env::var("MC_PASSWORD").unwrap_or_default();
+        let encryption_key = env::var("MC_PASSWORD").unwrap_or_else(|_| "".to_string());
         if !encryption_key.is_empty() {
             let result = conn.batch_execute(&format!(
                 "PRAGMA key = {};",

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -82,7 +82,8 @@ impl WalletDb {
 
     pub fn set_db_encryption_key_from_env(conn: &SqliteConnection) {
         // Send the encryption key to SQLCipher, if it is not the empty string.
-        let encryption_key = env::var("MC_PASSWORD").unwrap_or_else(|_| "".to_string());
+        // Then check that it worked, or else panic.
+        let encryption_key = env::var("MC_PASSWORD").unwrap_or_default();
         if !encryption_key.is_empty() {
             let result = conn.batch_execute(&format!(
                 "PRAGMA key = {};",

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -1,17 +1,13 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
-use crate::{
-    json_rpc::{
+use crate::{json_rpc::{
         json_rpc_request::{JsonCommandRequest, JsonRPCRequest},
         json_rpc_response::JsonRPCResponse,
         wallet::wallet_api_inner,
-    },
-    service::WalletService,
-    test_utils::{
+    }, service::WalletService, test_utils::{
         get_resolver_factory, get_test_ledger, setup_peer_manager_and_network_state,
         WalletDbTestContext,
-    },
-};
+    }, wallet::ApiKeyGuard};
 use mc_account_keys::PublicAddress;
 use mc_common::logger::{log, Logger};
 use mc_connection_test_utils::MockBlockchainConnection;
@@ -47,6 +43,7 @@ pub struct TestWalletState {
 // TestWalletState, which handles Mock objects.
 #[post("/wallet", format = "json", data = "<command>")]
 fn test_wallet_api(
+    _guard: ApiKeyGuard,
     state: rocket::State<TestWalletState>,
     command: Json<JsonRPCRequest>,
 ) -> Result<Json<JsonRPCResponse>, String> {

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -11,7 +11,7 @@ use crate::{
         get_resolver_factory, get_test_ledger, setup_peer_manager_and_network_state,
         WalletDbTestContext,
     },
-    wallet::ApiKeyGuard,
+    wallet::{APIKeyState, ApiKeyGuard},
 };
 use mc_account_keys::PublicAddress;
 use mc_common::logger::{log, Logger};
@@ -83,11 +83,11 @@ pub fn test_rocket(rocket_config: rocket::Config, state: TestWalletState) -> roc
         .manage(state)
 }
 
-pub fn setup(
+pub fn create_test_setup(
     mut rng: &mut StdRng,
     logger: Logger,
 ) -> (
-    Client,
+    rocket::Rocket,
     LedgerDB,
     WalletDbTestContext,
     Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
@@ -99,22 +99,62 @@ pub fn setup(
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone());
 
-    let service: WalletService<MockBlockchainConnection<LedgerDB>, MockFogPubkeyResolver> =
-        WalletService::new(
-            wallet_db,
-            ledger_db.clone(),
-            peer_manager,
-            network_state.clone(),
-            get_resolver_factory(&mut rng).unwrap(),
-            false,
-            logger,
-        );
+    let service = WalletService::new(
+        wallet_db,
+        ledger_db.clone(),
+        peer_manager,
+        network_state.clone(),
+        get_resolver_factory(&mut rng).unwrap(),
+        false,
+        logger,
+    );
 
     let rocket_config: rocket::Config =
         rocket::Config::build(rocket::config::Environment::Development)
             .port(get_free_port())
             .unwrap();
-    let rocket = test_rocket(rocket_config, TestWalletState { service });
+
+    let rocket_instance = test_rocket(rocket_config, TestWalletState { service });
+
+    (rocket_instance, ledger_db, db_test_context, network_state)
+}
+
+pub fn setup(
+    rng: &mut StdRng,
+    logger: Logger,
+) -> (
+    Client,
+    LedgerDB,
+    WalletDbTestContext,
+    Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
+) {
+    let (rocket_instance, ledger_db, db_test_context, network_state) =
+        create_test_setup(rng, logger);
+
+    let rocket = rocket_instance.manage(APIKeyState("".to_string()));
+    (
+        Client::new(rocket).expect("valid rocket instance"),
+        ledger_db,
+        db_test_context,
+        network_state,
+    )
+}
+
+pub fn setup_with_api_key(
+    rng: &mut StdRng,
+    logger: Logger,
+    api_key: String,
+) -> (
+    Client,
+    LedgerDB,
+    WalletDbTestContext,
+    Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
+) {
+    let (rocket_instance, ledger_db, db_test_context, network_state) =
+        create_test_setup(rng, logger);
+
+    let rocket = rocket_instance.manage(APIKeyState(api_key));
+
     (
         Client::new(rocket).expect("valid rocket instance"),
         ledger_db,

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -12,7 +12,7 @@ mod e2e {
         json_rpc,
         json_rpc::api_test_utils::{
             dispatch, dispatch_expect_error, dispatch_with_header,
-            dispatch_with_header_expect_error, setup,
+            dispatch_with_header_expect_error, setup, setup_with_api_key,
         },
         test_utils::{
             add_block_to_ledger_db, add_block_with_tx_proposal, manually_sync_account, MOB,
@@ -28,7 +28,7 @@ mod e2e {
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Token};
     use rand::{rngs::StdRng, SeedableRng};
     use rocket::http::{Header, Status};
-    use std::{convert::TryFrom, env};
+    use std::convert::TryFrom;
 
     #[test_with_logger]
     fn test_e2e_account_crud(logger: Logger) {
@@ -3474,9 +3474,11 @@ mod e2e {
 
     #[test_with_logger]
     fn test_request_with_correct_api_key(logger: Logger) {
-        env::set_var("MC_API_KEY", "mobilecats");
+        let api_key = "mobilecats";
+
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
+        let (client, _ledger_db, _db_ctx, _network_state) =
+            setup_with_api_key(&mut rng, logger.clone(), api_key.to_string());
 
         let body = json!({
             "jsonrpc": "2.0",
@@ -3487,16 +3489,18 @@ mod e2e {
             },
         });
 
-        let header = Header::new("X-API-KEY", "mobilecats");
+        let header = Header::new("X-API-KEY", api_key);
 
         dispatch_with_header(&client, body, header, &logger);
     }
 
     #[test_with_logger]
     fn test_request_with_bad_api_key(logger: Logger) {
-        env::set_var("MC_API_KEY", "mobilecats");
+        let api_key = "mobilecats";
+
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
+        let (client, _ledger_db, _db_ctx, _network_state) =
+            setup_with_api_key(&mut rng, logger.clone(), api_key.to_string());
 
         let body = json!({
             "jsonrpc": "2.0",
@@ -3508,6 +3512,7 @@ mod e2e {
         });
 
         let header = Header::new("X-API-KEY", "wrong-header");
+
         dispatch_with_header_expect_error(&client, body, header, &logger, Status::Unauthorized);
     }
 }

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -88,7 +88,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for ApiKeyGuard {
         if local_key == client_key {
             Outcome::Success(ApiKeyGuard {})
         } else {
-            Outcome::Failure((Status::BadRequest, ApiKeyError::Invalid))
+            Outcome::Failure((Status::Unauthorized, ApiKeyError::Invalid))
         }
     }
 }
@@ -135,18 +135,20 @@ where
 /// The route for the Full Service Wallet API.
 #[post("/wallet", format = "json", data = "<command>")]
 pub fn consensus_backed_wallet_api(
+    _api_key_guard: ApiKeyGuard,
     state: rocket::State<WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>>,
     command: Json<JsonRPCRequest>,
 ) -> Result<Json<JsonRPCResponse>, String> {
-    generic_wallet_api(state, command)
+    generic_wallet_api(_api_key_guard, state, command)
 }
 
 #[post("/wallet", format = "json", data = "<command>")]
 pub fn validator_backed_wallet_api(
+    _api_key_guard: ApiKeyGuard,
     state: rocket::State<WalletState<ValidatorConnection, FogResolver>>,
     command: Json<JsonRPCRequest>,
 ) -> Result<Json<JsonRPCResponse>, String> {
-    generic_wallet_api(state, command)
+    generic_wallet_api(_api_key_guard, state, command)
 }
 
 /// The Wallet API inner method, which handles switching on the method enum.

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -83,7 +83,6 @@ impl<'a, 'r> FromRequest<'a, 'r> for ApiKeyGuard {
     fn from_request(
         req: &'a Request<'r>,
     ) -> Outcome<Self, (rocket::http::Status, Self::Error), ()> {
-        println!("Tested from_request.");
         let client_key = req.headers().get_one(API_KEY_HEADER).unwrap_or_default();
         let local_key = std::env::var("MC_API_KEY").unwrap_or_default();
         if local_key == client_key {


### PR DESCRIPTION
### Motivation

Increase security on the full-service wallet's jsonrpc loop.  

### In this PR
* Full-service now examines an MC_API_KEY environment variable. If the environment variable is left blank, no checks will be performed. However, if the environment variable is set, an equality check will be performed, looking for an X-API-KEY header in the incoming http request. If these are not equal, an error will be returned. If this header does equal the environment variable, the jsonrpc command will be performed.

* The API key sourced from an env var and then added to the Rocket client's state. This allows us to source the API key from places other than the env var without changing the code for the request guard, which is particularly useful in testing. Testing with env vars in Rust is a bit fraught. Env vars are shared across all tests and tests run simultaneously, so you can't scope an env var config to a particular test. 

* Also did a bit of test util refactoring to help test this functionality

Implements functionality described in Asana ticket "[full-service API key](https://app.asana.com/0/1200175610892874/1201332924058314/f)"

In addition to unit tests, I ran the following smoke tests:
- expect request to succeed when I don't set env var and also don't set key header
- expect request to fail when I don't set env var but do set key header
- expect request to succeed when i set env var and set matching key header
- expect request to fail when I set env var and set mismatched key header