### PR TITLE
Get Subaddress by Index

### DIFF
--- a/docs/accounts/address/get_address_for_account.md
+++ b/docs/accounts/address/get_address_for_account.md
@@ -1,0 +1,52 @@
+---
+description: Get an assigned address by index for an account.
+---
+
+# Get Address For Account
+
+## Parameters
+
+| Required Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `account_id` | The account on which to perform this action. | The account must exist in the wallet. |
+| `index` | The subaddress index to lookup | The address must have already been assigned. |
+
+## Example
+
+{% tabs %}
+{% tab title="Request Body" %}
+```text
+{
+  "method": "get_address_for_account",
+  "params": {
+    "account_id": "a8c9c7acb96cf4ad9154eec9384c09f2c75a340b441924847fe5f60a41805bde",
+    "index": 1
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```text
+{
+  "method": "get_address_for_account",
+  "result": {
+      "address": {
+        "object": "address",
+        "public_address": "4bgkVAH1hs55dwLTGVpZER8ZayhqXbYqfuyisoRrmQPXoWcYQ3SQRTjsAytCiAgk21CRrVNysVw5qwzweURzDK9HL3rGXFmAAahb364kYe3",
+        "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
+        "metadata": "Main",
+        "subaddress_index": "0"
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+}
+verify_a
+```
+{% endtab %}
+{% endtabs %}
+

--- a/docs/accounts/address/get_address_for_account.md
+++ b/docs/accounts/address/get_address_for_account.md
@@ -45,7 +45,6 @@ description: Get an assigned address by index for an account.
   "jsonrpc": "2.0",
   "id": 1,
 }
-verify_a
 ```
 {% endtab %}
 {% endtabs %}

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -2189,7 +2189,7 @@ mod e2e {
     #[test_with_logger]
     fn test_get_address_for_account(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, mut ledger_db, db_ctx, network_state) = setup(&mut rng, logger.clone());
+        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
 
         // Add an account
         let body = json!({

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -133,6 +133,10 @@ pub enum JsonCommandRequest {
     get_account_status {
         account_id: String,
     },
+    get_address_for_account {
+        account_id: String,
+        index: i64,
+    },
     get_addresses_for_account {
         account_id: String,
         offset: String,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -180,6 +180,9 @@ pub enum JsonCommandResponse {
         account: Account,
         balance: Balance,
     },
+    get_address_for_account {
+        address: serde_json::Value,
+    },
     get_addresses_for_account {
         public_addresses: Vec<String>,
         address_map: Map<String, serde_json::Value>,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -181,7 +181,7 @@ pub enum JsonCommandResponse {
         balance: Balance,
     },
     get_address_for_account {
-        address: serde_json::Value,
+        address: Address,
     },
     get_addresses_for_account {
         public_addresses: Vec<String>,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -384,13 +384,11 @@ where
             JsonCommandResponse::get_account_status { account, balance }
         }
         JsonCommandRequest::get_address_for_account { account_id, index } => {
-            let address = service
+            let assigned_subaddress = service
                 .get_address_for_account(&AccountID(account_id), index)
                 .map_err(format_error)?;
-            let address_json =
-                serde_json::to_value(&(Address::from(&address))).expect("Could not get json value");
             JsonCommandResponse::get_address_for_account {
-                address: address_json,
+                address: Address::from(&assigned_subaddress),
             }
         }
         JsonCommandRequest::get_addresses_for_account {

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -383,6 +383,16 @@ where
             );
             JsonCommandResponse::get_account_status { account, balance }
         }
+        JsonCommandRequest::get_address_for_account { account_id, index } => {
+            let address = service
+                .get_address_for_account(&AccountID(account_id), index)
+                .map_err(format_error)?;
+            let address_json =
+                serde_json::to_value(&(Address::from(&address))).expect("Could not get json value");
+            JsonCommandResponse::get_address_for_account {
+                address: address_json,
+            }
+        }
         JsonCommandRequest::get_addresses_for_account {
             account_id,
             offset,


### PR DESCRIPTION
added functionality for getting a subaddress by its index. The address must have already been assigned to prevent users for accidentally getting an address at some random integer and effectively losing the txo's that end up there.