### PR TITLE
Excluding mobilecoin submodule from linter

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -8,7 +8,7 @@ if [[ ! -z "$1" ]]; then
     cd "$1"
 fi
 
-for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
+for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --exclude-dir mobilecoin --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
   cargo fmt -- --unstable-features --check


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=2Pzq5f6-PYo)

### Motivation

Running the linter in Fullservice fails because it tries to lint the mobilecoin submodule which needs to be run in an enclave. 

### In this PR
Excluding mobilecoin submodule from the linter

