### PR TITLE
LedgerDb syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,8 +2829,11 @@ name = "mc-validator-service"
 version = "1.0.0"
 dependencies = [
  "grpcio",
+ "mc-attest-verifier",
  "mc-common",
+ "mc-consensus-enclave-measurement",
  "mc-full-service",
+ "mc-ledger-sync",
  "mc-util-grpc",
  "mc-util-parse",
  "mc-util-uri",

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -127,7 +127,11 @@ fn main() {
     .expect("Failed creating ReqwestTransactionsFetcher");
 
     // Create the ledger_db.
-    let ledger_db = config.create_or_open_ledger_db(&logger, &transactions_fetcher);
+    let ledger_db = config.ledger_db_config.create_or_open_ledger_db(
+        &transactions_fetcher,
+        config.offline,
+        &logger,
+    );
 
     // Start ledger sync thread unless running in offline mode.
     let _ledger_sync_service_thread = if config.offline {

--- a/validator/service/Cargo.toml
+++ b/validator/service/Cargo.toml
@@ -13,7 +13,10 @@ path = "src/bin/main.rs"
 mc-full-service = { path = "../../full-service"}
 mc-validator-api = { path = "../api" }
 
+mc-attest-verifier = { path = "../../mobilecoin/attest/verifier" }
 mc-common = { path = "../../mobilecoin/common", default-features = false, features = ["loggers"] }
+mc-consensus-enclave-measurement = { path = "../../mobilecoin/consensus/enclave/measurement" }
+mc-ledger-sync = { path = "../../mobilecoin/ledger/sync" }
 mc-util-grpc = { path = "../../mobilecoin/util/grpc" }
 mc-util-parse = { path = "../../mobilecoin/util/parse" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -57,9 +57,9 @@ fn main() {
 
     // Start ledger sync thread.
     let _ledger_sync_service_thread = LedgerSyncServiceThread::new(
-        ledger_db.clone(),
-        peer_manager.clone(),
-        network_state.clone(),
+        ledger_db,
+        peer_manager,
+        network_state,
         transactions_fetcher,
         config.poll_interval,
         logger.clone(),

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -2,8 +2,11 @@
 
 //! The entrypoint for the Ledger Validator Service.
 
+use mc_attest_verifier::{MrSignerVerifier, Verifier, DEBUG_ENCLAVE};
 use mc_common::logger::{create_app_logger, log, o};
+use mc_ledger_sync::{LedgerSyncServiceThread, PollingNetworkState, ReqwestTransactionsFetcher};
 use mc_validator_service::{Config, Service};
+use std::sync::{Arc, RwLock};
 use structopt::StructOpt;
 
 fn main() {
@@ -15,6 +18,49 @@ fn main() {
     let config = Config::from_args();
 
     log::info!(logger, "Read Configs: {:?}", config);
+
+    // Create enclave verifier.
+    let mut mr_signer_verifier =
+        MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
+    mr_signer_verifier.allow_hardening_advisory("INTEL-SA-00334");
+
+    let mut verifier = Verifier::default();
+    verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
+
+    log::debug!(logger, "Verifier: {:?}", verifier);
+
+    // Create peer manager.
+    let peer_manager = config.peers_config.create_peer_manager(verifier, &logger);
+
+    // Create network state, transactions fetcher and ledger sync.
+    let network_state = Arc::new(RwLock::new(PollingNetworkState::new(
+        config.peers_config.quorum_set(),
+        peer_manager.clone(),
+        logger.clone(),
+    )));
+
+    let transactions_fetcher = ReqwestTransactionsFetcher::new(
+        config
+            .peers_config
+            .tx_source_urls
+            .clone()
+            .unwrap_or_default(),
+        logger.clone(),
+    )
+    .expect("Failed creating ReqwestTransactionsFetcher");
+
+    // Create the ledger_db.
+    let ledger_db = config.ledger_db_config.create_or_open_ledger_db(&transactions_fetcher, false, &logger);
+
+    // Start ledger sync thread.
+    let _ledger_sync_service_thread = LedgerSyncServiceThread::new(
+        ledger_db.clone(),
+        peer_manager.clone(),
+        network_state.clone(),
+        transactions_fetcher,
+        config.poll_interval,
+        logger.clone(),
+    );
 
     // Start GRPC service.
     let _service = Service::new(&config.listen_uri, logger);

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -50,7 +50,10 @@ fn main() {
     .expect("Failed creating ReqwestTransactionsFetcher");
 
     // Create the ledger_db.
-    let ledger_db = config.ledger_db_config.create_or_open_ledger_db(&transactions_fetcher, false, &logger);
+    let ledger_db =
+        config
+            .ledger_db_config
+            .create_or_open_ledger_db(&transactions_fetcher, false, &logger);
 
     // Start ledger sync thread.
     let _ledger_sync_service_thread = LedgerSyncServiceThread::new(

--- a/validator/service/src/config.rs
+++ b/validator/service/src/config.rs
@@ -1,7 +1,7 @@
-use mc_full_service::config::PeersConfig;
+use mc_full_service::config::{LedgerDbConfig, PeersConfig};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_validator_api::ValidatorUri;
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 use structopt::StructOpt;
 
 /// Configuration options for the validator service
@@ -12,19 +12,12 @@ use structopt::StructOpt;
 )]
 pub struct Config {
     /// Listening URI.
-    // #[structopt(long)]
+    #[structopt(long, default_value = "insecure-validator://127.0.0.1/")]
     pub listen_uri: ValidatorUri,
 
-    /// Path to LedgerDB.
-    #[structopt(long, parse(from_os_str))]
-    pub ledger_db: PathBuf,
+    #[structopt(flatten)]
+    pub ledger_db_config: LedgerDbConfig,
 
-    /// Path to existing ledger db that contains the origin block, used when
-    /// initializing new ledger dbs.
-    #[structopt(long)]
-    pub ledger_db_bootstrap: Option<String>,
-
-    /// The location for the network.toml/json configuration file.
     #[structopt(flatten)]
     pub peers_config: PeersConfig,
 


### PR DESCRIPTION
### Motivation

The validator node needs to sync the ledger, similar to other clients.

### In this PR
* Making ledger-related structopt config stuff inside full-service reusable
* Adding the plumbing required to start the LedgerSyncThread inside the validator service.

I tested this locally using this command, and it synced the ledger as expected:
```
SGX_MODE=HW IAS_MODE=PROD CONSENSUS_ENCLAVE_CSS=/home/eran/full-service/consensus-enclave.css cargo run --bin mc-validator-service -- \
        --ledger-db /tmp/ledger-db/ \
        --peer mc://node1.test.mobilecoin.com/ \
        --peer mc://node2.test.mobilecoin.com/ \
        --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/ \
        --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
```