### PR TITLE
Support using the validator service as a backend for full-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "mc-util-serial",
  "mc-util-uri",
  "mc-validator-api",
+ "mc-validator-connection",
  "num_cpus",
  "rand 0.8.4",
  "rayon",
@@ -2822,6 +2823,22 @@ dependencies = [
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
+ "protobuf",
+]
+
+[[package]]
+name = "mc-validator-connection"
+version = "1.0.0"
+dependencies = [
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-common",
+ "mc-transaction-core",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "mc-validator-api",
  "protobuf",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-connection",
+ "mc-fog-report-validation",
  "mc-transaction-core",
  "mc-util-grpc",
  "mc-util-uri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "mc-util-parse",
  "mc-util-serial",
  "mc-util-uri",
+ "mc-validator-api",
  "num_cpus",
  "rand 0.8.4",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "grpcio",
  "mc-api",
  "mc-common",
+ "mc-connection",
  "mc-transaction-core",
  "mc-util-grpc",
  "mc-util-uri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 members = [
     "full-service",
     "validator/api",
+    "validator/connection",
     "validator/service",
 ]
 exclude = [

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -14,6 +14,7 @@ ip-check = []
 
 [dependencies]
 mc-validator-api = { path = "../validator/api" }
+mc-validator-connection = { path = "../validator/connection" }
 
 mc-account-keys = { path = "../mobilecoin/account-keys" }
 mc-account-keys-slip10 = { path = "../mobilecoin/account-keys/slip10" }

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -13,6 +13,8 @@ default = ["ip-check"]
 ip-check = []
 
 [dependencies]
+mc-validator-api = { path = "../validator/api" }
+
 mc-account-keys = { path = "../mobilecoin/account-keys" }
 mc-account-keys-slip10 = { path = "../mobilecoin/account-keys/slip10" }
 mc-api = { path = "../mobilecoin/api" }

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -99,7 +99,8 @@ pub struct APIConfig {
     /// transactions to fog recipients).
     #[structopt(long, parse(try_from_str=load_css_file))]
     pub fog_ingest_enclave_css: Option<Signature>,
-    /// TODO
+
+    /// Validator service to connect to, when not connecting to the consensus network directly.
     #[structopt(long)]
     pub validator: Option<ValidatorUri>,
 }

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -100,7 +100,8 @@ pub struct APIConfig {
     #[structopt(long, parse(try_from_str=load_css_file))]
     pub fog_ingest_enclave_css: Option<Signature>,
 
-    /// Validator service to connect to, when not connecting to the consensus network directly.
+    /// Validator service to connect to, when not connecting to the consensus
+    /// network directly.
     #[structopt(long)]
     pub validator: Option<ValidatorUri>,
 }

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -12,10 +12,11 @@ use mc_consensus_scp::QuorumSet;
 use mc_fog_report_connection::GrpcFogReportConnection;
 use mc_fog_report_validation::FogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
-use mc_ledger_sync::ReqwestTransactionsFetcher;
 use mc_sgx_css::Signature;
+use mc_transaction_core::BlockData;
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
+use mc_validator_api::ValidatorUri;
 
 use displaydoc::Display;
 #[cfg(feature = "ip-check")]
@@ -98,6 +99,9 @@ pub struct APIConfig {
     /// transactions to fog recipients).
     #[structopt(long, parse(try_from_str=load_css_file))]
     pub fog_ingest_enclave_css: Option<Signature>,
+    /// TODO
+    #[structopt(long)]
+    pub validator: Option<ValidatorUri>,
 }
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {
@@ -227,7 +231,7 @@ impl APIConfig {
 #[structopt()]
 pub struct PeersConfig {
     /// validator nodes to connect to.
-    #[structopt(long = "peer", required_unless = "offline")]
+    #[structopt(long = "peer", required_unless_one = &["offline", "validator"], conflicts_with_all = &["offline", "validator"])]
     pub peers: Option<Vec<ConsensusClientUri>>,
 
     /// Quorum set for ledger syncing. By default, the quorum set would include
@@ -236,13 +240,13 @@ pub struct PeersConfig {
     /// The quorum set is represented in JSON. For example:
     /// {"threshold":1,"members":[{"type":"Node","args":"node2.test.mobilecoin.
     /// com:443"},{"type":"Node","args":"node3.test.mobilecoin.com:443"}]}
-    #[structopt(long, parse(try_from_str=parse_quorum_set_from_json))]
+    #[structopt(long, parse(try_from_str=parse_quorum_set_from_json), conflicts_with_all = &["offline", "validator"])]
     quorum_set: Option<QuorumSet<ResponderId>>,
 
     /// URLs to use for transaction data.
     ///
     /// For example: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
-    #[structopt(long = "tx-source-url", required_unless = "offline")]
+    #[structopt(long = "tx-source-url", required_unless_one = &["offline", "validator"], conflicts_with_all = &["offline", "validator"])]
     pub tx_source_urls: Option<Vec<String>>,
 }
 
@@ -340,7 +344,7 @@ pub struct LedgerDbConfig {
 impl LedgerDbConfig {
     pub fn create_or_open_ledger_db(
         &self,
-        transactions_fetcher: &ReqwestTransactionsFetcher,
+        get_origin_block_and_transactions: impl Fn() -> Result<BlockData, String>,
         offline: bool,
         logger: &Logger,
     ) -> LedgerDB {
@@ -400,8 +404,7 @@ impl LedgerDbConfig {
                         "Ledger DB {:?} does not exist, bootstrapping from peer, this may take a few minutes",
                         self.ledger_db
                     );
-                    let block_data = transactions_fetcher
-                        .get_origin_block_and_transactions()
+                    let block_data = get_origin_block_and_transactions()
                         .expect("Failed to download initial transactions");
                     let mut db = LedgerDB::open(&self.ledger_db).expect("Could not open ledger_db");
                     db.append_block(

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -44,12 +44,12 @@ use crate::{
     },
 };
 use mc_common::logger::global_log;
-use mc_validator_connection::ValidatorConnection;
 use mc_connection::{
     BlockchainConnection, HardcodedCredentialsProvider, ThickClient, UserTxConnection,
 };
 use mc_fog_report_validation::{FogPubkeyResolver, FogResolver};
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut};
+use mc_validator_connection::ValidatorConnection;
 use rocket::{get, post, routes};
 use rocket_contrib::json::Json;
 use serde_json::Map;
@@ -118,8 +118,6 @@ pub fn validator_backed_wallet_api(
 ) -> Result<Json<JsonRPCResponse>, String> {
     generic_wallet_api(state, command)
 }
-
-
 
 /// The Wallet API inner method, which handles switching on the method enum.
 ///
@@ -921,7 +919,10 @@ pub fn consensus_backed_rocket(
     state: WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>,
 ) -> rocket::Rocket {
     rocket::custom(rocket_config)
-        .mount("/", routes![consensus_backed_wallet_api, wallet_help, health])
+        .mount(
+            "/",
+            routes![consensus_backed_wallet_api, wallet_help, health],
+        )
         .manage(state)
 }
 
@@ -930,6 +931,9 @@ pub fn validator_backed_rocket(
     state: WalletState<ValidatorConnection, FogResolver>,
 ) -> rocket::Rocket {
     rocket::custom(rocket_config)
-        .mount("/", routes![validator_backed_wallet_api, wallet_help, health])
+        .mount(
+            "/",
+            routes![validator_backed_wallet_api, wallet_help, health],
+        )
         .manage(state)
 }

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -44,6 +44,7 @@ use crate::{
     },
 };
 use mc_common::logger::global_log;
+use mc_validator_connection::ValidatorConnection;
 use mc_connection::{
     BlockchainConnection, HardcodedCredentialsProvider, ThickClient, UserTxConnection,
 };
@@ -63,12 +64,14 @@ pub struct WalletState<
     pub service: WalletService<T, FPR>,
 }
 
-/// The route for the Full Service Wallet API.
-#[post("/wallet", format = "json", data = "<command>")]
-fn wallet_api(
-    state: rocket::State<WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>>,
+fn generic_wallet_api<T, FPR>(
+    state: rocket::State<WalletState<T, FPR>>,
     command: Json<JsonRPCRequest>,
-) -> Result<Json<JsonRPCResponse>, String> {
+) -> Result<Json<JsonRPCResponse>, String>
+where
+    T: BlockchainConnection + UserTxConnection + 'static,
+    FPR: FogPubkeyResolver + Send + Sync + 'static,
+{
     let req: JsonRPCRequest = command.0.clone();
 
     let mut response = JsonRPCResponse {
@@ -98,6 +101,25 @@ fn wallet_api(
 
     Ok(Json(response))
 }
+
+/// The route for the Full Service Wallet API.
+#[post("/wallet", format = "json", data = "<command>")]
+pub fn consensus_backed_wallet_api(
+    state: rocket::State<WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>>,
+    command: Json<JsonRPCRequest>,
+) -> Result<Json<JsonRPCResponse>, String> {
+    generic_wallet_api(state, command)
+}
+
+#[post("/wallet", format = "json", data = "<command>")]
+pub fn validator_backed_wallet_api(
+    state: rocket::State<WalletState<ValidatorConnection, FogResolver>>,
+    command: Json<JsonRPCRequest>,
+) -> Result<Json<JsonRPCResponse>, String> {
+    generic_wallet_api(state, command)
+}
+
+
 
 /// The Wallet API inner method, which handles switching on the method enum.
 ///
@@ -894,11 +916,20 @@ fn health() -> Result<(), ()> {
 }
 
 /// Returns an instance of a Rocket server.
-pub fn rocket(
+pub fn consensus_backed_rocket(
     rocket_config: rocket::Config,
     state: WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>,
 ) -> rocket::Rocket {
     rocket::custom(rocket_config)
-        .mount("/", routes![wallet_api, wallet_help, health])
+        .mount("/", routes![consensus_backed_wallet_api, wallet_help, health])
+        .manage(state)
+}
+
+pub fn validator_backed_rocket(
+    rocket_config: rocket::Config,
+    state: WalletState<ValidatorConnection, FogResolver>,
+) -> rocket::Rocket {
+    rocket::custom(rocket_config)
+        .mount("/", routes![validator_backed_wallet_api, wallet_help, health])
         .manage(state)
 }

--- a/full-service/src/lib.rs
+++ b/full-service/src/lib.rs
@@ -10,10 +10,12 @@ mod error;
 mod json_rpc;
 mod service;
 mod util;
+mod validator_ledger_sync;
 
 pub use db::WalletDb;
 pub use json_rpc::wallet;
 pub use service::WalletService;
+pub use validator_ledger_sync::ValidatorLedgerSyncThread;
 
 extern crate alloc;
 #[macro_use]

--- a/full-service/src/validator_ledger_sync.rs
+++ b/full-service/src/validator_ledger_sync.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2018-2022 MobileCoin, Inc.
+
+//! Ledger syncing via the Validator Service.
+
+use mc_common::logger::{log, Logger};
+use mc_ledger_db::{Ledger, LedgerDB};
+use mc_transaction_core::{Block, BlockContents};
+use mc_validator_api::ValidatorUri;
+use mc_validator_connection::ValidatorConnection;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+/// The maximum number of blocks to try and retrieve in each iteration
+pub const MAX_BLOCKS_PER_SYNC_ITERATION: u32 = 1000;
+
+pub struct ValidatorLedgerSyncThread {
+    join_handle: Option<thread::JoinHandle<()>>,
+    stop_requested: Arc<AtomicBool>,
+}
+
+impl ValidatorLedgerSyncThread {
+    pub fn new(
+        validator_uri: &ValidatorUri,
+        poll_interval: Duration,
+        ledger_db: LedgerDB,
+        logger: Logger,
+    ) -> Self {
+        let stop_requested = Arc::new(AtomicBool::new(false));
+
+        let validator_conn = ValidatorConnection::new(validator_uri, logger.clone());
+
+        let thread_stop_requested = stop_requested.clone();
+        let join_handle = Some(
+            thread::Builder::new()
+                .name("ValidatorLedgerSync".into())
+                .spawn(move || {
+                    Self::thread_entrypoint(
+                        validator_conn,
+                        poll_interval,
+                        ledger_db,
+                        logger,
+                        thread_stop_requested,
+                    );
+                })
+                .expect("Failed spawning ValidatorLedgerSync thread"),
+        );
+
+        Self {
+            join_handle,
+            stop_requested,
+        }
+    }
+
+    pub fn stop(&mut self) {
+        self.stop_requested.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.join_handle.take() {
+            thread.join().expect("thread join failed");
+        }
+    }
+
+    fn thread_entrypoint(
+        validator_conn: ValidatorConnection,
+        poll_interval: Duration,
+        mut ledger_db: LedgerDB,
+        logger: Logger,
+        stop_requested: Arc<AtomicBool>,
+    ) {
+        log::info!(logger, "ValidatorLedgerSync thread started");
+
+        loop {
+            if stop_requested.load(Ordering::SeqCst) {
+                log::debug!(logger, "ValidatorLedgerSyncThread stop requested.");
+                break;
+            }
+
+            let blocks_and_contents = Self::get_next_blocks(&ledger_db, &validator_conn, &logger);
+            if !blocks_and_contents.is_empty() {
+                Self::append_safe_blocks(&mut ledger_db, &blocks_and_contents, &logger);
+            }
+
+            // If we got no blocks, or less than the amount we asked for, sleep for a bit.
+            // Getting less the amount we asked for indicates we are fully synced.
+            if blocks_and_contents.is_empty()
+                || blocks_and_contents.len() < MAX_BLOCKS_PER_SYNC_ITERATION as usize
+            {
+                thread::sleep(poll_interval);
+            }
+        }
+    }
+
+    fn get_next_blocks(
+        ledger_db: &LedgerDB,
+        validator_conn: &ValidatorConnection,
+        logger: &Logger,
+    ) -> Vec<(Block, BlockContents)> {
+        let num_blocks = ledger_db
+            .num_blocks()
+            .expect("Failed getting the number of blocks in ledger");
+
+        let blocks_data =
+            match validator_conn.get_blocks_data(num_blocks, MAX_BLOCKS_PER_SYNC_ITERATION) {
+                Ok(blocks_data) => blocks_data,
+                Err(err) => {
+                    log::error!(
+                        logger,
+                        "Failed getting blocks data from validator: {:?}",
+                        err
+                    );
+                    return Vec::new();
+                }
+            };
+
+        let blocks_and_contents: Vec<(Block, BlockContents)> = blocks_data
+            .into_iter()
+            .map(|block_data| (block_data.block().clone(), block_data.contents().clone()))
+            .collect();
+
+        match mc_ledger_sync::identify_safe_blocks(ledger_db, &blocks_and_contents, logger) {
+            Ok(safe_blocks) => safe_blocks,
+            Err(err) => {
+                log::error!(logger, "Failed identifying safe blocks: {:?}", err);
+                Vec::new()
+            }
+        }
+    }
+
+    fn append_safe_blocks(
+        ledger_db: &mut LedgerDB,
+        blocks_and_contents: &[(Block, BlockContents)],
+        logger: &Logger,
+    ) {
+        log::info!(
+            logger,
+            "Appending {} blocks to ledger, which currently has {} blocks",
+            blocks_and_contents.len(),
+            ledger_db
+                .num_blocks()
+                .expect("failed getting number of blocks"),
+        );
+
+        for (block, contents) in blocks_and_contents {
+            ledger_db
+                .append_block(block, contents, None)
+                .expect(&format!(
+                    "Failed appending block #{} to ledger",
+                    block.index
+                ));
+        }
+    }
+}
+
+impl Drop for ValidatorLedgerSyncThread {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/full-service/src/validator_ledger_sync.rs
+++ b/full-service/src/validator_ledger_sync.rs
@@ -170,10 +170,9 @@ impl ValidatorLedgerSyncThread {
         for (block, contents) in blocks_and_contents {
             ledger_db
                 .append_block(block, contents, None)
-                .expect(&format!(
-                    "Failed appending block #{} to ledger",
-                    block.index
-                ));
+                .unwrap_or_else(|err| {
+                    panic!("Failed appending block #{} to ledger: {}", block.index, err)
+                });
         }
     }
 }

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -9,6 +9,7 @@ mc-validator-api = { path = "../api" }
 
 mc-api = { path = "../../mobilecoin/api" }
 mc-common = { path = "../../mobilecoin/common", features = ["log"] }
+mc-connection = { path = "../../mobilecoin/connection" }
 mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
 mc-util-grpc = { path = "../../mobilecoin/util/grpc" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mc-validator-connection"
+version = "1.0.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+mc-validator-api = { path = "../api" }
+
+mc-api = { path = "../../mobilecoin/api" }
+mc-common = { path = "../../mobilecoin/common", features = ["log"] }
+mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
+mc-util-grpc = { path = "../../mobilecoin/util/grpc" }
+mc-util-uri = { path = "../../mobilecoin/util/uri" }
+
+displaydoc = {version = "0.2", default-features = false }
+futures = "0.3"
+grpcio = "0.9.0"
+protobuf = "2.22.1"

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -10,6 +10,7 @@ mc-validator-api = { path = "../api" }
 mc-api = { path = "../../mobilecoin/api" }
 mc-common = { path = "../../mobilecoin/common", features = ["log"] }
 mc-connection = { path = "../../mobilecoin/connection" }
+mc-fog-report-validation = { path = "../../mobilecoin/fog/report/validation" }
 mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
 mc-util-grpc = { path = "../../mobilecoin/util/grpc" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }

--- a/validator/connection/src/error.rs
+++ b/validator/connection/src/error.rs
@@ -7,6 +7,9 @@ pub enum Error {
 
     /// Api Conversion: {0}
     ApiConversion(mc_api::ConversionError),
+
+    /// No reports returned from fog
+    NoReports,
 }
 
 impl From<grpcio::Error> for Error {
@@ -26,6 +29,9 @@ impl From<Error> for mc_connection::Error {
         match src {
             Error::Rpc(src) => mc_connection::Error::Grpc(src),
             Error::ApiConversion(src) => mc_connection::Error::Conversion(src),
+            Error::NoReports => {
+                mc_connection::Error::Other("No reports returned from fog".to_string())
+            }
         }
     }
 }

--- a/validator/connection/src/error.rs
+++ b/validator/connection/src/error.rs
@@ -15,9 +15,17 @@ impl From<grpcio::Error> for Error {
     }
 }
 
-impl From<mc_api::ConversionError> for Error  {
+impl From<mc_api::ConversionError> for Error {
     fn from(src: mc_api::ConversionError) -> Self {
         Self::ApiConversion(src)
     }
 }
 
+impl From<Error> for mc_connection::Error {
+    fn from(src: Error) -> Self {
+        match src {
+            Error::Rpc(src) => mc_connection::Error::Grpc(src),
+            Error::ApiConversion(src) => mc_connection::Error::Conversion(src),
+        }
+    }
+}

--- a/validator/connection/src/error.rs
+++ b/validator/connection/src/error.rs
@@ -1,0 +1,23 @@
+use displaydoc::Display;
+
+#[derive(Display, Debug)]
+pub enum Error {
+    /// GRPC: {0}
+    Rpc(grpcio::Error),
+
+    /// Api Conversion: {0}
+    ApiConversion(mc_api::ConversionError),
+}
+
+impl From<grpcio::Error> for Error {
+    fn from(src: grpcio::Error) -> Self {
+        Self::Rpc(src)
+    }
+}
+
+impl From<mc_api::ConversionError> for Error  {
+    fn from(src: mc_api::ConversionError) -> Self {
+        Self::ApiConversion(src)
+    }
+}
+

--- a/validator/connection/src/lib.rs
+++ b/validator/connection/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2018-2022 MobileCoin, Inc.
+
+//! Validator GRPC client.
+
+mod error;
+
+use grpcio::{ChannelBuilder, EnvBuilder};
+use mc_common::logger::Logger;
+use mc_transaction_core::BlockData;
+use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_validator_api::{
+    blockchain::ArchiveBlock, consensus_common::BlocksRequest,
+    consensus_common_grpc::BlockchainApiClient, validator_api_grpc::ValidatorApiClient,
+    ValidatorUri,
+};
+use std::{convert::TryFrom, sync::Arc};
+
+pub use error::Error;
+
+#[derive(Clone)]
+pub struct ValidatorConnection {
+    validator_api_client: ValidatorApiClient,
+    blockchain_api_client: BlockchainApiClient,
+}
+
+impl ValidatorConnection {
+    pub fn new(uri: &ValidatorUri, logger: Logger) -> Self {
+        let env = Arc::new(EnvBuilder::new().name_prefix("ValidatorRPC").build());
+        let ch = ChannelBuilder::new(env)
+            .max_receive_message_len(std::i32::MAX)
+            .max_send_message_len(std::i32::MAX)
+            .connect_to_uri(uri, &logger);
+
+        let validator_api_client = ValidatorApiClient::new(ch.clone());
+        let blockchain_api_client = BlockchainApiClient::new(ch);
+
+        Self {
+            validator_api_client,
+            blockchain_api_client,
+        }
+    }
+
+    pub fn get_archive_blocks(&self, offset: u64, limit: u32) -> Result<Vec<ArchiveBlock>, Error> {
+        let mut request = BlocksRequest::new();
+        request.set_offset(offset);
+        request.set_limit(limit);
+
+        let response = self.validator_api_client.get_archive_blocks(&request)?;
+
+        Ok(response.get_blocks().to_vec())
+    }
+
+    pub fn get_blocks_data(&self, offset: u64, limit: u32) -> Result<Vec<BlockData>, Error> {
+        let archive_blocks = self.get_archive_blocks(offset, limit)?;
+
+        let blocks_data = archive_blocks
+            .iter()
+            .map(BlockData::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(blocks_data)
+    }
+}

--- a/validator/connection/src/lib.rs
+++ b/validator/connection/src/lib.rs
@@ -6,19 +6,35 @@ mod error;
 
 use grpcio::{ChannelBuilder, EnvBuilder};
 use mc_common::logger::Logger;
-use mc_transaction_core::BlockData;
+use mc_connection::{
+    BlockInfo, BlockchainConnection, Connection, Error as ConnectionError,
+    Result as ConnectionResult, UserTxConnection,
+};
+use mc_transaction_core::{tx::Tx, Block, BlockData, BlockID, BlockIndex};
 use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_util_uri::ConnectionUri;
 use mc_validator_api::{
-    blockchain::ArchiveBlock, consensus_common::BlocksRequest,
-    consensus_common_grpc::BlockchainApiClient, validator_api_grpc::ValidatorApiClient,
+    blockchain::ArchiveBlock,
+    consensus_common::{BlocksRequest, ProposeTxResult},
+    consensus_common_grpc::BlockchainApiClient,
+    empty::Empty,
+    validator_api_grpc::ValidatorApiClient,
     ValidatorUri,
 };
-use std::{convert::TryFrom, sync::Arc};
+use std::{
+    cmp::Ordering,
+    convert::TryFrom,
+    fmt::{Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+    ops::Range,
+    sync::Arc,
+};
 
 pub use error::Error;
 
 #[derive(Clone)]
 pub struct ValidatorConnection {
+    uri: ValidatorUri,
     validator_api_client: ValidatorApiClient,
     blockchain_api_client: BlockchainApiClient,
 }
@@ -35,6 +51,7 @@ impl ValidatorConnection {
         let blockchain_api_client = BlockchainApiClient::new(ch);
 
         Self {
+            uri: uri.clone(),
             validator_api_client,
             blockchain_api_client,
         }
@@ -58,5 +75,93 @@ impl ValidatorConnection {
             .map(BlockData::try_from)
             .collect::<Result<Vec<_>, _>>()?;
         Ok(blocks_data)
+    }
+}
+
+impl Display for ValidatorConnection {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", self.uri)
+    }
+}
+
+impl Eq for ValidatorConnection {}
+
+impl Hash for ValidatorConnection {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.uri.addr().hash(hasher);
+    }
+}
+
+impl PartialEq for ValidatorConnection {
+    fn eq(&self, other: &Self) -> bool {
+        self.uri.addr() == other.uri.addr()
+    }
+}
+
+impl Ord for ValidatorConnection {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.uri.addr().cmp(&other.uri.addr())
+    }
+}
+
+impl PartialOrd for ValidatorConnection {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.uri.addr().partial_cmp(&other.uri.addr())
+    }
+}
+
+impl Connection for ValidatorConnection {
+    type Uri = ValidatorUri;
+
+    fn uri(&self) -> Self::Uri {
+        self.uri.clone()
+    }
+}
+
+impl BlockchainConnection for ValidatorConnection {
+    /// Retrieve the block metadata from the blockchain service.
+    fn fetch_blocks(&mut self, range: Range<BlockIndex>) -> ConnectionResult<Vec<Block>> {
+        let limit =
+            u32::try_from(range.end - range.start).or(Err(ConnectionError::RequestTooLarge))?;
+        let blocks_data = self.get_blocks_data(range.start, limit)?;
+
+        Ok(blocks_data
+            .into_iter()
+            .map(|block_data| block_data.block().clone())
+            .collect())
+    }
+
+    /// Retrieve the BlockIDs (hashes) of the given blocks from the blockchain
+    /// service.
+    fn fetch_block_ids(&mut self, range: Range<BlockIndex>) -> ConnectionResult<Vec<BlockID>> {
+        self.fetch_blocks(range)
+            .map(|blocks| blocks.into_iter().map(|block| block.id).collect())
+    }
+
+    /// Retrieve the consensus node's current block height
+    fn fetch_block_height(&mut self) -> ConnectionResult<BlockIndex> {
+        let response = self
+            .blockchain_api_client
+            .get_last_block_info(&Empty::new())?;
+        Ok(response.get_index())
+    }
+
+    /// Retrieve the consensus node's current block height and fee
+    fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
+        let response = self
+            .blockchain_api_client
+            .get_last_block_info(&Empty::new())?;
+        Ok(response.into())
+    }
+}
+
+impl UserTxConnection for ValidatorConnection {
+    fn propose_tx(&mut self, tx: &Tx) -> ConnectionResult<u64> {
+        let response = self.validator_api_client.propose_tx(&tx.into())?;
+        if response.get_result() == ProposeTxResult::Ok {
+            Ok(response.get_block_count())
+        } else {
+            Err(response.get_result().into())
+        }
     }
 }

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -50,10 +50,15 @@ fn main() {
     .expect("Failed creating ReqwestTransactionsFetcher");
 
     // Create the ledger_db.
-    let ledger_db =
-        config
-            .ledger_db_config
-            .create_or_open_ledger_db(&transactions_fetcher, false, &logger);
+    let ledger_db = config.ledger_db_config.create_or_open_ledger_db(
+        || {
+            transactions_fetcher
+                .get_origin_block_and_transactions()
+                .map_err(|err| err.to_string())
+        },
+        false,
+        &logger,
+    );
 
     // Start ledger sync thread.
     let _ledger_sync_service_thread = LedgerSyncServiceThread::new(


### PR DESCRIPTION
This PR contains the changes to full-service that allows it to get the ledger, submit transactions and lookup fog reports by using the validator service.

I have tested it locally using testnet and was able to:
* Sync the ledger
* Send a transaction to my desktop wallet account
* Send a transaction to my mobile wallet
* Receive a transaction sent into the full-service account

Next steps:
* In order to ensure full-service, when using this new `--validator` mode, really does not connect anywhere else, this needs to get tested on a firewalled machine that can only make outgoing connections to a single host:port.
* Unit tests for the validator API endpoints might be useful
* Full end to end test with the mirror

Now, for those that are interested in running this, here are the steps I took.

First, you need to have the CSS files for consensus and ingest. Once you have those you need to run the validator service. For testnet, this translates to:
```
SGX_MODE=HW IAS_MODE=PROD CONSENSUS_ENCLAVE_CSS=/home/eran/full-service/consensus-enclave.css cargo run --bin mc-validator-service -- \
        --ledger-db /tmp/ledger-db/ \
        --peer mc://node1.test.mobilecoin.com/ \
        --peer mc://node2.test.mobilecoin.com/ \
        --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/ \
        --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
```

By default the validator service will listen on `127.0.0.1:5554`.

Now, run `full-service`:
```
SGX_MODE=HW IAS_MODE=PROD CONSENSUS_ENCLAVE_CSS=/home/eran/full-service/consensus-enclave.css cargo run --bin full-service --release -- \
        --ledger-db /tmp/proxied/ledger-db/ \
        --wallet-db /tmp/proxied/wallet.db \
        --fog-ingest-enclave-css ingest-enclave.css \
        --validator insecure-validator://127.0.0.1:5554/
```

At this point you should be able to interact with `full-service` as usual.