### PR TITLE
LVN IP Check

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -45,7 +45,11 @@ fn main() {
     let config = APIConfig::from_args();
 
     // Exit if the user is not in an authorized country.
-    if !cfg!(debug_assertions) && !config.offline && config.validate_host().is_err() {
+    if !cfg!(debug_assertions)
+        && !config.offline
+        && !config.validator.is_some()
+        && APIConfig::validate_host().is_err()
+    {
         eprintln!("Could not validate host");
         exit(EXIT_INVALID_HOST);
     }

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -190,7 +190,7 @@ impl APIConfig {
     ///
     /// Note, both of these services are free tier and rate-limited.
     #[cfg(feature = "ip-check")]
-    pub fn validate_host(&self) -> Result<(), ConfigError> {
+    pub fn validate_host() -> Result<(), ConfigError> {
         let client = Client::builder().gzip(true).use_rustls_tls().build()?;
         let mut json_headers = HeaderMap::new();
         json_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -224,7 +224,7 @@ impl APIConfig {
     }
 
     #[cfg(not(feature = "ip-check"))]
-    pub fn validate_host(&self) -> Result<(), ConfigError> {
+    pub fn validate_host() -> Result<(), ConfigError> {
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

When using the `--validator` option and LVN, the LVN should perform the IP checking and not `full-service`.

### In this PR
* Add IP checking to LVN
* Skip IP checking in `full-service` when running with `--validator`
