### PR TITLE
First draft removing ip check feature and adding ipcheck for validator

### DIFF
--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -8,10 +8,6 @@ edition = "2018"
 name = "full-service"
 path = "src/bin/main.rs"
 
-[features]
-default = ["ip-check"]
-ip-check = []
-
 [dependencies]
 mc-validator-api = { path = "../validator/api" }
 mc-validator-connection = { path = "../validator/connection" }

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -12,6 +12,7 @@ use mc_connection::ConnectionManager;
 use mc_consensus_scp::QuorumSet;
 use mc_fog_report_validation::FogResolver;
 use mc_full_service::{
+    check_host,
     config::APIConfig,
     wallet::{consensus_backed_rocket, validator_backed_rocket, WalletState},
     ValidatorLedgerSyncThread, WalletDb, WalletService,
@@ -45,7 +46,11 @@ fn main() {
     let config = APIConfig::from_args();
 
     // Exit if the user is not in an authorized country.
-    if !cfg!(debug_assertions) && !config.offline && config.validate_host().is_err() {
+    if !cfg!(debug_assertions)
+        && !config.offline
+        && config.validator.is_none()
+        && check_host::check_host_is_allowed_country_and_region().is_err()
+    {
         eprintln!("Could not validate host");
         exit(EXIT_INVALID_HOST);
     }

--- a/full-service/src/check_host.rs
+++ b/full-service/src/check_host.rs
@@ -33,6 +33,11 @@ impl From<reqwest::Error> for CheckHostError {
     }
 }
 
+/// Ensure local IP address is valid.
+///
+/// Uses ipinfo.io for getting details about IP address.
+///
+/// Note, both of these services are free tier and rate-limited.
 pub fn check_host_is_allowed_country_and_region() -> Result<(), CheckHostError> {
     let client = Client::builder().gzip(true).use_rustls_tls().build()?;
     let mut json_headers = HeaderMap::new();

--- a/full-service/src/check_host.rs
+++ b/full-service/src/check_host.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2018-2022 MobileCoin, Inc.
+
+//! Utility for IP check related logic.
+
 use reqwest::{
     blocking::Client,
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},

--- a/full-service/src/check_host.rs
+++ b/full-service/src/check_host.rs
@@ -1,0 +1,67 @@
+use reqwest::{
+    blocking::Client,
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+};
+
+use displaydoc::Display;
+
+/// The Errors that may occur when checking if host is allowed
+#[derive(Display, Debug)]
+pub enum CheckHostError {
+    /// Error parsing json {0}
+    Json(serde_json::Error),
+
+    /// Error handling reqwest {0}
+    Reqwest(reqwest::Error),
+
+    /// Invalid country
+    InvalidCountry,
+
+    /// Data missing in the response {0}
+    DataMissing(String),
+}
+
+impl From<serde_json::Error> for CheckHostError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Json(e)
+    }
+}
+
+impl From<reqwest::Error> for CheckHostError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Reqwest(e)
+    }
+}
+
+pub fn check_host_is_allowed_country_and_region() -> Result<(), CheckHostError> {
+    let client = Client::builder().gzip(true).use_rustls_tls().build()?;
+    let mut json_headers = HeaderMap::new();
+    json_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    let response = client
+        .get("https://ipinfo.io/json/")
+        .headers(json_headers)
+        .send()?
+        .error_for_status()?;
+    let data = response.text()?;
+    let data_json: serde_json::Value = serde_json::from_str(&data)?;
+
+    let data_missing_err = Err(CheckHostError::DataMissing(data_json.to_string()));
+    let country: &str = match data_json["country"].as_str() {
+        Some(c) => c,
+        None => return data_missing_err,
+    };
+    let region: &str = match data_json["region"].as_str() {
+        Some(r) => r,
+        None => return data_missing_err,
+    };
+
+    let err = Err(CheckHostError::InvalidCountry);
+    match country {
+        "IR" | "SY" | "CU" | "KP" => err,
+        "UA" => match region {
+            "Crimea" => err,
+            _ => Ok(()),
+        },
+        _ => Ok(()),
+    }
+}

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -18,8 +18,6 @@ use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
 use mc_validator_api::ValidatorUri;
 
-use displaydoc::Display;
-
 use std::{
     convert::TryFrom,
     fs,
@@ -28,9 +26,6 @@ use std::{
     time::Duration,
 };
 use structopt::StructOpt;
-
-use crate::check_host::{self, CheckHostError};
-
 /// Command line config for the Wallet API
 #[derive(Clone, Debug, StructOpt)]
 #[structopt(name = "full-service", about = "An HTTP wallet service for MobileCoin")]
@@ -153,18 +148,6 @@ impl APIConfig {
                 )
             }
         })
-    }
-
-    /// Ensure local IP address is valid.
-    ///
-    /// Uses ipinfo.io for getting details about IP address.
-    ///
-    /// Note, both of these services are free tier and rate-limited.
-    pub fn validate_host(&self) -> Result<(), CheckHostError> {
-        if self.validator.is_some() {
-            return Ok(());
-        }
-        check_host::check_host_is_allowed_country_and_region()
     }
 }
 

--- a/full-service/src/lib.rs
+++ b/full-service/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![feature(proc_macro_hygiene, decl_macro)]
 
+pub mod check_host;
 pub mod config;
 mod db;
 mod error;

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use structopt::StructOpt;
 
+// Exit codes.
 const EXIT_INVALID_HOST: i32 = 4;
 
 fn main() {


### PR DESCRIPTION
Motivation
When using the --validator option and LVN, the LVN should perform the IP checking and not full-service.

In this PR
Add IP checking to LVN
Skip IP checking in full-service when running with --validator