### PR TITLE
Make logging of validator-related failures more explicit

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -255,7 +255,10 @@ fn validator_backed_full_service(
                 let report_responses = validator_conn
                     .fetch_fog_reports(fog_uris.iter().cloned())
                     .map_err(|err| {
-                    format!("Error fetching fog reports for {:?}: {}", fog_uris, err)
+                    format!(
+                        "Error fetching fog reports (via validator) for {:?}: {}",
+                        fog_uris, err
+                    )
                 })?;
 
                 log::debug!(logger2, "Got report responses {:?}", report_responses);


### PR DESCRIPTION
### Motivation

I ran into this log message today:
```
 "details": "Error building transaction: Error generating FogPubkeyResolver Error fetching fog reports for [Uri { url: Url { scheme: \"fog\", cannot_be_a_base: false, username: \"\", password: None, host: Some(Domain(\"fog.prod.mobilecoinww.com\")), port: None, path: \"/\", query: None, fragment: None }, host: \"fog.prod.mobilecoinww.com\", port: 443, use_tls: true, username: \"\", password: \"\", _scheme: PhantomData }]: GRPC: RpcFailure: 14-UNAVAILABLE failed to connect to all addresses"
```

Initially it appeared to me as if `fog.prod.mobilecoinww.com` was not responding, but in reality it was the validator node that was not responding. This confusion will make future debugging more difficult, so I am proposing to make some logging more verbose.

### In this PR
* Making some failure cases log more verbosely 
