### PR TITLE
Update builder and base image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN  --mount=type=cache,target=/root/.cargo/git \
 
 # This is the runtime container.
 # Adding/updating OS will not affect the ability to verify the build environment.
-FROM ubuntu:bionic-20210416
+FROM ubuntu:focal-20211006
 
 RUN  addgroup --system --gid 1000 app \
   && adduser --system --ingroup app --uid 1000 app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # In order to create a consistent and verifiable the build environment, only add
 # or update in the mobilecoin/rust-sgx-base image and refer to the image by its hash.
 
-FROM mobilecoin/rust-sgx-base@sha256:cf4ff6d68e937d1f57a8e445a06e257949b515a241e06c32c41820ec697c2ddb as builder
+FROM mobilecoin/rust-sgx-base@sha256:a7fcad9b7172ea0f20b2a83a47fbc34f13363cfd95788cc32427a658790adef0 as builder
 
 ARG NAMESPACE=test
 ARG SIGNED_ENCLAVE_BASE=enclave-distribution.${NAMESPACE}.mobilecoin.com


### PR DESCRIPTION
Soundtrack of this PR: [Jaco Pastorius - Portrait of Tracy](https://www.youtube.com/watch?v=nsZ_1mPOuyk)

### Motivation

The full-service docker container needed to be updated with a new builder image reference, as well as a base image reference, so that all images used Ubuntu Focal Fossa (20.04) and had the correct dev packages installed for the build.

### In this PR
* Uses an updated builder image sha reference (that contains `pkg-config`)
* Uses an updated base image (Ubuntu 20.04)

### Future Work
* None