### PR TITLE
Fix a bug causing sync to create many tiny chunks.

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -687,6 +687,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         // Build a transaction
@@ -841,6 +842,7 @@ mod tests {
             &mut ledger_db,
             &vec![100 * MOB as u64, 200 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         // Build a transaction
@@ -1019,6 +1021,7 @@ mod tests {
             &mut ledger_db,
             &vec![7_000_000 * MOB as u64, 14_000_000 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         // Build a transaction for > i64::Max
@@ -1076,6 +1079,7 @@ mod tests {
             &mut ledger_db,
             &vec![7 * MOB as u64, 8 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let mut builder = WalletTransactionBuilder::new(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1060,6 +1060,8 @@ mod tests {
         let _alice_account =
             manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 14, &logger);
 
+        manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 14, &logger);
+
         // We should now have 3 txos for this account - one spent, one change (minted),
         // and one minted (destined for alice).
         let txos = Txo::list_for_account(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1136,10 +1136,6 @@ mod tests {
         assert_eq!(alice_account.next_block_index, 14);
         assert_eq!(alice_account.next_subaddress_index, 5);
 
-        // Scan for alice to pick up the orphaned Txo
-        let _alice_account =
-            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 14, &logger);
-
         // Check that a transaction log entry was created for each received TxOut (note:
         // we are not creating submit logs in this test)
         let transaction_logs = TransactionLog::list_all(
@@ -1512,6 +1508,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
+            &logger,
         );
         let sender_account_id = AccountID::from(&sender_account_key);
 

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -203,10 +203,6 @@ fn sync_account_next_chunk(
                 key_images.push((block_index, key_image));
             }
         }
-        if tx_outs.is_empty() {
-            return Ok(SyncStatus::NoMoreBlocks);
-        }
-
         // Attempt to decode each transaction as received by this account.
         let received_txos: Vec<_> = tx_outs
             .into_par_iter()
@@ -312,12 +308,14 @@ fn sync_account_next_chunk(
         // Done syncing this chunk. Mark these blocks as synced for this account.
         account.update_next_block_index(last_block_index + 1, conn)?;
 
+        let num_blocks_synced = last_block_index - first_block_index + 1;
+
         let duration = start_time.elapsed();
 
         log::debug!(
             logger,
             "Synced {} blocks ({}-{}) for account {} in {:?}. {} txos received, {}/{} txos spent.",
-            last_block_index - first_block_index + 1,
+            num_blocks_synced,
             first_block_index,
             last_block_index,
             account_id_hex.chars().take(6).collect::<String>(),
@@ -327,7 +325,11 @@ fn sync_account_next_chunk(
             unspent_key_images.len(),
         );
 
-        Ok(SyncStatus::ChunkFinished)
+        if num_blocks_synced < BLOCKS_CHUNK_SIZE {
+            Ok(SyncStatus::NoMoreBlocks)
+        } else {
+            Ok(SyncStatus::ChunkFinished)
+        }
     })
 }
 

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -567,6 +567,7 @@ mod tests {
                 111111 * MOB as u64,
             ],
             &mut rng,
+            &logger,
         );
 
         // Construct a transaction
@@ -614,6 +615,7 @@ mod tests {
                 7_000_000 * MOB as u64,
             ],
             &mut rng,
+            &logger,
         );
 
         // Check balance
@@ -659,6 +661,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         // Get our TXO list
@@ -731,6 +734,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -789,6 +793,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -861,6 +866,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -942,6 +948,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -983,6 +990,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -1043,6 +1051,7 @@ mod tests {
                 7_000_000 * MOB as u64,
             ],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =
@@ -1083,6 +1092,7 @@ mod tests {
             &mut ledger_db,
             &vec![70 * MOB as u64, 80 * MOB as u64, 90 * MOB as u64],
             &mut rng,
+            &logger,
         );
 
         let (recipient, mut builder) =

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -354,28 +354,12 @@ pub fn manually_sync_account(
             Err(e) => panic!("Could not sync account due to {:?}", e),
         }
         account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-        if account.next_block_index as u64 == ledger_db.num_blocks().unwrap() {
+        if account.next_block_index as u64 >= ledger_db.num_blocks().unwrap() {
             break;
         }
     }
     assert_eq!(account.next_block_index as u64, target_block_index);
     account
-}
-
-fn wait_for_sync(
-    ledger_db: &LedgerDB,
-    wallet_db: &WalletDb,
-    account_id: &AccountID,
-    target_block_index: u64,
-) {
-    let mut account: Account;
-    loop {
-        account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-        if account.next_block_index as u64 == ledger_db.num_blocks().unwrap() {
-            break;
-        }
-    }
-    assert_eq!(account.next_block_index as u64, target_block_index);
 }
 
 pub fn setup_grpc_peer_manager_and_network_state(
@@ -552,6 +536,7 @@ pub fn random_account_with_seed_values(
     mut ledger_db: &mut LedgerDB,
     seed_values: &[u64],
     mut rng: &mut StdRng,
+    logger: &Logger,
 ) -> AccountKey {
     let root_id = RootIdentity::from_random(&mut rng);
     let account_key = AccountKey::from(&root_id);
@@ -580,11 +565,12 @@ pub fn random_account_with_seed_values(
         );
     }
 
-    wait_for_sync(
+    manually_sync_account(
         &ledger_db,
         &wallet_db,
         &AccountID::from(&account_key),
         ledger_db.num_blocks().unwrap(),
+        logger,
     );
 
     // Make sure we have all our TXOs


### PR DESCRIPTION
1) Start full-service with an empty ledger and an empty wallet db
2) Import an account from entropy, giving it a first_block of 0
3) The ledger sync process will enter one block at a time into the
ledger DB. The account sync process will then attempt to decode
transactions from these blocks in very small chunks, of size 5-10
(instead of ten thousand), with no sleeping in between. Furthermore, the
first account will do all of the syncing, not letting any other accounts
sync at the same time.

In order to fix this, the condition for reporting whether the sync
thread can pause was updated to more elegantly handle this condition, by
counting the number of blocks synced, and comparing it to the ideal
chunk size.
