### PR TITLE
Remove block index arg from manual account sync test util

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -802,7 +802,6 @@ mod tests {
             &ledger_db,
             &wallet_db,
             &AccountID(tx_log.account_id_hex.to_string()),
-            14,
             &logger,
         );
 
@@ -1190,7 +1189,6 @@ mod tests {
             &ledger_db,
             &wallet_db,
             &AccountID(tx_log.account_id_hex.to_string()),
-            15,
             &logger,
         );
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -990,7 +990,7 @@ mod tests {
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
 
         let _alice_account =
-            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 13, &logger);
+            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, &logger);
 
         let txos = Txo::list_for_account(
             &alice_account_id.to_string(),
@@ -1058,9 +1058,7 @@ mod tests {
 
         // Now we'll process these Txos and verify that the TXO was "spent."
         let _alice_account =
-            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 14, &logger);
-
-        manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 14, &logger);
+            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, &logger);
 
         // We should now have 3 txos for this account - one spent, one change (minted),
         // and one minted (destined for alice).
@@ -1227,11 +1225,10 @@ mod tests {
         );
 
         // Process the latest block for Bob (note, Bob is starting to sync from block 0)
-        let _bob_account =
-            manually_sync_account(&ledger_db, &wallet_db, &bob_account_id, 15, &logger);
+        let _bob_account = manually_sync_account(&ledger_db, &wallet_db, &bob_account_id, &logger);
         // Process the latest block for Alice
         let _alice_account =
-            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, 15, &logger);
+            manually_sync_account(&ledger_db, &wallet_db, &alice_account_id, &logger);
 
         // We should now have 1 txo in Bob's account.
         let txos = Txo::list_for_account(
@@ -1554,8 +1551,8 @@ mod tests {
 
         // Now let our sync thread catch up for both sender and receiver
         log::info!(logger, "Manually syncing account");
-        manually_sync_account(&ledger_db, &wallet_db, &recipient_account_id, 16, &logger);
-        manually_sync_account(&ledger_db, &wallet_db, &sender_account_id, 16, &logger);
+        manually_sync_account(&ledger_db, &wallet_db, &recipient_account_id, &logger);
+        manually_sync_account(&ledger_db, &wallet_db, &sender_account_id, &logger);
 
         // Then let's make sure we received the Txo on the recipient account
         log::info!(logger, "Listing all Txos for recipient account");

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -486,7 +486,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -593,7 +592,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -656,7 +654,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
@@ -674,7 +671,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 14);
@@ -749,7 +745,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            15,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 15);
@@ -830,7 +825,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
@@ -879,7 +873,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 14);
@@ -997,7 +990,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            15,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 15);
@@ -1203,7 +1195,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
@@ -1221,7 +1212,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 14);
@@ -1259,7 +1249,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            15,
             &logger,
         );
 
@@ -1310,7 +1299,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            17,
             &logger,
         );
 
@@ -1422,7 +1410,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -1568,21 +1555,18 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            14,
             &logger,
         );
         manually_sync_account(
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(bob_account_id.to_string()),
-            14,
             &logger,
         );
         manually_sync_account(
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(charlie_account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -1745,7 +1729,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            22,
             &logger,
         );
 
@@ -1933,7 +1916,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
@@ -1978,7 +1960,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
         let body = json!({
@@ -2055,7 +2036,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -2151,7 +2131,6 @@ mod e2e {
             &ledger_db,
             &wallet_db,
             &AccountID(account_id_1.to_string()),
-            13,
             &logger,
         );
         assert_eq!(
@@ -2201,7 +2180,6 @@ mod e2e {
             &ledger_db,
             &wallet_db,
             &AccountID(account_id_2.to_string()),
-            14,
             &logger,
         );
         assert_eq!(
@@ -2271,7 +2249,6 @@ mod e2e {
             &ledger_db,
             &wallet_db,
             &AccountID(account_id_3.to_string()),
-            15,
             &logger,
         );
         assert_eq!(
@@ -2356,7 +2333,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -2532,7 +2508,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -2624,7 +2599,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -2710,7 +2684,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -2747,7 +2720,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -2859,7 +2831,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            15,
             &logger,
         );
 
@@ -2911,7 +2882,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            15,
             &logger,
         );
 
@@ -2967,7 +2937,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -3057,7 +3026,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -3151,7 +3119,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -3205,7 +3172,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            13,
             &logger,
         );
 
@@ -3286,14 +3252,12 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            14,
             &logger,
         );
         manually_sync_account(
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(bob_account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -3347,7 +3311,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            13,
             &logger,
         );
         // Create a gift code
@@ -3407,7 +3370,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(alice_account_id.to_string()),
-            14,
             &logger,
         );
 
@@ -3444,7 +3406,6 @@ mod e2e {
             &ledger_db,
             &db_ctx.get_db_instance(logger.clone()),
             &AccountID(bob_account_id.to_string()),
-            14,
             &logger,
         );
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -364,7 +364,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(account.account_id_hex.to_string()),
-            12,
             &logger,
         );
 

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -750,13 +750,7 @@ mod tests {
             &vec![KeyImage::from(rng.next_u64())],
             &mut rng,
         );
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Verify balance for Alice
         let balance = service
@@ -794,13 +788,7 @@ mod tests {
         assert!(gift_code_value_opt.is_none());
 
         add_block_with_tx_proposal(&mut ledger_db, tx_proposal);
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            14,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Now the Gift Code should be Available
         let (status, gift_code_value_opt, _memo) = service
@@ -855,7 +843,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(bob.account_id_hex.clone()),
-            14,
             &logger,
         );
 
@@ -881,7 +868,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(bob.account_id_hex.clone()),
-            15,
             &logger,
         );
 
@@ -929,13 +915,7 @@ mod tests {
             &vec![KeyImage::from(rng.next_u64())],
             &mut rng,
         );
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Verify balance for Alice
         let balance = service
@@ -974,13 +954,7 @@ mod tests {
 
         // Let transaction hit the ledger
         add_block_with_tx_proposal(&mut ledger_db, tx_proposal);
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            14,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Check that it landed
         let (status, gift_code_value_opt, _memo) = service

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -358,7 +358,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            13,
             &logger,
         );
 
@@ -407,14 +406,12 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            14,
             &logger,
         );
         manually_sync_account(
             &ledger_db,
             &service.wallet_db,
             &AccountID(bob.account_id_hex.to_string()),
-            14,
             &logger,
         );
 
@@ -483,7 +480,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            13,
             &logger,
         );
 
@@ -544,14 +540,12 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            14,
             &logger,
         );
         manually_sync_account(
             &ledger_db,
             &service.wallet_db,
             &AccountID(bob.account_id_hex.to_string()),
-            14,
             &logger,
         );
 
@@ -597,7 +591,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            13,
             &logger,
         );
 
@@ -642,10 +635,9 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            14,
             &logger,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
 
         // Bob checks the status, and is expecting an incorrect value, from a
         // transaction with a different shared secret
@@ -715,7 +707,6 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            13,
             &logger,
         );
 
@@ -760,10 +751,9 @@ mod tests {
             &ledger_db,
             &service.wallet_db,
             &AccountID(alice.account_id_hex.to_string()),
-            14,
             &logger,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
 
         // Construct an invalid receipt with an incorrect confirmation number.
         let mut receipt = receipt0.clone();

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -457,7 +457,6 @@ mod tests {
             &ledger_db,
             &wallet_db,
             &AccountID::from(&account_key),
-            1,
             &logger,
         );
 

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -393,13 +393,7 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         let tx_logs = service
             .list_transaction_logs(&alice_account_id, None, None)
@@ -530,13 +524,7 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Verify balance for Alice
         let balance = service
@@ -583,14 +571,8 @@ mod tests {
             add_block_from_transaction_log(&mut ledger_db, &conn, &transaction_log);
         }
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            14,
-            &logger,
-        );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 14, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
 
         // Get the Txos from the transaction log
         let transaction_txos = transaction_log
@@ -661,14 +643,8 @@ mod tests {
             add_block_from_transaction_log(&mut ledger_db, &conn, &transaction_log);
         }
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            15,
-            &logger,
-        );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, 15, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
 
         let alice_balance = service
             .get_balance_for_account(&AccountID(alice.account_id_hex))
@@ -715,13 +691,7 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         match service.build_transaction(
             &alice.account_id_hex,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -214,13 +214,7 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &alice_account_id,
-            13,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
 
         // Verify balance for Alice
         let balance = service.get_balance_for_account(&alice_account_id).unwrap();

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -319,29 +319,14 @@ pub fn add_block_with_db_txos(
     add_block_with_tx_outs(ledger_db, &outputs, key_images)
 }
 
-// Not entirely sure what the expected functionality of this is supposed to be.
-// Do we want this to sync to a specific target block, or just sync to the most
-// current block? I think it makes more sense to sync to the most current one,
-// and we can ditch the target_block_index entirely. No need to check that. If
-// it's syncing correctly, the information will be correct regardless, and if
-// it's not, then it won't be.
+// Sync account to most recent block
 pub fn manually_sync_account(
     ledger_db: &LedgerDB,
     wallet_db: &WalletDb,
     account_id: &AccountID,
-    target_block_index: u64,
     logger: &Logger,
 ) -> Account {
     let mut account: Account;
-
-    account = Account::get(&account_id, &wallet_db.get_conn().unwrap()).unwrap();
-
-    // Check if the account is already synced to the target block. If so, return
-    // without doing anything further.
-    if account.next_block_index as u64 >= target_block_index {
-        return account;
-    }
-
     loop {
         match sync_account(&ledger_db, &wallet_db, &account_id.to_string(), &logger) {
             Ok(_) => {}
@@ -373,7 +358,6 @@ pub fn manually_sync_account(
             break;
         }
     }
-    assert_eq!(account.next_block_index as u64, target_block_index);
     account
 }
 
@@ -584,7 +568,6 @@ pub fn random_account_with_seed_values(
         &ledger_db,
         &wallet_db,
         &AccountID::from(&account_key),
-        ledger_db.num_blocks().unwrap(),
         logger,
     );
 


### PR DESCRIPTION
Soundtrack of this PR: [No Ghosty](https://soundcloud.com/swrlyy/no-ghosty)

### Motivation

We don't actually need to provide a target block index. Instead, let the account sync up to the most recent block.

### In this PR
- Remove target block index arg from `manually_sync_account` fn.
- Remove that arg from all calls to that fn.

[Ticket](https://app.asana.com/0/1200175610892874/1201832364350094/f)

