### PR TITLE
Initial action to build containers for tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Publish to DockerHub
         id: docker_publish_dockerhub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: Full Service CI
+
+env:
+  DOCKERHUB_REPO: mobilecoin/full-service
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'develop'
+      - 'feature/**'
+
+jobs:
+  # Stub out job for work Mikey is working on for stress tests
+  # tests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: CI Tests
+  #       run: |
+  #         echo "Hello World"
+
+  # Only run docker builds for tag pushes. Build testnet and mainnet images for now
+  docker:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - namespace: test
+            network: testnet
+          - namespace: prod
+            network: mainnet
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Generate Docker tags
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.DOCKERHUB_REPO }}
+          flavor: |
+            latest=false
+            suffix=-${{ matrix.network }}
+          tags: |
+            type=semver,pattern=v{{version}},priority=20
+            type=sha,priority=10
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Publish to DockerHub
+        id: docker_publish_dockerhub
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            NAMESPACE=${{ matrix.namespace }}
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Soundtrack of this PR: [Fantasy Ambient](https://www.youtube.com/watch?v=AohPsuy65hQ)

### Motivation

Currently there is no automated build of Docker images for Full-Service so updates lag behind the code.  This adds a github action to build and publish docker images when a tag is pushed

### In this PR
* Adds a github action workflow to build docker images for testnet and mainnet.
* Currently only builds images when a tag is pushed.
* Added the `-testnet` and `-mainnet` suffixes to the images for better clarification.
* Commented out a `tests` job placeholder for Mikey who is currently working on some stress tests.
  * Defined the `develop` and `feature/**` filters so when the tests are put in they should run for any push to those branches.  This is also just a placeholder and should be adjusted when the test action is created if need be for any additional branches (main?) 


### Future Work
* Would like to actually perform the build of the binaries as well in the future to apply more automation around CI/CD
