### PR TITLE
FOG Creds default to empty string if not provided from API

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -58,9 +58,9 @@ pub trait AccountModel {
         import_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
         name: &str,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -75,9 +75,9 @@ pub trait AccountModel {
         import_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
         name: &str,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -106,9 +106,9 @@ pub trait AccountModel {
         import_block_index: u64,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError>;
 
@@ -120,9 +120,9 @@ pub trait AccountModel {
         import_block_index: u64,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError>;
 
@@ -179,17 +179,17 @@ impl AccountModel for Account {
         import_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
         name: &str,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        let fog_enabled = fog_report_url.is_some();
+        let fog_enabled = fog_report_url.is_empty();
 
         let account_key = Slip10Key::from(mnemonic.clone()).try_into_account_key(
-            &fog_report_url.unwrap_or_else(|| "".to_string()),
-            &fog_report_id.unwrap_or_else(|| "".to_string()),
-            &base64::decode(fog_authority_spki.unwrap_or_else(|| "".to_string()))?,
+            &fog_report_url,
+            &fog_report_id,
+            &base64::decode(fog_authority_spki)?,
         )?;
 
         Account::create(
@@ -211,21 +211,18 @@ impl AccountModel for Account {
         import_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
         name: &str,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        let fog_enabled = fog_report_url.is_some();
+        let fog_enabled = fog_report_url.is_empty();
 
         let root_id = RootIdentity {
             root_entropy: entropy.clone(),
-            fog_report_url: fog_report_url.unwrap_or_else(|| "".to_string()),
-            fog_report_id: fog_report_id.unwrap_or_else(|| "".to_string()),
-            fog_authority_spki: base64::decode(
-                fog_authority_spki.unwrap_or_else(|| "".to_string()),
-            )
-            .expect("invalid spki"),
+            fog_report_url: fog_report_url,
+            fog_report_id: fog_report_id,
+            fog_authority_spki: base64::decode(fog_authority_spki).expect("invalid spki"),
         };
         let account_key = AccountKey::from(&root_id);
 
@@ -322,9 +319,9 @@ impl AccountModel for Account {
         import_block_index: u64,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
         let (account_id, _public_address_b58) = Account::create_from_mnemonic(
@@ -347,9 +344,9 @@ impl AccountModel for Account {
         import_block_index: u64,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<Account, WalletDbError> {
         let (account_id, _public_address_b58) = Account::create_from_root_entropy(

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -220,8 +220,8 @@ impl AccountModel for Account {
 
         let root_id = RootIdentity {
             root_entropy: entropy.clone(),
-            fog_report_url: fog_report_url,
-            fog_report_id: fog_report_id,
+            fog_report_url,
+            fog_report_id,
             fog_authority_spki: base64::decode(fog_authority_spki).expect("invalid spki"),
         };
         let account_key = AccountKey::from(&root_id);

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -184,7 +184,7 @@ impl AccountModel for Account {
         fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        let fog_enabled = fog_report_url.is_empty();
+        let fog_enabled = !fog_report_url.is_empty();
 
         let account_key = Slip10Key::from(mnemonic.clone()).try_into_account_key(
             &fog_report_url,
@@ -216,7 +216,7 @@ impl AccountModel for Account {
         fog_authority_spki: String,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<(AccountID, String), WalletDbError> {
-        let fog_enabled = fog_report_url.is_empty();
+        let fog_enabled = !fog_report_url.is_empty();
 
         let root_id = RootIdentity {
             root_entropy: entropy.clone(),
@@ -489,9 +489,9 @@ mod tests {
                 None,
                 None,
                 "Alice's Main Account",
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
                 &conn,
             )
             .unwrap();
@@ -557,9 +557,9 @@ mod tests {
                 Some(50),
                 None,
                 "",
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
                 &wallet_db.get_conn().unwrap(),
             )
             .unwrap();
@@ -635,9 +635,9 @@ mod tests {
                 None,
                 None,
                 "Alice's Main Account",
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
                 &conn,
             )
             .unwrap();
@@ -666,9 +666,9 @@ mod tests {
                 None,
                 None,
                 "Alice's FOG Account",
-                Some("fog//some.fog.url".to_string()),
-                Some("".to_string()),
-                Some("DefinitelyARealFOGAuthoritySPKI".to_string()),
+                "fog//some.fog.url".to_string(),
+                "".to_string(),
+                "DefinitelyARealFOGAuthoritySPKI".to_string(),
                 &conn,
             )
             .unwrap();

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -600,9 +600,9 @@ mod tests {
             None,
             None,
             "",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -925,9 +925,9 @@ mod tests {
                 None,
                 None,
                 "",
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
                 &wallet_db.get_conn().unwrap(),
             )
             .unwrap();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -970,9 +970,9 @@ mod tests {
             None,
             None,
             "Alice's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1197,9 +1197,9 @@ mod tests {
             None,
             None,
             "Bob's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1260,9 +1260,9 @@ mod tests {
             None,
             None,
             "Alice's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1369,9 +1369,9 @@ mod tests {
             None,
             None,
             "Alice's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1425,9 +1425,9 @@ mod tests {
             None,
             None,
             "",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1490,9 +1490,9 @@ mod tests {
             None,
             None,
             "Alice",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1629,9 +1629,9 @@ mod tests {
             None,
             None,
             "",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1674,9 +1674,9 @@ mod tests {
             None,
             None,
             "Alice's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1752,9 +1752,9 @@ mod tests {
             None,
             None,
             "",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/json_rpc/txo.rs
+++ b/full-service/src/json_rpc/txo.rs
@@ -192,9 +192,9 @@ mod tests {
             None,
             None,
             "Alice's Main Account",
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -343,7 +343,12 @@ where
             fog_authority_spki,
         } => {
             let account: db::models::Account = service
-                .create_account(name, fog_report_url, fog_report_id, fog_authority_spki)
+                .create_account(
+                    name,
+                    fog_report_url.unwrap_or_default(),
+                    fog_report_id.unwrap_or_default(),
+                    fog_authority_spki.unwrap_or_default(),
+                )
                 .map_err(format_error)?;
 
             JsonCommandResponse::create_account {
@@ -799,9 +804,9 @@ where
                             name,
                             fb,
                             ns,
-                            fog_report_url,
-                            fog_report_id,
-                            fog_authority_spki,
+                            fog_report_url.unwrap_or_default(),
+                            fog_report_id.unwrap_or_default(),
+                            fog_authority_spki.unwrap_or_default(),
                         )
                         .map_err(format_error)?,
                 )
@@ -834,9 +839,9 @@ where
                             name,
                             fb,
                             ns,
-                            fog_report_url,
-                            fog_report_id,
-                            fog_authority_spki,
+                            fog_report_url.unwrap_or_default(),
+                            fog_report_id.unwrap_or_default(),
+                            fog_authority_spki.unwrap_or_default(),
                         )
                         .map_err(format_error)?,
                 )

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -82,9 +82,9 @@ pub trait AccountService {
     fn create_account(
         &self,
         name: Option<String>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError>;
 
     /// Import an existing account to the wallet using the entropy.
@@ -96,9 +96,9 @@ pub trait AccountService {
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError>;
 
     /// Import an existing account to the wallet using the entropy.
@@ -109,9 +109,9 @@ pub trait AccountService {
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError>;
 
     /// List accounts in the wallet.
@@ -139,9 +139,9 @@ where
     fn create_account(
         &self,
         name: Option<String>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError> {
         log::info!(self.logger, "Creating account {:?}", name,);
 
@@ -183,9 +183,9 @@ where
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError> {
         log::info!(
             self.logger,
@@ -236,9 +236,9 @@ where
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
-        fog_report_url: Option<String>,
-        fog_report_id: Option<String>,
-        fog_authority_spki: Option<String>,
+        fog_report_url: String,
+        fog_report_id: String,
+        fog_authority_spki: String,
     ) -> Result<Account, AccountServiceError> {
         log::info!(
             self.logger,

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -328,7 +328,12 @@ mod tests {
 
         // Create an account.
         let account = service
-            .create_account(Some("A".to_string()), None, None, None)
+            .create_account(
+                Some("A".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a transaction, with transaction status.

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -349,9 +349,9 @@ mod tests {
                 None,
                 None,
                 None,
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
             )
             .expect("Could not import account entropy");
 

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -734,7 +734,12 @@ mod tests {
 
         // Create our main account for the wallet
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for Alice
@@ -837,7 +842,12 @@ mod tests {
         // Claim the gift code to another account
         log::info!(logger, "Creating new account to receive gift code");
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         manually_sync_account(
             &ledger_db,
@@ -899,7 +909,12 @@ mod tests {
 
         // Create our main account for the wallet
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for Alice

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -341,7 +341,12 @@ mod tests {
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Fund Alice
@@ -362,7 +367,12 @@ mod tests {
         );
 
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_addresses = service
             .get_addresses_for_account(&AccountID(bob.account_id_hex.clone()), None, None)
@@ -463,7 +473,12 @@ mod tests {
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Fund Alice
@@ -484,7 +499,12 @@ mod tests {
         );
 
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_addresses = service
             .get_addresses_for_account(&AccountID(bob.account_id_hex.clone()), None, None)
@@ -574,7 +594,12 @@ mod tests {
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Fund Alice
@@ -595,7 +620,12 @@ mod tests {
         );
 
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_addresses = service
             .get_addresses_for_account(&AccountID(bob.account_id_hex.clone()), None, None)
@@ -690,7 +720,12 @@ mod tests {
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Fund Alice
@@ -711,7 +746,12 @@ mod tests {
         );
 
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_addresses = service
             .get_addresses_for_account(&AccountID(bob.account_id_hex.clone()), None, None)

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -447,9 +447,9 @@ mod tests {
                 None,
                 None,
                 None,
-                None,
-                None,
-                None,
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
             )
             .expect("Could not import account entropy");
 

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -371,7 +371,12 @@ mod tests {
 
         // Create our main account for the wallet
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for Alice
@@ -409,7 +414,12 @@ mod tests {
 
         // Add an account for Bob
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_account_key: AccountKey =
             mc_util_serial::decode(&bob.account_key).expect("Could not decode account key");
@@ -509,7 +519,12 @@ mod tests {
 
         // Create our main account for the wallet
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for Alice
@@ -534,7 +549,12 @@ mod tests {
 
         // Add an account for Bob
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
         let bob_account_key: AccountKey =
             mc_util_serial::decode(&bob.account_key).expect("Could not decode account key");
@@ -676,7 +696,12 @@ mod tests {
 
         // Create our main account for the wallet
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for Alice

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -198,7 +198,12 @@ mod tests {
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
         let alice = service
-            .create_account(Some("Alice's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Add a block with a transaction for this recipient
@@ -227,7 +232,12 @@ mod tests {
 
         // Add another account
         let bob = service
-            .create_account(Some("Bob's Main Account".to_string()), None, None, None)
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
             .unwrap();
 
         // Construct a new transaction to Bob

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -546,9 +546,9 @@ pub fn random_account_with_seed_values(
             None,
             None,
             &format!("SeedAccount{}", rng.next_u32()),
-            None,
-            None,
-            None,
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
Since we were defaulting to empty string when creating the account key, it makes it easier to deal with this earlier in the chain and simply turn null values for fog creds into empty strings at the RPC layer