### PR TITLE
Update builder-install image version used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_24
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_25
   default-xcode-version: &default-xcode-version "12.0.0"
 
   default-environment: &default-environment


### PR DESCRIPTION
1.25 was published with https://github.com/mobilecoinfoundation/mobilecoin/pull/1307