### PR TITLE
Add public key field to view only txo

### DIFF
--- a/docs/transactions/txo/README.md
+++ b/docs/transactions/txo/README.md
@@ -103,6 +103,7 @@ a minimal txo entity useful for view-only-accounts
 | _Name_ | _Type_ | _Description_ |
 | :--- | :--- | :--- |
 | `object` | string, value is "view_only_txo" | String representing the object's type. Objects of the same type share the same value. |
+| `public_key` | string \(hex\) | The public key for this TXO, can be used as an identifier to find the TXO in the ledger. |
 | `value_pmob` | string \(uint64\) | Available pico MOB for this account at the current `account_block_height`. If the account is syncing, this value may change. |
 | `view_only_account_id_hex` | string | The local ID for view only account that has the private view key capable of decrypting this txo. |
 | `spent` | string | Whether or not this txo has been manually marked as spent. |

--- a/docs/transactions/txo/get_txos_for_view_only_account.md
+++ b/docs/transactions/txo/get_txos_for_view_only_account.md
@@ -45,6 +45,7 @@ description: Get view only TXOs for a given view only account with offset and li
         "object": "view_only_txo",
         "txo_id_hex": "84eab721b7eeb4dc6f6d73c0504182a06ccfb98e2d341acac2dfe22d831fae44",
         "value_pmob": "10000000000000",
+        "public_key": "ef3e04533424fd181e8039ec4e2df0bc67c2f59dbbe55d660202d0fc588638d2",
         "view_only_account_id_hex": "324a0969a356a81916eecb3aa002da2bbc79154a835c9f6df61d71f67dc5f632",
         "spent": false
       }
@@ -52,6 +53,7 @@ description: Get view only TXOs for a given view only account with offset and li
         "object": "view_only_txo",
         "txo_id_hex": "27eab721b7eeb4dc6f6d73c0504182a06ccfb98e2d341acac2dfe22d831fae44",
         "value_pmob": "20000000000000",
+        "public_key": "222204533424fd181e8039ec4e2df0bc67c2f59dbbe55d660202d0fc588638d2",
         "view_only_account_id_hex": "324a0969a356a81916eecb3aa002da2bbc79154a835c9f6df61d71f67dc5f632",
         "spent": false
       }
@@ -59,6 +61,7 @@ description: Get view only TXOs for a given view only account with offset and li
         "object": "view_only_txo",
         "txo_id_hex": "93eab721b7eeb4dc6f6d73c0504182a06ccfb98e2d341acac2dfe22d831fae44",
         "value_pmob": "30000000000000",
+        "public_key": "123454533424fd181e8039ec4e2df0bc67c2f59dbbe55d660202d0fc588638d2",
         "view_only_account_id_hex": "324a0969a356a81916eecb3aa002da2bbc79154a835c9f6df61d71f67dc5f632",
         "spent": false
       }

--- a/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/down.sql
+++ b/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/down.sql
@@ -1,2 +1,3 @@
+DROP INDEX IF EXISTS idx_view_only_txos__public_key;
 DROP TABLE IF EXISTS view_only_accounts;
 DROP TABLE IF EXISTS view_only_txos;

--- a/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/up.sql
+++ b/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/up.sql
@@ -14,6 +14,7 @@ CREATE TABLE view_only_txos (
   txo BLOB NOT NULL,
   value INT NOT NULL,
   view_only_account_id_hex TEXT NOT NULL,
+  public_key BLOB NOT NULL,
   spent BOOLEAN NOT NULL DEFAULT FALSE,
   FOREIGN KEY (view_only_account_id_hex) REFERENCES view_only_accounts(account_id_hex)
 );

--- a/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/up.sql
+++ b/full-service/migrations/2022-02-28-190052_view-only-accounts-and-txos/up.sql
@@ -19,4 +19,5 @@ CREATE TABLE view_only_txos (
   FOREIGN KEY (view_only_account_id_hex) REFERENCES view_only_accounts(account_id_hex)
 );
 
+CREATE UNIQUE INDEX idx_view_only_txos__public_key ON view_only_txos(public_key);
 

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -235,6 +235,8 @@ pub struct ViewOnlyTxo {
     pub txo: Vec<u8>,
     /// The value of this transaction output, in picoMob.
     pub value: i64,
+    /// The serialized public_key of the TxOut.
+    pub public_key: Vec<u8>,
     /// account_id_hex of the view_only_account that received this txo
     pub view_only_account_id_hex: String,
     // whether or not this txo has been spent
@@ -249,6 +251,7 @@ pub struct NewViewOnlyTxo<'a> {
     pub txo: &'a [u8],
     pub txo_id_hex: &'a str,
     pub value: i64,
+    pub public_key: &'a [u8],
     pub view_only_account_id_hex: &'a str,
 }
 

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -34,6 +34,7 @@ table! {
         txo_id_hex -> Text,
         txo -> Binary,
         value -> BigInt,
+        public_key -> Binary,
         view_only_account_id_hex -> Text,
         spent -> Bool,
     }

--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -79,6 +79,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
             txo: &mc_util_serial::encode(&tx_out),
             txo_id_hex: &txo_id.to_string(),
             value,
+            public_key: &mc_util_serial::encode(&tx_out.public_key),
             view_only_account_id_hex,
         };
 
@@ -216,6 +217,7 @@ mod tests {
             txo_id_hex: txo_id.to_string(),
             view_only_account_id_hex: view_only_account.account_id_hex.to_string(),
             txo: mc_util_serial::encode(&fake_tx_out),
+            public_key: mc_util_serial::encode(&fake_tx_out.public_key),
             value,
             spent: false,
         };

--- a/full-service/src/json_rpc/view_only_txo.rs
+++ b/full-service/src/json_rpc/view_only_txo.rs
@@ -20,6 +20,10 @@ pub struct ViewOnlyTxo {
     /// If the account is syncing, this value may change.
     pub value_pmob: String,
 
+    /// The public key for this txo, can be used as an identifier to find the
+    /// txo in the ledger.
+    pub public_key: String,
+
     /// the view-only-account id for this txo
     pub view_only_account_id_hex: String,
 
@@ -33,6 +37,7 @@ impl From<&db::models::ViewOnlyTxo> for ViewOnlyTxo {
             object: "view_only_txo".to_string(),
             txo_id_hex: txo.txo_id_hex.clone(),
             value_pmob: (txo.value as u64).to_string(),
+            public_key: hex::encode(&txo.public_key),
             view_only_account_id_hex: txo.view_only_account_id_hex.to_string(),
             spent: txo.spent,
         }


### PR DESCRIPTION
### Motivation

I preparation for using imported transactions to update the balance of view-only accounts, add a public key field to view-only txos. When importing a transaction proposal, we will create a temporary log that records all of the public keys for inputs and outputs in the proposal and any existing view-only-txos whose public key matches any of the input TXOs. On ledger updates, we will look for txos with keys that match the logged outputs. If any keys match, we will update the related view-only txo as spent and delete the log.

### In this PR
Edit migration to add new column to table.
Update create method to populate field.

[Ticket](https://app.asana.com/0/1200175610892874/1202001794683748/f)

### Future Work
* Implement rest of flow described above.
* Add ability to export txos for an account and import view-only txos for an account

