### PR TITLE
Export spent txos and mark spent

### DIFF
--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -130,6 +130,9 @@ pub enum JsonCommandRequest {
     export_account_secrets {
         account_id: String,
     },
+    export_spent_txo_ids {
+        account_id: String,
+    },
     export_view_only_account_secrets {
         account_id: String,
     },

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -253,6 +253,9 @@ pub enum JsonCommandRequest {
     remove_view_only_account {
         account_id: String,
     },
+    set_view_only_txos_spent {
+        txo_ids: Vec<String>,
+    },
     submit_gift_code {
         from_account_id: String,
         gift_code_b58: String,

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -174,6 +174,9 @@ pub enum JsonCommandResponse {
     export_account_secrets {
         account_secrets: AccountSecrets,
     },
+    export_spent_txo_ids {
+        spent_txo_ids: Vec<String>,
+    },
     export_view_only_account_secrets {
         view_only_account_secrets: ViewOnlyAccountSecrets,
     },

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -294,6 +294,9 @@ pub enum JsonCommandResponse {
     remove_view_only_account {
         removed: bool,
     },
+    set_view_only_txos_spent {
+        success: bool,
+    },
     submit_gift_code {
         gift_code: GiftCode,
     },

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -434,6 +434,17 @@ where
                 account_secrets: AccountSecrets::try_from(&account).map_err(format_error)?,
             }
         }
+        JsonCommandRequest::export_spent_txo_ids { account_id } => {
+            let txos = service
+                .list_spent_txos(&AccountID(account_id))
+                .map_err(format_error)?;
+            let spent_txo_ids: Vec<String> = txos
+                .iter()
+                .map(|txo| txo.txo_id_hex.clone())
+                .collect::<Vec<String>>();
+
+            JsonCommandResponse::export_spent_txo_ids { spent_txo_ids }
+        }
         JsonCommandRequest::export_view_only_account_secrets { account_id } => {
             let account = service
                 .get_view_only_account(&account_id)

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -1030,6 +1030,13 @@ where
                     .map_err(format_error)?,
             }
         }
+        JsonCommandRequest::set_view_only_txos_spent { txo_ids } => {
+            JsonCommandResponse::set_view_only_txos_spent {
+                success: service
+                    .set_view_only_txos_spent(txo_ids)
+                    .map_err(format_error)?,
+            }
+        }
         JsonCommandRequest::submit_gift_code {
             from_account_id,
             gift_code_b58,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -71,6 +71,9 @@ pub trait TxoService {
         offset: Option<u64>,
     ) -> Result<Vec<Txo>, TxoServiceError>;
 
+    /// list all spent txos
+    fn list_spent_txos(&self, account_id: &AccountID) -> Result<Vec<Txo>, TxoServiceError>;
+
     /// Get a Txo from the wallet.
     fn get_txo(&self, txo_id: &TxoID) -> Result<Txo, TxoServiceError>;
 
@@ -108,6 +111,11 @@ where
                 &conn,
             )?)
         })
+    }
+
+    fn list_spent_txos(&self, account_id: &AccountID) -> Result<Vec<Txo>, TxoServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+        conn.transaction(|| Ok(Txo::list_spent(&account_id.to_string(), None, &conn)?))
     }
 
     fn get_txo(&self, txo_id: &TxoID) -> Result<Txo, TxoServiceError> {

--- a/full-service/src/service/view_only_txo.rs
+++ b/full-service/src/service/view_only_txo.rs
@@ -21,6 +21,9 @@ pub trait ViewOnlyTxoService {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<Vec<ViewOnlyTxo>, TxoServiceError>;
+
+    /// set a group of txos as spent.
+    fn set_view_only_txos_spent(&self, txo_ids: Vec<String>) -> Result<bool, TxoServiceError>;
 }
 
 impl<T, FPR> ViewOnlyTxoService for WalletService<T, FPR>
@@ -39,6 +42,14 @@ where
             Ok(ViewOnlyTxo::list_for_account(
                 account_id, limit, offset, &conn,
             )?)
+        })
+    }
+
+    fn set_view_only_txos_spent(&self, txo_ids: Vec<String>) -> Result<bool, TxoServiceError> {
+        let conn = self.wallet_db.get_conn()?;
+        conn.transaction(|| {
+            ViewOnlyTxo::set_spent(txo_ids, &conn)?;
+            Ok(true)
         })
     }
 }


### PR DESCRIPTION
### Motivation

for users with hot&cold wallets, give them the ability to build a transaction proposal on their cold full-access wallet, then set any spent txos to spent on their hot view-only wallet.

### In this PR
Add export_spent_txo_ids endpoint
Add set_view_only_txos_spent endpoing

[Ticket](https://app.asana.com/0/1200175610892874/1202001794683752/f)

### Future Work
see description of [273](https://github.com/mobilecoinofficial/full-service/pull/273)

