### PR TITLE
Bugfixes for offline account creation.

### DIFF
--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -252,7 +252,11 @@ impl AccountModel for Account {
         use crate::db::schema::accounts;
 
         let account_id = AccountID::from(account_key);
+
+        // The next block for scanning should should start one after the current block, unless we
+        // are starting at the beginning of the ledger.
         let fb = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
+        let nb = if fb == DEFAULT_FIRST_BLOCK_INDEX { 0 } else { fb + 1 };
 
         let change_subaddress_index = if fog_enabled {
             DEFAULT_SUBADDRESS_INDEX as i64
@@ -276,7 +280,7 @@ impl AccountModel for Account {
             change_subaddress_index,
             next_subaddress_index,
             first_block_index: fb as i64,
-            next_block_index: fb as i64,
+            next_block_index: nb as i64,
             import_block_index: import_block_index.map(|i| i as i64),
             name,
             fog_enabled,
@@ -577,7 +581,7 @@ mod tests {
             change_subaddress_index: 1,
             next_subaddress_index: 2,
             first_block_index: 51,
-            next_block_index: 51,
+            next_block_index: 52,
             import_block_index: Some(50),
             name: "".to_string(),
             fog_enabled: false,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -253,10 +253,14 @@ impl AccountModel for Account {
 
         let account_id = AccountID::from(account_key);
 
-        // The next block for scanning should should start one after the current block, unless we
-        // are starting at the beginning of the ledger.
+        // The next block for scanning should should start one after the current block,
+        // unless we are starting at the beginning of the ledger.
         let fb = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
-        let nb = if fb == DEFAULT_FIRST_BLOCK_INDEX { 0 } else { fb + 1 };
+        let nb = if fb == DEFAULT_FIRST_BLOCK_INDEX {
+            0
+        } else {
+            fb + 1
+        };
 
         let change_subaddress_index = if fog_enabled {
             DEFAULT_SUBADDRESS_INDEX as i64

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -253,14 +253,8 @@ impl AccountModel for Account {
 
         let account_id = AccountID::from(account_key);
 
-        // The next block for scanning should should start one after the current block,
-        // unless we are starting at the beginning of the ledger.
-        let fb = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
-        let nb = if fb == DEFAULT_FIRST_BLOCK_INDEX {
-            0
-        } else {
-            fb + 1
-        };
+        let first_block_index = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
+        let next_block_index = first_block_index;
 
         let change_subaddress_index = if fog_enabled {
             DEFAULT_SUBADDRESS_INDEX as i64
@@ -283,8 +277,8 @@ impl AccountModel for Account {
             main_subaddress_index: DEFAULT_SUBADDRESS_INDEX as i64,
             change_subaddress_index,
             next_subaddress_index,
-            first_block_index: fb as i64,
-            next_block_index: nb as i64,
+            first_block_index: first_block_index as i64,
+            next_block_index: next_block_index as i64,
             import_block_index: import_block_index.map(|i| i as i64),
             name,
             fog_enabled,
@@ -560,7 +554,7 @@ mod tests {
         let (account_id_hex_secondary, _public_address_b58_secondary) =
             Account::create_from_root_entropy(
                 &root_id_secondary.root_entropy,
-                Some(51),
+                Some(50),
                 Some(50),
                 None,
                 "",
@@ -584,8 +578,8 @@ mod tests {
             main_subaddress_index: 0,
             change_subaddress_index: 1,
             next_subaddress_index: 2,
-            first_block_index: 51,
-            next_block_index: 52,
+            first_block_index: 50,
+            next_block_index: 50,
             import_block_index: Some(50),
             name: "".to_string(),
             fog_enabled: false,

--- a/full-service/src/db/view_only_transaction_log.rs
+++ b/full-service/src/db/view_only_transaction_log.rs
@@ -130,20 +130,10 @@ mod tests {
             &RistrettoPublic::from_random(&mut rng),
             &RistrettoPublic::from_random(&mut rng),
         );
-        let fake_input_tx_out = TxOut::new(
-            value,
-            &public_address,
-            &tx_private_key_1,
-            hint.clone(),
-        )
-        .unwrap();
-        let fake_change_tx_out = TxOut::new(
-            value,
-            &public_address,
-            &tx_private_key_2,
-            hint.clone(),
-        )
-        .unwrap();
+        let fake_input_tx_out =
+            TxOut::new(value, &public_address, &tx_private_key_1, hint.clone()).unwrap();
+        let fake_change_tx_out =
+            TxOut::new(value, &public_address, &tx_private_key_2, hint.clone()).unwrap();
 
         ViewOnlyAccount::create(
             view_only_account_id,

--- a/full-service/src/db/view_only_transaction_log.rs
+++ b/full-service/src/db/view_only_transaction_log.rs
@@ -122,7 +122,7 @@ mod tests {
 
         // make fake txos, view only txos & account
         let view_only_account_id = "accountId";
-        let value: i64 = 420;
+        let value = 420;
         let tx_private_key_1 = RistrettoPrivate::from_random(&mut rng);
         let tx_private_key_2 = RistrettoPrivate::from_random(&mut rng);
         let hint = EncryptedFogHint::fake_onetime_hint(&mut rng);
@@ -131,14 +131,14 @@ mod tests {
             &RistrettoPublic::from_random(&mut rng),
         );
         let fake_input_tx_out = TxOut::new(
-            value as u64,
+            value,
             &public_address,
             &tx_private_key_1,
             hint.clone(),
         )
         .unwrap();
         let fake_change_tx_out = TxOut::new(
-            value as u64,
+            value,
             &public_address,
             &tx_private_key_2,
             hint.clone(),
@@ -148,8 +148,8 @@ mod tests {
         ViewOnlyAccount::create(
             view_only_account_id,
             &RistrettoPrivate::from_random(&mut rng),
-            0 as i64,
-            0 as i64,
+            0,
+            0,
             "catcoin_name",
             &conn,
         )

--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -20,7 +20,7 @@ pub trait ViewOnlyTxoModel {
     /// insert a new txo linked to a view-only-account
     fn create(
         tx_out: TxOut,
-        value: i64,
+        value: u64,
         view_only_account_id_hex: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<ViewOnlyTxo, WalletDbError>;
@@ -64,7 +64,7 @@ pub trait ViewOnlyTxoModel {
 impl ViewOnlyTxoModel for ViewOnlyTxo {
     fn create(
         tx_out: TxOut,
-        value: i64,
+        value: u64,
         view_only_account_id_hex: &str,
         conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
     ) -> Result<ViewOnlyTxo, WalletDbError> {
@@ -78,7 +78,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         let new_txo = NewViewOnlyTxo {
             txo: &mc_util_serial::encode(&tx_out),
             txo_id_hex: &txo_id.to_string(),
-            value,
+            value: value as i64,
             public_key: &mc_util_serial::encode(&tx_out.public_key),
             view_only_account_id_hex,
         };
@@ -187,7 +187,7 @@ mod tests {
         let conn = wallet_db.get_conn().unwrap();
 
         // make fake txo
-        let value: i64 = 420;
+        let value = 420;
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let hint = EncryptedFogHint::fake_onetime_hint(&mut rng);
         let public_address = PublicAddress::new(
@@ -209,8 +209,8 @@ mod tests {
         let view_only_account = ViewOnlyAccount::create(
             view_only_account_id,
             &RistrettoPrivate::from_random(&mut rng),
-            0 as i64,
-            0 as i64,
+            0,
+            0,
             "catcoin_name",
             &conn,
         )
@@ -223,7 +223,7 @@ mod tests {
             view_only_account_id_hex: view_only_account.account_id_hex.to_string(),
             txo: mc_util_serial::encode(&fake_tx_out),
             public_key: mc_util_serial::encode(&fake_tx_out.public_key),
-            value,
+            value: value as i64,
             spent: false,
         };
 
@@ -251,7 +251,7 @@ mod tests {
 
         // test list for account
 
-        let value: i64 = 420;
+        let value = 420;
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let hint = EncryptedFogHint::fake_onetime_hint(&mut rng);
         let public_address = PublicAddress::new(

--- a/full-service/src/json_rpc/api_test_utils.rs
+++ b/full-service/src/json_rpc/api_test_utils.rs
@@ -99,7 +99,7 @@ pub fn create_test_setup(
     let known_recipients: Vec<PublicAddress> = Vec::new();
     let ledger_db = get_test_ledger(5, &known_recipients, BASE_TEST_BLOCK_HEIGHT, &mut rng);
     let (peer_manager, network_state) =
-        setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone());
+        setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
     let service = WalletService::new(
         wallet_db,

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -994,7 +994,7 @@ where
             first_block_index,
         } => {
             let fb = first_block_index
-                .map(|fb| fb.parse::<i64>())
+                .map(|fb| fb.parse::<u64>())
                 .transpose()
                 .map_err(format_error)?;
 

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -187,12 +187,13 @@ where
 
         // Since we are creating the account from randomness, it is astronomically
         // improbable that it would have collided with another account that
-        // already received funds. For this reason, start scanning at the
-        // current network block index.
-        let first_block_index = network_block_height.saturating_sub(1);
-
-        // Only perform account scanning on blocks that are newer than the account.
-        let import_block_index = local_block_height.saturating_sub(1);
+        // already received funds. For this reason, start scanning after the
+        // current network block index. Only perform account scanning on blocks that are newer than
+        // the account.
+        // The index of the previously published block is one less than the ledger height, and the
+        // next block after that has an index of one more.
+        let first_block_index = network_block_height; // - 1 + 1
+        let import_block_index = local_block_height; // - 1 + 1;
 
         let conn = self.wallet_db.get_conn()?;
         conn.transaction(|| {
@@ -432,18 +433,18 @@ mod tests {
         // Even though we don't have a network connection, it sets the block indices
         // based on the ledger height.
         assert_eq!(service.ledger_db.num_blocks().unwrap(), 12);
-        assert_eq!(account.first_block_index, 11);
+        assert_eq!(account.first_block_index, 12);
         assert_eq!(account.next_block_index, 12);
-        assert_eq!(account.import_block_index, Some(11));
+        assert_eq!(account.import_block_index, Some(12));
 
         // Syncing the account does nothing to the block indices since there are no new
         // blocks.
         let account_id = AccountID(account.account_id_hex);
         manually_sync_account(&ledger_db, &service.wallet_db, &account_id, &logger);
         let account = service.get_account(&account_id).unwrap();
-        assert_eq!(account.first_block_index, 11);
+        assert_eq!(account.first_block_index, 12);
         assert_eq!(account.next_block_index, 12);
-        assert_eq!(account.import_block_index, Some(11));
+        assert_eq!(account.import_block_index, Some(12));
     }
 
     #[test_with_logger]

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -188,12 +188,12 @@ where
         // Since we are creating the account from randomness, it is astronomically
         // improbable that it would have collided with another account that
         // already received funds. For this reason, start scanning after the
-        // current network block index. Only perform account scanning on blocks that are newer than
-        // the account.
-        // The index of the previously published block is one less than the ledger height, and the
-        // next block after that has an index of one more.
-        let first_block_index = network_block_height; // - 1 + 1
-        let import_block_index = local_block_height; // - 1 + 1;
+        // current network block index. Only perform account scanning on blocks that are
+        // newer than the account.
+        // The index of the previously published block is one less than the ledger
+        // height, and the next block after that has an index of one more.
+        let first_block_index = network_block_height; // -1 +1
+        let import_block_index = local_block_height; // -1 +1
 
         let conn = self.wallet_db.get_conn()?;
         conn.transaction(|| {

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -176,14 +176,23 @@ where
         // Generate entropy for the account
         let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
 
-        // Since we are creating the account from randomness, it is highly unlikely that
-        // it would have collided with another account that already received funds. For
-        // this reason, start scanning at the current network block index.
-        let first_block_index = self.get_network_block_height()? - 1;
+        // Determine bounds for account syncing. If we are offline, assume the network
+        // has at least as many blocks as our local ledger.
+        let local_block_height = self.ledger_db.num_blocks()?;
+        let network_block_height = if self.offline {
+            local_block_height
+        } else {
+            self.get_network_block_height()?
+        };
 
-        // The earliest we could start scanning is the current highest block index of
-        // the local ledger.
-        let import_block_index = self.ledger_db.num_blocks()? - 1;
+        // Since we are creating the account from randomness, it is astronomically
+        // improbable that it would have collided with another account that
+        // already received funds. For this reason, start scanning at the
+        // current network block index.
+        let first_block_index = network_block_height.saturating_sub(1);
+
+        // Only perform account scanning on blocks that are newer than the account.
+        let import_block_index = local_block_height.saturating_sub(1);
 
         let conn = self.wallet_db.get_conn()?;
         conn.transaction(|| {
@@ -338,7 +347,10 @@ mod tests {
     use super::*;
     use crate::{
         db::{models::Txo, txo::TxoModel},
-        test_utils::{create_test_received_txo, get_test_ledger, setup_wallet_service, MOB},
+        test_utils::{
+            create_test_received_txo, get_empty_test_ledger, get_test_ledger,
+            manually_sync_account, setup_wallet_service, setup_wallet_service_offline, MOB,
+        },
     };
     use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{test_with_logger, Logger};
@@ -398,5 +410,80 @@ mod tests {
         )
         .unwrap();
         assert_eq!(txos.len(), 0);
+    }
+
+    #[test_with_logger]
+    fn test_create_account_offline(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+        let service = setup_wallet_service_offline(ledger_db.clone(), logger.clone());
+
+        // Create an account.
+        let account = service
+            .create_account(
+                Some("A".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
+            .unwrap();
+
+        // Even though we don't have a network connection, it sets the block indices
+        // based on the ledger height.
+        assert_eq!(service.ledger_db.num_blocks().unwrap(), 12);
+        assert_eq!(account.first_block_index, 11);
+        assert_eq!(account.next_block_index, 12);
+        assert_eq!(account.import_block_index, Some(11));
+
+        // Syncing the account does nothing to the block indices since there are no new blocks.
+        let account_id = AccountID(account.account_id_hex);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &account_id,
+            &logger,
+        );
+        let account = service.get_account(&account_id).unwrap();
+        assert_eq!(account.first_block_index, 11);
+        assert_eq!(account.next_block_index, 12);
+        assert_eq!(account.import_block_index, Some(11));
+    }
+
+    #[test_with_logger]
+    fn test_create_account_offline_no_ledger(logger: Logger) {
+        let ledger_db = get_empty_test_ledger();
+        let service = setup_wallet_service_offline(ledger_db.clone(), logger.clone());
+
+        // Create an account.
+        let account = service
+            .create_account(
+                Some("A".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
+            .unwrap();
+
+
+        // The block indices are set to zero because we have no ledger information whatsoever.
+        assert_eq!(service.ledger_db.num_blocks().unwrap(), 0);
+        assert_eq!(account.first_block_index, 0);
+        assert_eq!(account.next_block_index, 0);
+        assert_eq!(account.import_block_index, Some(0));
+
+        // Syncing the account does nothing to the block indices since there are no blocks in the
+        // ledger.
+        let account_id = AccountID(account.account_id_hex);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db,
+            &account_id,
+            &logger,
+        );
+        let account = service.get_account(&account_id).unwrap();
+        assert_eq!(account.first_block_index, 0);
+        assert_eq!(account.next_block_index, 0);
+        assert_eq!(account.import_block_index, Some(0));
     }
 }

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -436,14 +436,10 @@ mod tests {
         assert_eq!(account.next_block_index, 12);
         assert_eq!(account.import_block_index, Some(11));
 
-        // Syncing the account does nothing to the block indices since there are no new blocks.
+        // Syncing the account does nothing to the block indices since there are no new
+        // blocks.
         let account_id = AccountID(account.account_id_hex);
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &account_id,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &account_id, &logger);
         let account = service.get_account(&account_id).unwrap();
         assert_eq!(account.first_block_index, 11);
         assert_eq!(account.next_block_index, 12);
@@ -465,22 +461,17 @@ mod tests {
             )
             .unwrap();
 
-
-        // The block indices are set to zero because we have no ledger information whatsoever.
+        // The block indices are set to zero because we have no ledger information
+        // whatsoever.
         assert_eq!(service.ledger_db.num_blocks().unwrap(), 0);
         assert_eq!(account.first_block_index, 0);
         assert_eq!(account.next_block_index, 0);
         assert_eq!(account.import_block_index, Some(0));
 
-        // Syncing the account does nothing to the block indices since there are no blocks in the
-        // ledger.
+        // Syncing the account does nothing to the block indices since there are no
+        // blocks in the ledger.
         let account_id = AccountID(account.account_id_hex);
-        manually_sync_account(
-            &ledger_db,
-            &service.wallet_db,
-            &account_id,
-            &logger,
-        );
+        manually_sync_account(&ledger_db, &service.wallet_db, &account_id, &logger);
         let account = service.get_account(&account_id).unwrap();
         assert_eq!(account.first_block_index, 0);
         assert_eq!(account.next_block_index, 0);

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -190,8 +190,8 @@ fn sync_view_only_account_next_chunk(
         let view_private_key: RistrettoPrivate =
             mc_util_serial::decode(&view_only_account.view_private_key)?;
         let start_time = Instant::now();
-        let first_block_index = view_only_account.next_block_index as u64;
-        let mut last_block_index = view_only_account.next_block_index as u64;
+        let start_block_index = view_only_account.next_block_index as u64;
+        let mut end_block_index = view_only_account.next_block_index as u64;
 
         // Load transaction outputs for this chunk. View only accounts have a view
         // private key but no spend private key, so they can scan TXOs but
@@ -200,7 +200,6 @@ fn sync_view_only_account_next_chunk(
 
         let start = view_only_account.next_block_index as u64;
         let end = start + BLOCKS_CHUNK_SIZE;
-
         for block_index in start..end {
             let block_index = block_index as u64;
             let block_contents = match ledger_db.get_block_contents(block_index as u64) {
@@ -212,7 +211,7 @@ fn sync_view_only_account_next_chunk(
                     return Err(err.into());
                 }
             };
-            last_block_index = block_index;
+            end_block_index = block_index;
 
             for tx_out in block_contents.outputs {
                 tx_outs.push(tx_out);
@@ -234,7 +233,7 @@ fn sync_view_only_account_next_chunk(
 
         // Write received txos to db
         for (tx_out, amount) in received_txos {
-            let new_txo = ViewOnlyTxo::create(tx_out.clone(), amount as i64, account_id_hex, conn)?;
+            let new_txo = ViewOnlyTxo::create(tx_out.clone(), amount, account_id_hex, conn)?;
             // If this txo is change from a transaction that was submitted to this wallet
             // without an account-id, we should have some logs associating the
             // change txo with txos used as inputs for that transaction. See cold wallet/hot
@@ -249,10 +248,8 @@ fn sync_view_only_account_next_chunk(
         }
 
         // Done syncing this chunk. Mark these blocks as synced for this account.
-
-        view_only_account.update_next_block_index((last_block_index + 1) as i64, conn)?;
-
-        let num_blocks_synced = last_block_index - first_block_index + 1;
+        view_only_account.update_next_block_index(end_block_index + 1, conn)?;
+        let num_blocks_synced = end_block_index - start_block_index + 1;
 
         let duration = start_time.elapsed();
 
@@ -260,8 +257,8 @@ fn sync_view_only_account_next_chunk(
             logger,
             "Synced {} blocks ({}-{}) for view only account {} in {:?}. {} txos received.",
             num_blocks_synced,
-            first_block_index,
-            last_block_index,
+            start_block_index,
+            end_block_index,
             account_id_hex.chars().take(6).collect::<String>(),
             duration,
             num_received_txos,
@@ -312,8 +309,8 @@ fn sync_account_next_chunk(
         }
 
         let start_time = Instant::now();
-        let first_block_index = account.next_block_index as u64;
-        let mut last_block_index: Option<u64> = None;
+        let start_block_index = account.next_block_index as u64;
+        let mut end_block_index: Option<u64> = None;
 
         // Load transaction outputs and key images for this chunk.
         let mut tx_outs: Vec<(u64, TxOut)> = Vec::new();
@@ -332,7 +329,7 @@ fn sync_account_next_chunk(
                     return Err(err.into());
                 }
             };
-            last_block_index = Some(block_index);
+            end_block_index = Some(block_index);
 
             for tx_out in block_contents.outputs {
                 tx_outs.push((block_index, tx_out));
@@ -344,10 +341,10 @@ fn sync_account_next_chunk(
         }
 
         // If no blocks were found, exit.
-        if last_block_index.is_none() {
+        if end_block_index.is_none() {
             return Ok(SyncStatus::NoMoreBlocks);
         }
-        let last_block_index = last_block_index.unwrap();
+        let end_block_index = end_block_index.unwrap();
 
         // Attempt to decode each transaction as received by this account.
         let received_txos: Vec<_> = tx_outs
@@ -440,21 +437,21 @@ fn sync_account_next_chunk(
         }
 
         let txos_exceeding_pending_block_index =
-            Txo::list_pending_exceeding_block_index(account_id_hex, last_block_index + 1, conn)?;
+            Txo::list_pending_exceeding_block_index(account_id_hex, end_block_index + 1, conn)?;
         TransactionLog::update_tx_logs_associated_with_txos_to_failed(
             &txos_exceeding_pending_block_index,
             conn,
         )?;
 
         Txo::update_txos_exceeding_pending_tombstone_block_index_to_unspent(
-            last_block_index + 1,
+            end_block_index + 1,
             conn,
         )?;
 
         // Done syncing this chunk. Mark these blocks as synced for this account.
-        account.update_next_block_index(last_block_index + 1, conn)?;
+        account.update_next_block_index(end_block_index + 1, conn)?;
 
-        let num_blocks_synced = last_block_index - first_block_index + 1;
+        let num_blocks_synced = end_block_index - start_block_index + 1;
 
         let duration = start_time.elapsed();
 
@@ -462,8 +459,8 @@ fn sync_account_next_chunk(
             logger,
             "Synced {} blocks ({}-{}) for account {} in {:?}. {} txos received, {}/{} txos spent.",
             num_blocks_synced,
-            first_block_index,
-            last_block_index,
+            start_block_index,
+            end_block_index,
             account_id_hex.chars().take(6).collect::<String>(),
             duration,
             num_received_txos,

--- a/full-service/src/service/view_only_account.rs
+++ b/full-service/src/service/view_only_account.rs
@@ -69,10 +69,11 @@ where
 
         let account_id_hex = ViewOnlyAccountID::from(&view_private_key).to_string();
 
-        // We record one block after the local highest block index, because that is the earliest we
-        // could start scanning. Set first block to 0 if none is provided.
+        // We record one block after the local highest block index, because that is the
+        // earliest we could start scanning. Set first block to 0 if none is
+        // provided.
         let local_block_height = self.ledger_db.num_blocks()?;
-        let import_block_index = local_block_height; // - 1 + 1;
+        let import_block_index = local_block_height; // -1 +1
         let first_block_index = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
 
         let conn = self.wallet_db.get_conn()?;


### PR DESCRIPTION
Bugs fixed:
* When creating an account, it sets the next block index equal to the
  current block, forcing the current block to re-sync unnecessarily.
* When creating an account offline, it continues to endlessly sync the
  account past the zero blocks that are known in the ledger.
* When creating an account offline with no ledger, the first block is
  set to negative one, which overflows to <u64>::MAX - 1
