### PR TITLE
bugfix/db transactions

### DIFF
--- a/cli/test/stress.py
+++ b/cli/test/stress.py
@@ -1,0 +1,83 @@
+import aiohttp
+import asyncio
+import time
+
+
+async def main():
+        c = StressClient()
+
+        account = await c.create_account()
+        account_id = account['account_id']
+
+        await test_addresses(c, account_id, n=100)
+
+        await c.remove_account(account_id)
+
+
+async def test_addresses(c, account_id, n=10):
+    addresses = await c.get_addresses_for_account(account_id)
+    assert len(addresses) == 2
+
+    start = time.time()
+    await asyncio.gather(*[
+        c.assign_address(account_id, str(i))
+        for i in range(1, n+1)
+    ])
+    end = time.time()
+
+    addresses = await c.get_addresses_for_account(account_id)
+    assert len(addresses) == n + 2
+
+    print('Created {} addresses in {:.3f}s'.format(n, end - start))
+
+
+class StressClient:
+
+    async def _req(self, request_data):
+        default_params = {
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1,
+        }
+        request_data = {**request_data, **default_params}
+        async with aiohttp.ClientSession() as session:
+            async with session.post('http://localhost:9090/wallet', json=request_data) as response:
+                r = await response.json()
+        return r['result']
+
+    async def create_account(self):
+        r = await self._req({
+            "method": "create_account",
+            "params": {"name": ""}
+        })
+        return r['account']
+
+    async def remove_account(self, account_id):
+        return await self._req({
+            "method": "remove_account",
+            "params": {"account_id": account_id}
+        })
+
+    async def assign_address(self, account_id, name=''):
+        return await self._req({
+            "method": "assign_address_for_account",
+            "params": {
+                "account_id": account_id,
+                "metadata": name,
+            },
+        })
+
+    async def get_addresses_for_account(self, account_id):
+        r = await self._req({
+            "method": "get_addresses_for_account",
+            "params": {
+                "account_id": account_id,
+                "offset": "0",
+                "limit": "1000",
+            },
+        })
+        return r['address_map']
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -20,11 +20,8 @@ use mc_account_keys::AccountKey;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 use mc_ledger_db::{Ledger, LedgerDB};
 
-use crate::db::WalletDbError;
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-};
+use crate::db::{transaction, Conn, WalletDbError};
+use diesel::prelude::*;
 
 pub trait AssignedSubaddressModel {
     /// Assign a subaddress to a contact.
@@ -45,7 +42,7 @@ pub trait AssignedSubaddressModel {
         address_book_entry: Option<i64>,
         subaddress_index: u64,
         comment: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<String, WalletDbError>;
 
     /// Create the next subaddress for a given account.
@@ -56,21 +53,18 @@ pub trait AssignedSubaddressModel {
         account_id_hex: &str,
         comment: &str,
         ledger_db: &LedgerDB,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(String, i64), WalletDbError>;
 
     /// Get the AssignedSubaddress for a given assigned_subaddress_b58
-    fn get(
-        public_address_b58: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<AssignedSubaddress, WalletDbError>;
+    fn get(public_address_b58: &str, conn: &Conn) -> Result<AssignedSubaddress, WalletDbError>;
 
     /// Get the Assigned Subaddress for a given index in an account, if it
     /// exists
     fn get_for_account_by_index(
         account_id_hex: &str,
         index: i64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<AssignedSubaddress, WalletDbError>;
 
     /// Find an AssignedSubaddress by the subaddress spend public key
@@ -79,7 +73,7 @@ pub trait AssignedSubaddressModel {
     /// * (subaddress_index, assigned_subaddress_b58)
     fn find_by_subaddress_spend_public_key(
         subaddress_spend_public_key: &RistrettoPublic,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(i64, String), WalletDbError>;
 
     /// List all AssignedSubaddresses for a given account.
@@ -87,14 +81,11 @@ pub trait AssignedSubaddressModel {
         account_id_hex: &str,
         offset: Option<i64>,
         limit: Option<i64>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<AssignedSubaddress>, WalletDbError>;
 
     /// Delete all AssignedSubaddresses for a given account.
-    fn delete_all(
-        account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), WalletDbError>;
+    fn delete_all(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError>;
 }
 
 impl AssignedSubaddressModel for AssignedSubaddress {
@@ -103,7 +94,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
         address_book_entry: Option<i64>,
         subaddress_index: u64,
         comment: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<String, WalletDbError> {
         use crate::db::schema::assigned_subaddresses;
 
@@ -132,7 +123,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
         account_id_hex: &str,
         comment: &str,
         ledger_db: &LedgerDB,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(String, i64), WalletDbError> {
         use crate::db::schema::{
             accounts::dsl::{account_id_hex as dsl_account_id_hex, accounts},
@@ -143,103 +134,102 @@ impl AssignedSubaddressModel for AssignedSubaddress {
             },
         };
 
-        let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
+        transaction(conn, || {
+            let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
 
-        if account.fog_enabled {
-            return Err(WalletDbError::SubaddressesNotSupportedForFOGEnabledAccounts);
-        }
+            if account.fog_enabled {
+                return Err(WalletDbError::SubaddressesNotSupportedForFOGEnabledAccounts);
+            }
 
-        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-        let view_private_key = account_key.view_private_key();
-        let subaddress_index = account.next_subaddress_index;
-        let subaddress = account_key.subaddress(subaddress_index as u64);
+            let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+            let view_private_key = account_key.view_private_key();
+            let subaddress_index = account.next_subaddress_index;
+            let subaddress = account_key.subaddress(subaddress_index as u64);
 
-        let subaddress_b58 = b58_encode_public_address(&subaddress)?;
-        let subaddress_entry = NewAssignedSubaddress {
-            assigned_subaddress_b58: &subaddress_b58,
-            account_id_hex,
-            address_book_entry: None, /* FIXME: WS-8 - Address Book Entry if details
-                                       * provided, or None always for main? */
-            public_address: &mc_util_serial::encode(&subaddress),
-            subaddress_index: subaddress_index as i64,
-            comment,
-            subaddress_spend_key: &mc_util_serial::encode(subaddress.spend_public_key()),
-        };
+            let subaddress_b58 = b58_encode_public_address(&subaddress)?;
+            let subaddress_entry = NewAssignedSubaddress {
+                assigned_subaddress_b58: &subaddress_b58,
+                account_id_hex,
+                address_book_entry: None, /* FIXME: WS-8 - Address Book Entry if details
+                                           * provided, or None always for main? */
+                public_address: &mc_util_serial::encode(&subaddress),
+                subaddress_index: subaddress_index as i64,
+                comment,
+                subaddress_spend_key: &mc_util_serial::encode(subaddress.spend_public_key()),
+            };
 
-        diesel::insert_into(assigned_subaddresses::table)
-            .values(&subaddress_entry)
-            .execute(conn)?;
+            diesel::insert_into(assigned_subaddresses::table)
+                .values(&subaddress_entry)
+                .execute(conn)?;
 
-        // Update the next subaddress index for the account
-        diesel::update(accounts.filter(dsl_account_id_hex.eq(account_id_hex)))
-            .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
-            .execute(conn)?;
+            // Update the next subaddress index for the account
+            diesel::update(accounts.filter(dsl_account_id_hex.eq(account_id_hex)))
+                .set((crate::db::schema::accounts::next_subaddress_index.eq(subaddress_index + 1),))
+                .execute(conn)?;
 
-        // Find and repair orphaned txos at this subaddress.
-        let orphaned_txos = Txo::list_orphaned(account_id_hex, conn)?;
+            // Find and repair orphaned txos at this subaddress.
+            let orphaned_txos = Txo::list_orphaned(account_id_hex, conn)?;
 
-        for orphaned_txo in orphaned_txos.iter() {
-            let tx_out_target_key: RistrettoPublic =
-                mc_util_serial::decode(&orphaned_txo.target_key).unwrap();
-            let tx_public_key: RistrettoPublic =
-                mc_util_serial::decode(&orphaned_txo.public_key).unwrap();
-            let txo_public_key = CompressedRistrettoPublic::from(tx_public_key);
+            for orphaned_txo in orphaned_txos.iter() {
+                let tx_out_target_key: RistrettoPublic =
+                    mc_util_serial::decode(&orphaned_txo.target_key).unwrap();
+                let tx_public_key: RistrettoPublic =
+                    mc_util_serial::decode(&orphaned_txo.public_key).unwrap();
+                let txo_public_key = CompressedRistrettoPublic::from(tx_public_key);
 
-            let txo_subaddress_spk: RistrettoPublic = recover_public_subaddress_spend_key(
-                view_private_key,
-                &tx_out_target_key,
-                &tx_public_key,
-            );
-
-            if txo_subaddress_spk == *subaddress.spend_public_key() {
-                let onetime_private_key = recover_onetime_private_key(
+                let txo_subaddress_spk: RistrettoPublic = recover_public_subaddress_spend_key(
+                    view_private_key,
+                    &tx_out_target_key,
                     &tx_public_key,
-                    account_key.view_private_key(),
-                    &account_key.subaddress_spend_private(subaddress_index as u64),
                 );
 
-                let key_image = KeyImage::from(&onetime_private_key);
+                if txo_subaddress_spk == *subaddress.spend_public_key() {
+                    let onetime_private_key = recover_onetime_private_key(
+                        &tx_public_key,
+                        account_key.view_private_key(),
+                        &account_key.subaddress_spend_private(subaddress_index as u64),
+                    );
 
-                if ledger_db.contains_key_image(&key_image)? {
-                    let txo_index = ledger_db.get_tx_out_index_by_public_key(&txo_public_key)?;
-                    let block_index = ledger_db.get_block_index_by_tx_out_index(txo_index)?;
+                    let key_image = KeyImage::from(&onetime_private_key);
+
+                    if ledger_db.contains_key_image(&key_image)? {
+                        let txo_index = ledger_db.get_tx_out_index_by_public_key(&txo_public_key)?;
+                        let block_index = ledger_db.get_block_index_by_tx_out_index(txo_index)?;
+                        diesel::update(orphaned_txo)
+                            .set(
+                                crate::db::schema::txos::spent_block_index.eq(Some(block_index as i64)),
+                            )
+                            .execute(conn)?;
+                    }
+
+                    let key_image_bytes = mc_util_serial::encode(&key_image);
+
+                    // Update the account status mapping.
                     diesel::update(orphaned_txo)
-                        .set(
-                            crate::db::schema::txos::spent_block_index.eq(Some(block_index as i64)),
-                        )
+                        .set((
+                            crate::db::schema::txos::subaddress_index.eq(subaddress_index),
+                            crate::db::schema::txos::key_image.eq(key_image_bytes),
+                        ))
                         .execute(conn)?;
-                }
 
-                let key_image_bytes = mc_util_serial::encode(&key_image);
-
-                // Update the account status mapping.
-                diesel::update(orphaned_txo)
-                    .set((
-                        crate::db::schema::txos::subaddress_index.eq(subaddress_index),
-                        crate::db::schema::txos::key_image.eq(key_image_bytes),
-                    ))
+                    diesel::update(
+                        transaction_logs
+                            .filter(tx_log_transaction_id_hex.eq(&orphaned_txo.txo_id_hex))
+                            .filter(tx_log_account_id_hex.eq(account_id_hex)),
+                    )
+                    .set(
+                        (crate::db::schema::transaction_logs::assigned_subaddress_b58
+                            .eq(&subaddress_b58),),
+                    )
                     .execute(conn)?;
-
-                diesel::update(
-                    transaction_logs
-                        .filter(tx_log_transaction_id_hex.eq(&orphaned_txo.txo_id_hex))
-                        .filter(tx_log_account_id_hex.eq(account_id_hex)),
-                )
-                .set(
-                    (crate::db::schema::transaction_logs::assigned_subaddress_b58
-                        .eq(&subaddress_b58),),
-                )
-                .execute(conn)?;
+                }
             }
-        }
 
-        Ok((subaddress_b58, subaddress_index))
+            Ok((subaddress_b58, subaddress_index))
+        })
     }
 
-    fn get(
-        public_address_b58: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<AssignedSubaddress, WalletDbError> {
+    fn get(public_address_b58: &str, conn: &Conn) -> Result<AssignedSubaddress, WalletDbError> {
         use crate::db::schema::assigned_subaddresses::dsl::{
             assigned_subaddress_b58, assigned_subaddresses,
         };
@@ -265,7 +255,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
     fn get_for_account_by_index(
         account_id_hex: &str,
         index: i64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<AssignedSubaddress, WalletDbError> {
         let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
 
@@ -278,7 +268,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
 
     fn find_by_subaddress_spend_public_key(
         subaddress_spend_public_key: &RistrettoPublic,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(i64, String), WalletDbError> {
         use crate::db::schema::assigned_subaddresses::{
             account_id_hex, dsl::assigned_subaddresses, subaddress_index, subaddress_spend_key,
@@ -308,7 +298,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
         account_id_hex: &str,
         offset: Option<i64>,
         limit: Option<i64>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<AssignedSubaddress>, WalletDbError> {
         use crate::db::schema::assigned_subaddresses::{
             account_id_hex as schema_account_id_hex, all_columns, dsl::assigned_subaddresses,
@@ -327,10 +317,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
         Ok(addresses)
     }
 
-    fn delete_all(
-        account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
-    ) -> Result<(), WalletDbError> {
+    fn delete_all(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError> {
         use crate::db::schema::assigned_subaddresses::dsl::{
             account_id_hex as schema_account_id_hex, assigned_subaddresses,
         };

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -193,11 +193,13 @@ impl AssignedSubaddressModel for AssignedSubaddress {
                     let key_image = KeyImage::from(&onetime_private_key);
 
                     if ledger_db.contains_key_image(&key_image)? {
-                        let txo_index = ledger_db.get_tx_out_index_by_public_key(&txo_public_key)?;
+                        let txo_index =
+                            ledger_db.get_tx_out_index_by_public_key(&txo_public_key)?;
                         let block_index = ledger_db.get_block_index_by_tx_out_index(txo_index)?;
                         diesel::update(orphaned_txo)
                             .set(
-                                crate::db::schema::txos::spent_block_index.eq(Some(block_index as i64)),
+                                crate::db::schema::txos::spent_block_index
+                                    .eq(Some(block_index as i64)),
                             )
                             .execute(conn)?;
                     }

--- a/full-service/src/db/gift_code.rs
+++ b/full-service/src/db/gift_code.rs
@@ -4,9 +4,8 @@
 
 use crate::{
     db::{
-        Conn,
         models::{GiftCode, NewGiftCode},
-        WalletDbError,
+        Conn, WalletDbError,
     },
     service::gift_code::EncodedGiftCode,
 };
@@ -42,21 +41,13 @@ pub trait GiftCodeModel {
     ) -> Result<GiftCode, WalletDbError>;
 
     /// Get the details of a specific Gift Code.
-    fn get(
-        gift_code_b58: &EncodedGiftCode,
-        conn: &Conn,
-    ) -> Result<GiftCode, WalletDbError>;
+    fn get(gift_code_b58: &EncodedGiftCode, conn: &Conn) -> Result<GiftCode, WalletDbError>;
 
     /// Get all Gift Codes in this wallet.
-    fn list_all(
-        conn: &Conn,
-    ) -> Result<Vec<GiftCode>, WalletDbError>;
+    fn list_all(conn: &Conn) -> Result<Vec<GiftCode>, WalletDbError>;
 
     /// Delete a gift code.
-    fn delete(
-        self,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn delete(self, conn: &Conn) -> Result<(), WalletDbError>;
 }
 
 impl GiftCodeModel for GiftCode {
@@ -80,10 +71,7 @@ impl GiftCodeModel for GiftCode {
         Ok(gift_code)
     }
 
-    fn get(
-        gift_code_b58: &EncodedGiftCode,
-        conn: &Conn,
-    ) -> Result<GiftCode, WalletDbError> {
+    fn get(gift_code_b58: &EncodedGiftCode, conn: &Conn) -> Result<GiftCode, WalletDbError> {
         use crate::db::schema::gift_codes::dsl::{gift_code_b58 as dsl_gift_code_b58, gift_codes};
 
         match gift_codes
@@ -99,9 +87,7 @@ impl GiftCodeModel for GiftCode {
         }
     }
 
-    fn list_all(
-        conn: &Conn,
-    ) -> Result<Vec<GiftCode>, WalletDbError> {
+    fn list_all(conn: &Conn) -> Result<Vec<GiftCode>, WalletDbError> {
         use crate::db::schema::gift_codes;
 
         Ok(gift_codes::table
@@ -109,10 +95,7 @@ impl GiftCodeModel for GiftCode {
             .load::<GiftCode>(conn)?)
     }
 
-    fn delete(
-        self,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn delete(self, conn: &Conn) -> Result<(), WalletDbError> {
         use crate::db::schema::gift_codes::dsl::{gift_code_b58, gift_codes};
 
         diesel::delete(gift_codes.filter(gift_code_b58.eq(&self.gift_code_b58))).execute(conn)?;

--- a/full-service/src/db/gift_code.rs
+++ b/full-service/src/db/gift_code.rs
@@ -4,16 +4,13 @@
 
 use crate::{
     db::{
+        Conn,
         models::{GiftCode, NewGiftCode},
         WalletDbError,
     },
     service::gift_code::EncodedGiftCode,
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-    RunQueryDsl,
-};
+use diesel::prelude::*;
 use displaydoc::Display;
 
 #[derive(Display, Debug)]
@@ -41,24 +38,24 @@ pub trait GiftCodeModel {
     fn create(
         gift_code_b58: &EncodedGiftCode,
         value: i64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<GiftCode, WalletDbError>;
 
     /// Get the details of a specific Gift Code.
     fn get(
         gift_code_b58: &EncodedGiftCode,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<GiftCode, WalletDbError>;
 
     /// Get all Gift Codes in this wallet.
     fn list_all(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<GiftCode>, WalletDbError>;
 
     /// Delete a gift code.
     fn delete(
         self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 }
 
@@ -66,7 +63,7 @@ impl GiftCodeModel for GiftCode {
     fn create(
         gift_code_b58: &EncodedGiftCode,
         value: i64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<GiftCode, WalletDbError> {
         use crate::db::schema::gift_codes;
 
@@ -85,7 +82,7 @@ impl GiftCodeModel for GiftCode {
 
     fn get(
         gift_code_b58: &EncodedGiftCode,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<GiftCode, WalletDbError> {
         use crate::db::schema::gift_codes::dsl::{gift_code_b58 as dsl_gift_code_b58, gift_codes};
 
@@ -103,7 +100,7 @@ impl GiftCodeModel for GiftCode {
     }
 
     fn list_all(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<GiftCode>, WalletDbError> {
         use crate::db::schema::gift_codes;
 
@@ -114,7 +111,7 @@ impl GiftCodeModel for GiftCode {
 
     fn delete(
         self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use crate::db::schema::gift_codes::dsl::{gift_code_b58, gift_codes};
 

--- a/full-service/src/db/mod.rs
+++ b/full-service/src/db/mod.rs
@@ -16,5 +16,5 @@ pub mod view_only_txo;
 mod wallet_db;
 mod wallet_db_error;
 
-pub use wallet_db::WalletDb;
+pub use wallet_db::{transaction, Conn, WalletDb};
 pub use wallet_db_error::WalletDbError;

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -19,11 +19,10 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
-        Conn,
         models::{
             Account, AssignedSubaddress, NewTxo, Txo, TXO_USED_AS_CHANGE, TXO_USED_AS_OUTPUT,
         },
-        WalletDbError,
+        Conn, WalletDbError,
     },
     util::{b58::b58_encode_public_address, constants::DEFAULT_CHANGE_SUBADDRESS_INDEX},
 };
@@ -164,15 +163,9 @@ pub trait TxoModel {
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError>;
 
-    fn list_secreted(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError>;
+    fn list_secreted(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError>;
 
-    fn list_orphaned(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError>;
+    fn list_orphaned(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError>;
 
     fn list_pending(
         account_id_hex: &str,
@@ -180,10 +173,7 @@ pub trait TxoModel {
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError>;
 
-    fn list_minted(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError>;
+    fn list_minted(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError>;
 
     fn list_pending_exceeding_block_index(
         account_id_hex: &str,
@@ -195,10 +185,7 @@ pub trait TxoModel {
     ///
     /// Returns:
     /// * Txo
-    fn get(
-        txo_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Txo, WalletDbError>;
+    fn get(txo_id_hex: &str, conn: &Conn) -> Result<Txo, WalletDbError>;
 
     /// Get several Txos by Txo public_keys
     ///
@@ -242,15 +229,10 @@ pub trait TxoModel {
         conn: &Conn,
     ) -> Result<bool, WalletDbError>;
 
-    fn scrub_account(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn scrub_account(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError>;
 
     /// Delete txos which are not referenced by any account or transaction.
-    fn delete_unreferenced(
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn delete_unreferenced(conn: &Conn) -> Result<(), WalletDbError>;
 
     fn is_change(&self) -> bool;
 
@@ -602,10 +584,7 @@ impl TxoModel for Txo {
         Ok(txos)
     }
 
-    fn list_secreted(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError> {
+    fn list_secreted(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
 
         // Secreted txos were minted by this account, but not received by this account,
@@ -622,10 +601,7 @@ impl TxoModel for Txo {
         Ok(txos)
     }
 
-    fn list_orphaned(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError> {
+    fn list_orphaned(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
 
         let txos: Vec<Txo> = txos::table
@@ -679,10 +655,7 @@ impl TxoModel for Txo {
         Ok(txos)
     }
 
-    fn list_minted(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Vec<Txo>, WalletDbError> {
+    fn list_minted(account_id_hex: &str, conn: &Conn) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
 
         let results = txos::table
@@ -692,10 +665,7 @@ impl TxoModel for Txo {
         Ok(results)
     }
 
-    fn get(
-        txo_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<Txo, WalletDbError> {
+    fn get(txo_id_hex: &str, conn: &Conn) -> Result<Txo, WalletDbError> {
         use crate::db::schema::txos;
 
         let txo = match txos::table
@@ -737,19 +707,17 @@ impl TxoModel for Txo {
     ) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
 
-        conn.transaction(|| {
-            let txos: Vec<Txo> = txos::table
-                .filter(txos::txo_id_hex.eq_any(txo_ids))
-                .load(conn)?;
+        let txos: Vec<Txo> = txos::table
+            .filter(txos::txo_id_hex.eq_any(txo_ids))
+            .load(conn)?;
 
-            if let Some(pending_tombstone_block_index) = pending_tombstone_block_index {
-                for txo in &txos {
-                    txo.update_to_pending(pending_tombstone_block_index, conn)?;
-                }
+        if let Some(pending_tombstone_block_index) = pending_tombstone_block_index {
+            for txo in &txos {
+                txo.update_to_pending(pending_tombstone_block_index, conn)?;
             }
+        }
 
-            Ok(txos)
-        })
+        Ok(txos)
     }
 
     fn select_unspent_txos_for_value(
@@ -760,105 +728,102 @@ impl TxoModel for Txo {
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
-        conn.transaction(|| {
-            let spendable_txos: Vec<Txo> = txos::table
-                .filter(txos::spent_block_index.is_null())
-                .filter(txos::pending_tombstone_block_index.is_null())
-                .filter(txos::subaddress_index.is_not_null())
-                .filter(txos::key_image.is_not_null())
-                .filter(txos::received_account_id_hex.eq(account_id_hex))
-                .order_by(txos::value.desc())
-                .load(conn)?;
+        let spendable_txos: Vec<Txo> = txos::table
+            .filter(txos::spent_block_index.is_null())
+            .filter(txos::pending_tombstone_block_index.is_null())
+            .filter(txos::subaddress_index.is_not_null())
+            .filter(txos::key_image.is_not_null())
+            .filter(txos::received_account_id_hex.eq(account_id_hex))
+            .order_by(txos::value.desc())
+            .load(conn)?;
 
-            // The SQLite database cannot filter effectively on a u64 value, so filter for
-            // maximum value in memory.
-            let mut spendable_txos = if let Some(msv) = max_spendable_value {
-                spendable_txos
-                    .into_iter()
-                    .filter(|txo| (txo.value as u64) <= msv)
-                    .collect()
-            } else {
-                spendable_txos
-            };
+        // The SQLite database cannot filter effectively on a u64 value, so filter for
+        // maximum value in memory.
+        let mut spendable_txos = if let Some(msv) = max_spendable_value {
+            spendable_txos
+                .into_iter()
+                .filter(|txo| (txo.value as u64) <= msv)
+                .collect()
+        } else {
+            spendable_txos
+        };
 
-            if spendable_txos.is_empty() {
-                return Err(WalletDbError::NoSpendableTxos);
-            }
+        if spendable_txos.is_empty() {
+            return Err(WalletDbError::NoSpendableTxos);
+        }
 
-            // The maximum spendable is limited by the maximal number of inputs we can use.
-            // Since the txos are sorted by decreasing value, this is the maximum
-            // value we can possibly spend in one transaction.
-            // Note, u128::Max = 340_282_366_920_938_463_463_374_607_431_768_211_455, which
-            // is far beyond the total number of pMOB in the MobileCoin system
-            // (250_000_000_000_000_000_000)
-            let max_spendable_in_wallet: u128 = spendable_txos
+        // The maximum spendable is limited by the maximal number of inputs we can use.
+        // Since the txos are sorted by decreasing value, this is the maximum
+        // value we can possibly spend in one transaction.
+        // Note, u128::Max = 340_282_366_920_938_463_463_374_607_431_768_211_455, which
+        // is far beyond the total number of pMOB in the MobileCoin system
+        // (250_000_000_000_000_000_000)
+        let max_spendable_in_wallet: u128 = spendable_txos
+            .iter()
+            .take(MAX_INPUTS as usize)
+            .map(|utxo| (utxo.value as u64) as u128)
+            .sum();
+        // If we're trying to spend more than we have in the wallet, we may need to
+        // defrag
+        if target_value as u128 > max_spendable_in_wallet {
+            // See if we merged the UTXOs we would be able to spend this amount.
+            let total_unspent_value_in_wallet: u128 = spendable_txos
                 .iter()
-                .take(MAX_INPUTS as usize)
                 .map(|utxo| (utxo.value as u64) as u128)
                 .sum();
-            // If we're trying to spend more than we have in the wallet, we may need to
-            // defrag
-            if target_value as u128 > max_spendable_in_wallet {
-                // See if we merged the UTXOs we would be able to spend this amount.
-                let total_unspent_value_in_wallet: u128 = spendable_txos
-                    .iter()
-                    .map(|utxo| (utxo.value as u64) as u128)
-                    .sum();
-                if total_unspent_value_in_wallet >= target_value as u128 {
-                    return Err(WalletDbError::InsufficientFundsFragmentedTxos);
-                } else {
-                    return Err(WalletDbError::InsufficientFundsUnderMaxSpendable(format!(
-                        "Max spendable value in wallet: {:?}, but target value: {:?}",
-                        max_spendable_in_wallet, target_value
-                    )));
-                }
+            if total_unspent_value_in_wallet >= target_value as u128 {
+                return Err(WalletDbError::InsufficientFundsFragmentedTxos);
+            } else {
+                return Err(WalletDbError::InsufficientFundsUnderMaxSpendable(format!(
+                    "Max spendable value in wallet: {:?}, but target value: {:?}",
+                    max_spendable_in_wallet, target_value
+                )));
+            }
+        }
+
+        // Select the actual Txos to spend. We want to opportunistically fill up the
+        // input slots with dust, from any subaddress, so we take from the back
+        // of the Txo vec. This is a knapsack problem, and the selection could
+        // be improved. For now, we simply move the window of MAX_INPUTS up from
+        // the back of the sorted vector until we have a window with
+        // a large enough sum.
+        let mut selected_utxos: Vec<Txo> = Vec::new();
+        let mut total: u64 = 0;
+        loop {
+            if total >= target_value {
+                break;
             }
 
-            // Select the actual Txos to spend. We want to opportunistically fill up the
-            // input slots with dust, from any subaddress, so we take from the back
-            // of the Txo vec. This is a knapsack problem, and the selection could
-            // be improved. For now, we simply move the window of MAX_INPUTS up from
-            // the back of the sorted vector until we have a window with
-            // a large enough sum.
-            let mut selected_utxos: Vec<Txo> = Vec::new();
-            let mut total: u64 = 0;
-            loop {
-                if total >= target_value {
-                    break;
-                }
+            // Grab the next (smallest) utxo, in order to opportunistically sweep up dust
+            let next_utxo = spendable_txos.pop().ok_or_else(|| {
+                WalletDbError::InsufficientFunds(format!(
+                    "Not enough Txos to sum to target value: {:?}",
+                    target_value
+                ))
+            })?;
+            selected_utxos.push(next_utxo.clone());
+            total += next_utxo.value as u64;
 
-                // Grab the next (smallest) utxo, in order to opportunistically sweep up dust
-                let next_utxo = spendable_txos.pop().ok_or_else(|| {
-                    WalletDbError::InsufficientFunds(format!(
-                        "Not enough Txos to sum to target value: {:?}",
-                        target_value
-                    ))
-                })?;
-                selected_utxos.push(next_utxo.clone());
-                total += next_utxo.value as u64;
-
-                // Cap at maximum allowed inputs.
-                if selected_utxos.len() > MAX_INPUTS as usize {
-                    // Remove the lowest utxo.
-                    let removed = selected_utxos.remove(0);
-                    total -= removed.value as u64;
-                }
+            // Cap at maximum allowed inputs.
+            if selected_utxos.len() > MAX_INPUTS as usize {
+                // Remove the lowest utxo.
+                let removed = selected_utxos.remove(0);
+                total -= removed.value as u64;
             }
+        }
 
-            if selected_utxos.is_empty() || selected_utxos.len() > MAX_INPUTS as usize {
-                return Err(WalletDbError::InsufficientFunds(
-                    "Logic error. Could not select Txos despite having sufficient funds"
-                        .to_string(),
-                ));
+        if selected_utxos.is_empty() || selected_utxos.len() > MAX_INPUTS as usize {
+            return Err(WalletDbError::InsufficientFunds(
+                "Logic error. Could not select Txos despite having sufficient funds".to_string(),
+            ));
+        }
+        if let Some(pending_tombstone_block_index) = pending_tombstone_block_index {
+            for txo in &selected_utxos {
+                txo.update_to_pending(pending_tombstone_block_index, conn)?;
             }
-            if let Some(pending_tombstone_block_index) = pending_tombstone_block_index {
-                for txo in &selected_utxos {
-                    txo.update_to_pending(pending_tombstone_block_index, conn)?;
-                }
-            }
+        }
 
-            Ok(selected_utxos)
-        })
+        Ok(selected_utxos)
     }
 
     fn validate_confirmation(
@@ -874,10 +839,7 @@ impl TxoModel for Txo {
         Ok(confirmation.validate(&public_key, account_key.view_private_key()))
     }
 
-    fn scrub_account(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn scrub_account(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError> {
         use crate::db::schema::txos;
 
         let txos_received_by_account =
@@ -897,9 +859,7 @@ impl TxoModel for Txo {
         Ok(())
     }
 
-    fn delete_unreferenced(
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn delete_unreferenced(conn: &Conn) -> Result<(), WalletDbError> {
         use crate::db::schema::txos;
 
         let unreferenced_txos = txos::table
@@ -1606,10 +1566,10 @@ mod tests {
         // Create TxProposal from the sender account, which contains the Confirmation
         // Number
         log::info!(logger, "Creating transaction builder");
+        let conn = wallet_db.get_conn().unwrap();
         let mut builder: WalletTransactionBuilder<MockFogPubkeyResolver> =
             WalletTransactionBuilder::new(
                 AccountID::from(&sender_account_key).to_string(),
-                wallet_db.clone(),
                 ledger_db.clone(),
                 get_resolver_factory(&mut rng).unwrap(),
                 logger.clone(),
@@ -1617,9 +1577,9 @@ mod tests {
         builder
             .add_recipient(recipient_account_key.default_subaddress(), 50 * MOB)
             .unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
 
         // Sleep to make sure that the foreign keys exist
         std::thread::sleep(Duration::from_secs(3));

--- a/full-service/src/db/view_only_account.rs
+++ b/full-service/src/db/view_only_account.rs
@@ -4,17 +4,14 @@
 
 use crate::{
     db::{
+        Conn,
         models::{NewViewOnlyAccount, ViewOnlyAccount, ViewOnlyTxo},
         view_only_txo::ViewOnlyTxoModel,
         schema, WalletDbError,
     },
     util::encoding_helpers::{ristretto_to_vec, vec_to_hex},
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-    RunQueryDsl,
-};
+use diesel::prelude::*;
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use std::{fmt, str};
@@ -46,7 +43,7 @@ pub trait ViewOnlyAccountModel {
         first_block_index: u64,
         import_block_index: u64,
         name: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyAccount, WalletDbError>;
 
     /// Get a specific account.
@@ -54,14 +51,14 @@ pub trait ViewOnlyAccountModel {
     /// * ViewOnlyAccount
     fn get(
         account_id: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyAccount, WalletDbError>;
 
     /// List all view-only-accounts.
     /// Returns:
     /// * Vector of all View Only Accounts in the DB
     fn list_all(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyAccount>, WalletDbError>;
 
     /// Update an view-only-account name.
@@ -70,20 +67,20 @@ pub trait ViewOnlyAccountModel {
     fn update_name(
         &self,
         new_name: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 
     /// Update the next block index this account will need to sync.
     fn update_next_block_index(
         &self,
         next_block_index: u64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 
     /// Delete a view-only-account.
     fn delete(
         self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 }
 
@@ -94,7 +91,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
         first_block_index: u64,
         import_block_index: u64,
         name: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyAccount, WalletDbError> {
         use schema::view_only_accounts;
 
@@ -120,7 +117,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
 
     fn get(
         account_id: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyAccount, WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, view_only_accounts,
@@ -140,7 +137,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
     }
 
     fn list_all(
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyAccount>, WalletDbError> {
         use schema::view_only_accounts;
 
@@ -152,7 +149,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
     fn update_name(
         &self,
         new_name: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, name as dsl_name, view_only_accounts,
@@ -167,7 +164,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
     fn update_next_block_index(
         &self,
         next_block_index: u64,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, next_block_index as dsl_next_block,
@@ -181,7 +178,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
 
     fn delete(
         self,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, view_only_accounts,

--- a/full-service/src/db/view_only_account.rs
+++ b/full-service/src/db/view_only_account.rs
@@ -4,10 +4,10 @@
 
 use crate::{
     db::{
-        Conn,
         models::{NewViewOnlyAccount, ViewOnlyAccount, ViewOnlyTxo},
+        schema,
         view_only_txo::ViewOnlyTxoModel,
-        schema, WalletDbError,
+        Conn, WalletDbError,
     },
     util::encoding_helpers::{ristretto_to_vec, vec_to_hex},
 };
@@ -49,26 +49,17 @@ pub trait ViewOnlyAccountModel {
     /// Get a specific account.
     /// Returns:
     /// * ViewOnlyAccount
-    fn get(
-        account_id: &str,
-        conn: &Conn,
-    ) -> Result<ViewOnlyAccount, WalletDbError>;
+    fn get(account_id: &str, conn: &Conn) -> Result<ViewOnlyAccount, WalletDbError>;
 
     /// List all view-only-accounts.
     /// Returns:
     /// * Vector of all View Only Accounts in the DB
-    fn list_all(
-        conn: &Conn,
-    ) -> Result<Vec<ViewOnlyAccount>, WalletDbError>;
+    fn list_all(conn: &Conn) -> Result<Vec<ViewOnlyAccount>, WalletDbError>;
 
     /// Update an view-only-account name.
     /// The only updatable field is the name. Any other desired update requires
     /// adding a new account, and deleting the existing if desired.
-    fn update_name(
-        &self,
-        new_name: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn update_name(&self, new_name: &str, conn: &Conn) -> Result<(), WalletDbError>;
 
     /// Update the next block index this account will need to sync.
     fn update_next_block_index(
@@ -78,10 +69,7 @@ pub trait ViewOnlyAccountModel {
     ) -> Result<(), WalletDbError>;
 
     /// Delete a view-only-account.
-    fn delete(
-        self,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn delete(self, conn: &Conn) -> Result<(), WalletDbError>;
 }
 
 impl ViewOnlyAccountModel for ViewOnlyAccount {
@@ -115,10 +103,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
         ViewOnlyAccount::get(account_id_hex, conn)
     }
 
-    fn get(
-        account_id: &str,
-        conn: &Conn,
-    ) -> Result<ViewOnlyAccount, WalletDbError> {
+    fn get(account_id: &str, conn: &Conn) -> Result<ViewOnlyAccount, WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, view_only_accounts,
         };
@@ -136,9 +121,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
         }
     }
 
-    fn list_all(
-        conn: &Conn,
-    ) -> Result<Vec<ViewOnlyAccount>, WalletDbError> {
+    fn list_all(conn: &Conn) -> Result<Vec<ViewOnlyAccount>, WalletDbError> {
         use schema::view_only_accounts;
 
         Ok(view_only_accounts::table
@@ -146,11 +129,7 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
             .load::<ViewOnlyAccount>(conn)?)
     }
 
-    fn update_name(
-        &self,
-        new_name: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn update_name(&self, new_name: &str, conn: &Conn) -> Result<(), WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, name as dsl_name, view_only_accounts,
         };
@@ -176,16 +155,13 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
         Ok(())
     }
 
-    fn delete(
-        self,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn delete(self, conn: &Conn) -> Result<(), WalletDbError> {
         use schema::view_only_accounts::dsl::{
             account_id_hex as dsl_account_id, view_only_accounts,
         };
 
         // delete associated view-only-txos
-        ViewOnlyTxo::delete_all_for_account(&self.account_id_hex, &conn)?;
+        ViewOnlyTxo::delete_all_for_account(&self.account_id_hex, conn)?;
         diesel::delete(view_only_accounts.filter(dsl_account_id.eq(&self.account_id_hex)))
             .execute(conn)?;
         Ok(())

--- a/full-service/src/db/view_only_account.rs
+++ b/full-service/src/db/view_only_account.rs
@@ -4,7 +4,8 @@
 
 use crate::{
     db::{
-        models::{NewViewOnlyAccount, ViewOnlyAccount},
+        models::{NewViewOnlyAccount, ViewOnlyAccount, ViewOnlyTxo},
+        view_only_txo::ViewOnlyTxoModel,
         schema, WalletDbError,
     },
     util::encoding_helpers::{ristretto_to_vec, vec_to_hex},
@@ -186,9 +187,10 @@ impl ViewOnlyAccountModel for ViewOnlyAccount {
             account_id_hex as dsl_account_id, view_only_accounts,
         };
 
+        // delete associated view-only-txos
+        ViewOnlyTxo::delete_all_for_account(&self.account_id_hex, &conn)?;
         diesel::delete(view_only_accounts.filter(dsl_account_id.eq(&self.account_id_hex)))
             .execute(conn)?;
-
         Ok(())
     }
 }

--- a/full-service/src/db/view_only_transaction_log.rs
+++ b/full-service/src/db/view_only_transaction_log.rs
@@ -3,33 +3,30 @@
 //! DB impl for the view-only transaction log model.
 
 use crate::db::{
+    Conn,
     models::{NewViewOnlyTransactionLog, ViewOnlyTransactionLog},
     schema, WalletDbError,
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-    RunQueryDsl,
-};
+use diesel::prelude::*;
 
 pub trait ViewOnlyTransactionLogModel {
     /// insert a new view only transaction log
     fn create(
         change_txo_id_hex: &str,
         input_txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTransactionLog, WalletDbError>;
 
     /// get a view only transaction log by change txo id
     fn get_by_change_txo_id(
         change_txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTransactionLog, WalletDbError>;
 
     /// get a all view only transaction logs for a change txo id
     fn find_all_by_change_txo_id(
         change_txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyTransactionLog>, WalletDbError>;
 }
 
@@ -37,7 +34,7 @@ impl ViewOnlyTransactionLogModel for ViewOnlyTransactionLog {
     fn create(
         change_txo_id_hex: &str,
         input_txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTransactionLog, WalletDbError> {
         use schema::view_only_transaction_logs;
 
@@ -55,7 +52,7 @@ impl ViewOnlyTransactionLogModel for ViewOnlyTransactionLog {
 
     fn get_by_change_txo_id(
         txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTransactionLog, WalletDbError> {
         use schema::view_only_transaction_logs::dsl::{
             change_txo_id_hex, view_only_transaction_logs,
@@ -75,7 +72,7 @@ impl ViewOnlyTransactionLogModel for ViewOnlyTransactionLog {
 
     fn find_all_by_change_txo_id(
         txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyTransactionLog>, WalletDbError> {
         use schema::view_only_transaction_logs::dsl::{
             change_txo_id_hex, view_only_transaction_logs,

--- a/full-service/src/db/view_only_transaction_log.rs
+++ b/full-service/src/db/view_only_transaction_log.rs
@@ -3,9 +3,8 @@
 //! DB impl for the view-only transaction log model.
 
 use crate::db::{
-    Conn,
     models::{NewViewOnlyTransactionLog, ViewOnlyTransactionLog},
-    schema, WalletDbError,
+    schema, Conn, WalletDbError,
 };
 use diesel::prelude::*;
 

--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -160,7 +160,6 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         };
 
         diesel::delete(view_only_txos.filter(dsl_account_id.eq(account_id_hex))).execute(conn)?;
-
         Ok(())
     }
 }

--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -3,17 +3,14 @@
 //! DB impl for the view-only Txo model.
 
 use crate::db::{
+    Conn,
     models::{NewViewOnlyTxo, ViewOnlyAccount, ViewOnlyTxo},
     schema,
     txo::TxoID,
     view_only_account::ViewOnlyAccountModel,
     WalletDbError,
 };
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-    RunQueryDsl,
-};
+use diesel::prelude::*;
 use mc_transaction_core::tx::TxOut;
 
 pub trait ViewOnlyTxoModel {
@@ -22,7 +19,7 @@ pub trait ViewOnlyTxoModel {
         tx_out: TxOut,
         value: u64,
         view_only_account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTxo, WalletDbError>;
 
     /// Get the details for a specific view only Txo.
@@ -31,7 +28,7 @@ pub trait ViewOnlyTxoModel {
     /// * ViewOnlyTxo
     fn get(
         txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTxo, WalletDbError>;
 
     /// mark a group of view-only-txo as spent
@@ -40,7 +37,7 @@ pub trait ViewOnlyTxoModel {
     /// * ()
     fn set_spent(
         txo_ids: Vec<String>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 
     /// list view only txos for a view only account
@@ -51,13 +48,13 @@ pub trait ViewOnlyTxoModel {
         account_id_hex: &str,
         offset: Option<i64>,
         limit: Option<i64>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyTxo>, WalletDbError>;
 
     /// delete all view only txos for a view-only account
     fn delete_all_for_account(
         account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError>;
 }
 
@@ -66,7 +63,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         tx_out: TxOut,
         value: u64,
         view_only_account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTxo, WalletDbError> {
         use schema::view_only_txos;
 
@@ -92,7 +89,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
 
     fn get(
         txo_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<ViewOnlyTxo, WalletDbError> {
         use schema::view_only_txos;
 
@@ -116,7 +113,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         account_id_hex: &str,
         offset: Option<i64>,
         limit: Option<i64>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<Vec<ViewOnlyTxo>, WalletDbError> {
         use schema::view_only_txos;
 
@@ -134,7 +131,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
 
     fn set_spent(
         txo_ids: Vec<String>,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use schema::view_only_txos::dsl::{
             spent as dsl_spent, txo_id_hex as dsl_txo_id, view_only_txos,
@@ -153,7 +150,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
 
     fn delete_all_for_account(
         account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use schema::view_only_txos::dsl::{
             view_only_account_id_hex as dsl_account_id, view_only_txos,

--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -3,12 +3,11 @@
 //! DB impl for the view-only Txo model.
 
 use crate::db::{
-    Conn,
     models::{NewViewOnlyTxo, ViewOnlyAccount, ViewOnlyTxo},
     schema,
     txo::TxoID,
     view_only_account::ViewOnlyAccountModel,
-    WalletDbError,
+    Conn, WalletDbError,
 };
 use diesel::prelude::*;
 use mc_transaction_core::tx::TxOut;
@@ -26,19 +25,13 @@ pub trait ViewOnlyTxoModel {
     ///
     /// Returns:
     /// * ViewOnlyTxo
-    fn get(
-        txo_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<ViewOnlyTxo, WalletDbError>;
+    fn get(txo_id_hex: &str, conn: &Conn) -> Result<ViewOnlyTxo, WalletDbError>;
 
     /// mark a group of view-only-txo as spent
     ///
     /// Returns:
     /// * ()
-    fn set_spent(
-        txo_ids: Vec<String>,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn set_spent(txo_ids: Vec<String>, conn: &Conn) -> Result<(), WalletDbError>;
 
     /// list view only txos for a view only account
     ///
@@ -52,10 +45,7 @@ pub trait ViewOnlyTxoModel {
     ) -> Result<Vec<ViewOnlyTxo>, WalletDbError>;
 
     /// delete all view only txos for a view-only account
-    fn delete_all_for_account(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError>;
+    fn delete_all_for_account(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError>;
 }
 
 impl ViewOnlyTxoModel for ViewOnlyTxo {
@@ -87,10 +77,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         ViewOnlyTxo::get(&txo_id.to_string(), conn)
     }
 
-    fn get(
-        txo_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<ViewOnlyTxo, WalletDbError> {
+    fn get(txo_id_hex: &str, conn: &Conn) -> Result<ViewOnlyTxo, WalletDbError> {
         use schema::view_only_txos;
 
         let txo = match view_only_txos::table
@@ -129,10 +116,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         Ok(txos)
     }
 
-    fn set_spent(
-        txo_ids: Vec<String>,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn set_spent(txo_ids: Vec<String>, conn: &Conn) -> Result<(), WalletDbError> {
         use schema::view_only_txos::dsl::{
             spent as dsl_spent, txo_id_hex as dsl_txo_id, view_only_txos,
         };
@@ -148,10 +132,7 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         Ok(())
     }
 
-    fn delete_all_for_account(
-        account_id_hex: &str,
-        conn: &Conn,
-    ) -> Result<(), WalletDbError> {
+    fn delete_all_for_account(account_id_hex: &str, conn: &Conn) -> Result<(), WalletDbError> {
         use schema::view_only_txos::dsl::{
             view_only_account_id_hex as dsl_account_id, view_only_txos,
         };

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -78,7 +78,7 @@ impl WalletDb {
 
     pub fn get_conn(
         &self,
-    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, WalletDbError> {
+    ) -> Result<Conn, WalletDbError> {
         Ok(self.pool.get()?)
     }
 

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -6,9 +6,7 @@ use diesel::{
     sql_types,
 };
 use mc_common::logger::{global_log, Logger};
-use std::{env, time::Duration};
-use std::thread::sleep;
-
+use std::{env, thread::sleep, time::Duration};
 
 pub type Conn = PooledConnection<ConnectionManager<SqliteConnection>>;
 
@@ -145,7 +143,6 @@ impl WalletDb {
     }
 }
 
-
 /// Create an immediate SQLite transaction with retry.
 pub fn transaction<T, E, F>(conn: &Conn, f: F) -> Result<T, E>
 where
@@ -164,12 +161,9 @@ where
 const BASE_DELAY_MS: u32 = 10;
 const NUM_RETRIES: u32 = 5;
 
-
 /// Escape a string for consumption by SQLite.
 /// This function doubles all single quote characters within the string, then
 /// wraps the string in single quotes on the front and back.
 fn sql_escape_string(s: &str) -> String {
     format!("'{}'", s.replace("'", "''"))
 }
-
-

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -1,10 +1,9 @@
 use crate::db::WalletDbError;
 use diesel::{
     connection::SimpleConnection,
-    SqliteConnection,
     prelude::*,
     r2d2::{ConnectionManager, Pool, PooledConnection},
-    sql_types,
+    sql_types, SqliteConnection,
 };
 use diesel_migrations::embed_migrations;
 use mc_common::logger::{global_log, Logger};

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -163,6 +163,7 @@ impl WalletDb {
 }
 
 /// Create an immediate SQLite transaction with retry.
+/// Note: This function does not support nested transactions.
 pub fn transaction<T, E, F>(conn: &Conn, f: F) -> Result<T, E>
 where
     F: Clone + FnOnce() -> Result<T, E>,

--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -76,9 +76,7 @@ impl WalletDb {
         Ok(Self::new(pool, logger))
     }
 
-    pub fn get_conn(
-        &self,
-    ) -> Result<Conn, WalletDbError> {
+    pub fn get_conn(&self) -> Result<Conn, WalletDbError> {
         Ok(self.pool.get()?)
     }
 

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -250,19 +250,17 @@ where
         let import_block = self.ledger_db.num_blocks()? - 1;
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(Account::import(
-                &mnemonic,
-                name,
-                import_block,
-                first_block_index,
-                next_subaddress_index,
-                fog_report_url,
-                fog_report_id,
-                fog_authority_spki,
-                &conn,
-            )?)
-        })
+        Ok(Account::import(
+            &mnemonic,
+            name,
+            import_block,
+            first_block_index,
+            next_subaddress_index,
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+            &conn,
+        )?)
     }
 
     fn import_account_from_legacy_root_entropy(
@@ -290,29 +288,27 @@ where
         let import_block = self.ledger_db.num_blocks()? - 1;
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(Account::import_legacy(
-                &RootEntropy::from(&entropy_bytes),
-                name,
-                import_block,
-                first_block_index,
-                next_subaddress_index,
-                fog_report_url,
-                fog_report_id,
-                fog_authority_spki,
-                &conn,
-            )?)
-        })
+        Ok(Account::import_legacy(
+            &RootEntropy::from(&entropy_bytes),
+            name,
+            import_block,
+            first_block_index,
+            next_subaddress_index,
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+            &conn,
+        )?)
     }
 
     fn list_accounts(&self) -> Result<Vec<Account>, AccountServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| Ok(Account::list_all(&conn)?))
+        Ok(Account::list_all(&conn)?)
     }
 
     fn get_account(&self, account_id: &AccountID) -> Result<Account, AccountServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| Ok(Account::get(account_id, &conn)?))
+        Ok(Account::get(account_id, &conn)?)
     }
 
     fn update_account_name(
@@ -321,10 +317,8 @@ where
         name: String,
     ) -> Result<Account, AccountServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Account::get(account_id, &conn)?.update_name(name, &conn)?;
-            Ok(Account::get(account_id, &conn)?)
-        })
+        Account::get(account_id, &conn)?.update_name(name, &conn)?;
+        Ok(Account::get(account_id, &conn)?)
     }
 
     fn remove_account(&self, account_id: &AccountID) -> Result<bool, AccountServiceError> {

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use base64;
 use bip39::{Language, Mnemonic, MnemonicType};
-use diesel::Connection;
 use displaydoc::Display;
 use mc_account_keys::RootEntropy;
 use mc_account_keys_slip10;

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -196,22 +196,19 @@ where
         let import_block_index = local_block_height; // -1 +1
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let (account_id, _public_address_b58) = Account::create_from_mnemonic(
-                &mnemonic,
-                Some(first_block_index),
-                Some(import_block_index),
-                None,
-                &name.unwrap_or_else(|| "".to_string()),
-                fog_report_url,
-                fog_report_id,
-                fog_authority_spki,
-                &conn,
-            )?;
-
-            let account = Account::get(&account_id, &conn)?;
-            Ok(account)
-        })
+        let (account_id, _public_address_b58) = Account::create_from_mnemonic(
+            &mnemonic,
+            Some(first_block_index),
+            Some(import_block_index),
+            None,
+            &name.unwrap_or_else(|| "".to_string()),
+            fog_report_url,
+            fog_report_id,
+            fog_authority_spki,
+            &conn,
+        )?;
+        let account = Account::get(&account_id, &conn)?;
+        Ok(account)
     }
 
     fn import_account(
@@ -332,14 +329,10 @@ where
 
     fn remove_account(&self, account_id: &AccountID) -> Result<bool, AccountServiceError> {
         log::info!(self.logger, "Deleting account {}", account_id,);
-
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let account = Account::get(account_id, &conn)?;
-            account.delete(&conn)?;
-
-            Ok(true)
-        })
+        let account = Account::get(account_id, &conn)?;
+        account.delete(&conn)?;
+        Ok(true)
     }
 }
 

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -6,7 +6,7 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         models::Account,
-        WalletDbError,
+        transaction, WalletDbError,
     },
     service::{
         ledger::{LedgerService, LedgerServiceError},
@@ -195,19 +195,21 @@ where
         let import_block_index = local_block_height; // -1 +1
 
         let conn = self.wallet_db.get_conn()?;
-        let (account_id, _public_address_b58) = Account::create_from_mnemonic(
-            &mnemonic,
-            Some(first_block_index),
-            Some(import_block_index),
-            None,
-            &name.unwrap_or_else(|| "".to_string()),
-            fog_report_url,
-            fog_report_id,
-            fog_authority_spki,
-            &conn,
-        )?;
-        let account = Account::get(&account_id, &conn)?;
-        Ok(account)
+        transaction(&conn, || {
+            let (account_id, _public_address_b58) = Account::create_from_mnemonic(
+                &mnemonic,
+                Some(first_block_index),
+                Some(import_block_index),
+                None,
+                &name.unwrap_or_else(|| "".to_string()),
+                fog_report_url,
+                fog_report_id,
+                fog_authority_spki,
+                &conn,
+            )?;
+            let account = Account::get(&account_id, &conn)?;
+            Ok(account)
+        })
     }
 
     fn import_account(
@@ -249,17 +251,19 @@ where
         let import_block = self.ledger_db.num_blocks()? - 1;
 
         let conn = self.wallet_db.get_conn()?;
-        Ok(Account::import(
-            &mnemonic,
-            name,
-            import_block,
-            first_block_index,
-            next_subaddress_index,
-            fog_report_url,
-            fog_report_id,
-            fog_authority_spki,
-            &conn,
-        )?)
+        transaction(&conn, || {
+            Ok(Account::import(
+                &mnemonic,
+                name,
+                import_block,
+                first_block_index,
+                next_subaddress_index,
+                fog_report_url,
+                fog_report_id,
+                fog_authority_spki,
+                &conn,
+            )?)
+        })
     }
 
     fn import_account_from_legacy_root_entropy(
@@ -287,17 +291,19 @@ where
         let import_block = self.ledger_db.num_blocks()? - 1;
 
         let conn = self.wallet_db.get_conn()?;
-        Ok(Account::import_legacy(
-            &RootEntropy::from(&entropy_bytes),
-            name,
-            import_block,
-            first_block_index,
-            next_subaddress_index,
-            fog_report_url,
-            fog_report_id,
-            fog_authority_spki,
-            &conn,
-        )?)
+        transaction(&conn, || {
+            Ok(Account::import_legacy(
+                &RootEntropy::from(&entropy_bytes),
+                name,
+                import_block,
+                first_block_index,
+                next_subaddress_index,
+                fog_report_url,
+                fog_report_id,
+                fog_authority_spki,
+                &conn,
+            )?)
+        })
     }
 
     fn list_accounts(&self) -> Result<Vec<Account>, AccountServiceError> {
@@ -323,9 +329,11 @@ where
     fn remove_account(&self, account_id: &AccountID) -> Result<bool, AccountServiceError> {
         log::info!(self.logger, "Deleting account {}", account_id,);
         let conn = self.wallet_db.get_conn()?;
-        let account = Account::get(account_id, &conn)?;
-        account.delete(&conn)?;
-        Ok(true)
+        transaction(&conn, || {
+            let account = Account::get(account_id, &conn)?;
+            account.delete(&conn)?;
+            Ok(true)
+        })
     }
 }
 

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -80,17 +80,14 @@ where
         metadata: Option<&str>,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
         let conn = &self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let (public_address_b58, _subaddress_index) =
-                AssignedSubaddress::create_next_for_account(
-                    &account_id.to_string(),
-                    metadata.unwrap_or(""),
-                    &self.ledger_db,
-                    conn,
-                )?;
-
-            Ok(AssignedSubaddress::get(&public_address_b58, conn)?)
-        })
+        let (public_address_b58, _subaddress_index) =
+            AssignedSubaddress::create_next_for_account(
+                &account_id.to_string(),
+                metadata.unwrap_or(""),
+                &self.ledger_db,
+                conn,
+            )?;
+        Ok(AssignedSubaddress::get(&public_address_b58, conn)?)
     }
 
     fn get_addresses_for_account(

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -80,13 +80,12 @@ where
         metadata: Option<&str>,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
         let conn = &self.wallet_db.get_conn()?;
-        let (public_address_b58, _subaddress_index) =
-            AssignedSubaddress::create_next_for_account(
-                &account_id.to_string(),
-                metadata.unwrap_or(""),
-                &self.ledger_db,
-                conn,
-            )?;
+        let (public_address_b58, _subaddress_index) = AssignedSubaddress::create_next_for_account(
+            &account_id.to_string(),
+            metadata.unwrap_or(""),
+            &self.ledger_db,
+            conn,
+        )?;
         Ok(AssignedSubaddress::get(&public_address_b58, conn)?)
     }
 

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -5,7 +5,7 @@
 use crate::{
     db::{
         account::AccountID, assigned_subaddress::AssignedSubaddressModel,
-        models::AssignedSubaddress, WalletDbError,
+        models::AssignedSubaddress, transaction, WalletDbError,
     },
     service::WalletService,
     util::b58::b58_decode_public_address,
@@ -14,7 +14,6 @@ use mc_common::logger::log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 
-use diesel::Connection;
 use displaydoc::Display;
 
 /// Errors for the Address Service.
@@ -79,14 +78,17 @@ where
         account_id: &AccountID,
         metadata: Option<&str>,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
-        let (public_address_b58, _subaddress_index) = AssignedSubaddress::create_next_for_account(
-            &account_id.to_string(),
-            metadata.unwrap_or(""),
-            &self.ledger_db,
-            conn,
-        )?;
-        Ok(AssignedSubaddress::get(&public_address_b58, conn)?)
+        let conn = self.wallet_db.get_conn()?;
+        transaction(&conn, || {
+            let (public_address_b58, _subaddress_index) =
+                AssignedSubaddress::create_next_for_account(
+                    &account_id.to_string(),
+                    metadata.unwrap_or(""),
+                    &self.ledger_db,
+                    &conn,
+                )?;
+            Ok(AssignedSubaddress::get(&public_address_b58, &conn)?)
+        })
     }
 
     fn get_addresses_for_account(
@@ -96,14 +98,12 @@ where
         limit: Option<i64>,
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(AssignedSubaddress::list_all(
-                &account_id.to_string(),
-                offset,
-                limit,
-                &conn,
-            )?)
-        })
+        Ok(AssignedSubaddress::list_all(
+            &account_id.to_string(),
+            offset,
+            limit,
+            &conn,
+        )?)
     }
 
     fn get_address_for_account(
@@ -112,13 +112,11 @@ where
         index: i64,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(AssignedSubaddress::get_for_account_by_index(
-                &account_id.to_string(),
-                index,
-                &conn,
-            )?)
-        })
+        Ok(AssignedSubaddress::get_for_account_by_index(
+            &account_id.to_string(),
+            index,
+            &conn,
+        )?)
     }
 
     fn verify_address(&self, public_address: &str) -> Result<bool, AddressServiceError> {

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -17,8 +17,6 @@ use crate::{
         WalletService,
     },
 };
-
-use diesel::Connection;
 use displaydoc::Display;
 use mc_common::HashMap;
 use mc_connection::{BlockchainConnection, UserTxConnection};
@@ -157,24 +155,22 @@ where
         let account_id_hex = &account_id.to_string();
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let (unspent, pending, spent, secreted, orphaned) =
-                Self::get_balance_inner(account_id_hex, &conn)?;
+        let (unspent, pending, spent, secreted, orphaned) =
+            Self::get_balance_inner(account_id_hex, &conn)?;
 
-            let network_block_height = self.get_network_block_height()?;
-            let local_block_height = self.ledger_db.num_blocks()?;
-            let account = Account::get(account_id, &conn)?;
+        let network_block_height = self.get_network_block_height()?;
+        let local_block_height = self.ledger_db.num_blocks()?;
+        let account = Account::get(account_id, &conn)?;
 
-            Ok(Balance {
-                unspent,
-                pending,
-                spent,
-                secreted,
-                orphaned,
-                network_block_height,
-                local_block_height,
-                synced_blocks: account.next_block_index as u64,
-            })
+        Ok(Balance {
+            unspent,
+            pending,
+            spent,
+            secreted,
+            orphaned,
+            network_block_height,
+            local_block_height,
+            synced_blocks: account.next_block_index as u64,
         })
     }
 
@@ -183,25 +179,23 @@ where
         account_id: &str,
     ) -> Result<ViewOnlyBalance, BalanceServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let txos = ViewOnlyTxo::list_for_account(account_id, None, None, &conn)?;
-            let total_value = txos.iter().map(|t| (t.value as u64) as u128).sum::<u128>();
-            let spent = txos
-                .iter()
-                .filter(|t| t.spent)
-                .map(|t| (t.value as u64) as u128)
-                .sum::<u128>();
+        let txos = ViewOnlyTxo::list_for_account(account_id, None, None, &conn)?;
+        let total_value = txos.iter().map(|t| (t.value as u64) as u128).sum::<u128>();
+        let spent = txos
+            .iter()
+            .filter(|t| t.spent)
+            .map(|t| (t.value as u64) as u128)
+            .sum::<u128>();
 
-            let network_block_height = self.get_network_block_height()?;
-            let local_block_height = self.ledger_db.num_blocks()?;
-            let account = ViewOnlyAccount::get(account_id, &conn)?;
+        let network_block_height = self.get_network_block_height()?;
+        let local_block_height = self.ledger_db.num_blocks()?;
+        let account = ViewOnlyAccount::get(account_id, &conn)?;
 
-            Ok(ViewOnlyBalance {
-                balance: total_value - spent,
-                network_block_height,
-                local_block_height,
-                synced_blocks: account.next_block_index as u64,
-            })
+        Ok(ViewOnlyBalance {
+            balance: total_value - spent,
+            network_block_height,
+            local_block_height,
+            synced_blocks: account.next_block_index as u64,
         })
     }
 
@@ -210,44 +204,40 @@ where
         let local_block_height = self.ledger_db.num_blocks()?;
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let assigned_address = AssignedSubaddress::get(address, &conn)?;
+        let assigned_address = AssignedSubaddress::get(address, &conn)?;
 
-            // Orphaned txos have no subaddress assigned, so none of these txos can
-            // be orphaned.
-            let orphaned: u128 = 0;
+        // Orphaned txos have no subaddress assigned, so none of these txos can
+        // be orphaned.
+        let orphaned: u128 = 0;
 
-            let unspent =
-                Txo::list_unspent(&assigned_address.account_id_hex, Some(address), &conn)?
-                    .iter()
-                    .map(|txo| (txo.value as u64) as u128)
-                    .sum::<u128>();
-            let pending =
-                Txo::list_pending(&assigned_address.account_id_hex, Some(address), &conn)?
-                    .iter()
-                    .map(|txo| (txo.value as u64) as u128)
-                    .sum::<u128>();
-            let spent = Txo::list_spent(&assigned_address.account_id_hex, Some(address), &conn)?
-                .iter()
-                .map(|txo| (txo.value as u64) as u128)
-                .sum::<u128>();
-            let secreted = Txo::list_secreted(&assigned_address.account_id_hex, &conn)?
-                .iter()
-                .map(|txo| (txo.value as u64) as u128)
-                .sum::<u128>();
+        let unspent = Txo::list_unspent(&assigned_address.account_id_hex, Some(address), &conn)?
+            .iter()
+            .map(|txo| (txo.value as u64) as u128)
+            .sum::<u128>();
+        let pending = Txo::list_pending(&assigned_address.account_id_hex, Some(address), &conn)?
+            .iter()
+            .map(|txo| (txo.value as u64) as u128)
+            .sum::<u128>();
+        let spent = Txo::list_spent(&assigned_address.account_id_hex, Some(address), &conn)?
+            .iter()
+            .map(|txo| (txo.value as u64) as u128)
+            .sum::<u128>();
+        let secreted = Txo::list_secreted(&assigned_address.account_id_hex, &conn)?
+            .iter()
+            .map(|txo| (txo.value as u64) as u128)
+            .sum::<u128>();
 
-            let account = Account::get(&AccountID(assigned_address.account_id_hex), &conn)?;
+        let account = Account::get(&AccountID(assigned_address.account_id_hex), &conn)?;
 
-            Ok(Balance {
-                unspent,
-                pending,
-                spent,
-                secreted,
-                orphaned,
-                network_block_height,
-                local_block_height,
-                synced_blocks: account.next_block_index as u64,
-            })
+        Ok(Balance {
+            unspent,
+            pending,
+            spent,
+            secreted,
+            orphaned,
+            network_block_height,
+            local_block_height,
+            synced_blocks: account.next_block_index as u64,
         })
     }
 
@@ -264,59 +254,57 @@ where
         let network_block_height = self.get_network_block_height()?;
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let accounts = Account::list_all(&conn)?;
-            let mut account_map = HashMap::default();
-            let view_only_accounts = ViewOnlyAccount::list_all(&conn)?;
-            let mut view_only_account_map = HashMap::default();
+        let accounts = Account::list_all(&conn)?;
+        let mut account_map = HashMap::default();
+        let view_only_accounts = ViewOnlyAccount::list_all(&conn)?;
+        let mut view_only_account_map = HashMap::default();
 
-            let mut unspent: u128 = 0;
-            let mut pending: u128 = 0;
-            let mut spent: u128 = 0;
-            let mut secreted: u128 = 0;
-            let mut orphaned: u128 = 0;
+        let mut unspent: u128 = 0;
+        let mut pending: u128 = 0;
+        let mut spent: u128 = 0;
+        let mut secreted: u128 = 0;
+        let mut orphaned: u128 = 0;
 
-            let mut min_synced_block_index = network_block_height - 1;
-            let mut account_ids = Vec::new();
-            for account in accounts {
-                let account_id = AccountID(account.account_id_hex.clone());
-                let balance = Self::get_balance_inner(&account_id.to_string(), &conn)?;
-                account_map.insert(account_id.clone(), account.clone());
-                unspent += balance.0;
-                pending += balance.1;
-                spent += balance.2;
-                secreted += balance.3;
-                orphaned += balance.4;
+        let mut min_synced_block_index = network_block_height - 1;
+        let mut account_ids = Vec::new();
+        for account in accounts {
+            let account_id = AccountID(account.account_id_hex.clone());
+            let balance = Self::get_balance_inner(&account_id.to_string(), &conn)?;
+            account_map.insert(account_id.clone(), account.clone());
+            unspent += balance.0;
+            pending += balance.1;
+            spent += balance.2;
+            secreted += balance.3;
+            orphaned += balance.4;
 
-                // account.next_block_index is an index in range [0..ledger_db.num_blocks()]
-                min_synced_block_index = std::cmp::min(
-                    min_synced_block_index,
-                    (account.next_block_index as u64).saturating_sub(1),
-                );
-                account_ids.push(account_id);
-            }
+            // account.next_block_index is an index in range [0..ledger_db.num_blocks()]
+            min_synced_block_index = std::cmp::min(
+                min_synced_block_index,
+                (account.next_block_index as u64).saturating_sub(1),
+            );
+            account_ids.push(account_id);
+        }
 
-            let mut view_only_account_ids = Vec::new();
-            for account in view_only_accounts {
-                let account_id = account.account_id_hex.clone();
-                view_only_account_map.insert(account_id.clone(), account.clone());
-                view_only_account_ids.push(account_id);
-            }
+        let mut view_only_account_ids = Vec::new();
+        for account in view_only_accounts {
+            let account_id = account.account_id_hex.clone();
+            view_only_account_map.insert(account_id.clone(), account.clone());
+            view_only_account_ids.push(account_id);
+        }
 
-            Ok(WalletStatus {
-                unspent,
-                pending,
-                spent,
-                secreted,
-                orphaned,
-                network_block_height,
-                local_block_height: self.ledger_db.num_blocks()?,
-                min_synced_block_index: min_synced_block_index as u64,
-                account_ids,
-                account_map,
-                view_only_account_ids,
-                view_only_account_map,
-            })
+        Ok(WalletStatus {
+            unspent,
+            pending,
+            spent,
+            secreted,
+            orphaned,
+            network_block_height,
+            local_block_height: self.ledger_db.num_blocks()?,
+            min_synced_block_index: min_synced_block_index as u64,
+            account_ids,
+            account_map,
+            view_only_account_ids,
+            view_only_account_map,
         })
     }
 }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -6,12 +6,11 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
-        Conn,
         models::{Account, AssignedSubaddress, Txo, ViewOnlyAccount, ViewOnlyTxo},
         txo::TxoModel,
         view_only_account::ViewOnlyAccountModel,
         view_only_txo::ViewOnlyTxoModel,
-        WalletDbError,
+        Conn, WalletDbError,
     },
     service::{
         ledger::{LedgerService, LedgerServiceError},

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -6,6 +6,7 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
+        Conn,
         models::{Account, AssignedSubaddress, Txo, ViewOnlyAccount, ViewOnlyTxo},
         txo::TxoModel,
         view_only_account::ViewOnlyAccountModel,
@@ -18,11 +19,7 @@ use crate::{
     },
 };
 
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-    Connection,
-};
+use diesel::Connection;
 use displaydoc::Display;
 use mc_common::HashMap;
 use mc_connection::{BlockchainConnection, UserTxConnection};
@@ -332,7 +329,7 @@ where
 {
     fn get_balance_inner(
         account_id_hex: &str,
-        conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+        conn: &Conn,
     ) -> Result<(u128, u128, u128, u128, u128), BalanceServiceError> {
         // Note: We need to cast to u64 first, because i64 could have wrapped, then to
         // u128

--- a/full-service/src/service/confirmation_number.rs
+++ b/full-service/src/service/confirmation_number.rs
@@ -22,8 +22,6 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::tx::TxOutConfirmationNumber;
 
-use diesel::Connection;
-
 /// Errors for the Txo Service.
 #[derive(Display, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -159,15 +157,13 @@ where
         confirmation_hex: &str,
     ) -> Result<bool, ConfirmationServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let confirmation: TxOutConfirmationNumber =
-                mc_util_serial::decode(&hex::decode(confirmation_hex)?)?;
-            Ok(Txo::validate_confirmation(
-                &AccountID(account_id.to_string()),
-                &txo_id.to_string(),
-                &confirmation,
-                &conn,
-            )?)
-        })
+        let confirmation: TxOutConfirmationNumber =
+            mc_util_serial::decode(&hex::decode(confirmation_hex)?)?;
+        Ok(Txo::validate_confirmation(
+            &AccountID(account_id.to_string()),
+            &txo_id.to_string(),
+            &confirmation,
+            &conn,
+        )?)
     }
 }

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -6,6 +6,7 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
+        Conn,
         models::{
             Account, AssignedSubaddress, TransactionLog, Txo, ViewOnlyAccount,
             ViewOnlyTransactionLog, ViewOnlyTxo,
@@ -36,10 +37,7 @@ use mc_transaction_core::{
 };
 use rayon::prelude::*;
 
-use diesel::{
-    prelude::*,
-    r2d2::{ConnectionManager, PooledConnection},
-};
+use diesel::prelude::*;
 use std::{
     convert::TryFrom,
     sync::{
@@ -179,7 +177,7 @@ pub fn sync_view_only_account(
 
 fn sync_view_only_account_next_chunk(
     ledger_db: &LedgerDB,
-    conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    conn: &Conn,
     logger: &Logger,
     account_id_hex: &str,
 ) -> Result<SyncStatus, SyncError> {
@@ -290,7 +288,7 @@ pub fn sync_account(
 
 fn sync_account_next_chunk(
     ledger_db: &LedgerDB,
-    conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
+    conn: &Conn,
     logger: &Logger,
     account_id_hex: &str,
 ) -> Result<SyncStatus, SyncError> {

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -10,6 +10,7 @@ use crate::{
             Account, AssignedSubaddress, TransactionLog, Txo, ViewOnlyAccount,
             ViewOnlyTransactionLog, ViewOnlyTxo,
         },
+        transaction,
         transaction_log::TransactionLogModel,
         txo::TxoModel,
         view_only_account::ViewOnlyAccountModel,
@@ -36,7 +37,6 @@ use mc_transaction_core::{
 };
 use rayon::prelude::*;
 
-use diesel::prelude::*;
 use std::{
     convert::TryFrom,
     sync::{
@@ -47,7 +47,7 @@ use std::{
     time::Instant,
 };
 
-const BLOCKS_CHUNK_SIZE: u64 = 10_000;
+const BLOCKS_CHUNK_SIZE: u64 = 1_000;
 
 /// Sync thread - holds objects needed to cleanly terminate the sync thread.
 pub struct SyncThread {
@@ -180,7 +180,7 @@ fn sync_view_only_account_next_chunk(
     logger: &Logger,
     account_id_hex: &str,
 ) -> Result<SyncStatus, SyncError> {
-    conn.transaction::<SyncStatus, SyncError, _>(|| {
+    transaction(conn, || {
         // Get the account data. If it is no longer available, the account has been
         // removed and we can simply return.
         let view_only_account = ViewOnlyAccount::get(account_id_hex, conn)?;
@@ -291,7 +291,7 @@ fn sync_account_next_chunk(
     logger: &Logger,
     account_id_hex: &str,
 ) -> Result<SyncStatus, SyncError> {
-    conn.transaction::<SyncStatus, SyncError, _>(|| {
+    transaction(conn, || {
         // Get the account data. If it is no longer available, the account has been
         // removed and we can simply return.
         let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -6,7 +6,6 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
-        Conn,
         models::{
             Account, AssignedSubaddress, TransactionLog, Txo, ViewOnlyAccount,
             ViewOnlyTransactionLog, ViewOnlyTxo,
@@ -16,7 +15,7 @@ use crate::{
         view_only_account::ViewOnlyAccountModel,
         view_only_transaction_log::ViewOnlyTransactionLogModel,
         view_only_txo::ViewOnlyTxoModel,
-        WalletDb,
+        Conn, WalletDb,
     },
     error::SyncError,
     util::b58::b58_encode_public_address,

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -26,8 +26,6 @@ use crate::service::address::{AddressService, AddressServiceError};
 use displaydoc::Display;
 use std::{convert::TryFrom, iter::empty, sync::atomic::Ordering};
 
-use diesel::Connection;
-
 /// Errors for the Transaction Service.
 #[derive(Display, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -282,7 +280,7 @@ where
         // Log the transaction.
         let result = if let Some(a) = account_id_hex {
             let conn = self.wallet_db.get_conn()?;
-            conn.transaction(|| {
+            transaction(&conn, || {
                 let transaction_log = TransactionLog::log_submitted(
                     tx_proposal,
                     block_index,

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -224,7 +224,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
         }
 
         let conn = self.wallet_db.get_conn()?;
-
         conn.transaction::<TxProposal, WalletTransactionBuilderError, _>(|| {
             let account: Account =
                 Account::get(&AccountID(self.account_id_hex.to_string()), &conn)?;

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -12,9 +12,8 @@ use crate::{
     db::{
         account::{AccountID, AccountModel},
         models::{Account, Txo},
-        transaction,
         txo::TxoModel,
-        WalletDb,
+        Conn,
     },
     error::WalletTransactionBuilderError,
 };
@@ -41,7 +40,6 @@ use mc_transaction_core::{
 use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_uri::FogUri;
 
-use diesel::prelude::*;
 use rand::Rng;
 use std::{convert::TryFrom, str::FromStr, sync::Arc};
 
@@ -54,9 +52,6 @@ pub const DEFAULT_NEW_TX_BLOCK_ATTEMPTS: u64 = 10;
 pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {
     /// Account ID (hex-encoded) from which to construct a transaction.
     account_id_hex: String,
-
-    /// The wallet DB.
-    wallet_db: WalletDb,
 
     /// The ledger DB.
     ledger_db: LedgerDB,
@@ -86,14 +81,12 @@ pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {
 impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
     pub fn new(
         account_id_hex: String,
-        wallet_db: WalletDb,
         ledger_db: LedgerDB,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync + 'static>,
         logger: Logger,
     ) -> Self {
         WalletTransactionBuilder {
             account_id_hex,
-            wallet_db,
             ledger_db,
             inputs: vec![],
             outlays: vec![],
@@ -108,6 +101,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
     /// txos are included.
     pub fn set_txos(
         &mut self,
+        conn: &Conn,
         input_txo_ids: &[String],
         update_to_pending: bool,
     ) -> Result<(), WalletTransactionBuilderError> {
@@ -117,11 +111,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             None
         };
 
-        let txos = Txo::select_by_id(
-            &input_txo_ids.to_vec(),
-            pending_tombstone_block_index,
-            &self.wallet_db.get_conn()?,
-        )?;
+        let txos = Txo::select_by_id(&input_txo_ids.to_vec(), pending_tombstone_block_index, conn)?;
 
         let unspent: Vec<Txo> = txos
             .iter()
@@ -143,6 +133,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
     /// Selects Txos from the account.
     pub fn select_txos(
         &mut self,
+        conn: &Conn,
         max_spendable_value: Option<u64>,
         update_to_pending: bool,
     ) -> Result<(), WalletTransactionBuilderError> {
@@ -167,17 +158,13 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             None
         };
 
-        let conn = self.wallet_db.get_conn()?;
-
-        self.inputs = transaction(&conn, || {
-            Txo::select_unspent_txos_for_value(
-                &self.account_id_hex,
-                total_value,
-                max_spendable_value,
-                pending_tombstone_block_index,
-                &conn,
-            )
-        })?;
+        self.inputs = Txo::select_unspent_txos_for_value(
+            &self.account_id_hex,
+            total_value,
+            max_spendable_value,
+            pending_tombstone_block_index,
+            conn,
+        )?;
 
         Ok(())
     }
@@ -219,7 +206,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
     }
 
     /// Consumes self
-    pub fn build(&self) -> Result<TxProposal, WalletTransactionBuilderError> {
+    pub fn build(&self, conn: &Conn) -> Result<TxProposal, WalletTransactionBuilderError> {
         if self.inputs.is_empty() {
             return Err(WalletTransactionBuilderError::NoInputs);
         }
@@ -228,265 +215,261 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             return Err(WalletTransactionBuilderError::TombstoneNotSet);
         }
 
-        let conn = self.wallet_db.get_conn()?;
+        let account: Account = Account::get(&AccountID(self.account_id_hex.to_string()), conn)?;
+        let from_account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
 
-        conn.transaction::<TxProposal, WalletTransactionBuilderError, _>(|| {
-            let account: Account =
-                Account::get(&AccountID(self.account_id_hex.to_string()), &conn)?;
-            let from_account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-
-            // Collect all required FogUris from public addresses, then pass to resolver
-            // factory
-            let fog_resolver = {
-                let change_address =
-                    from_account_key.subaddress(account.change_subaddress_index as u64);
-                let fog_uris = core::slice::from_ref(&change_address)
-                    .iter()
-                    .chain(self.outlays.iter().map(|(receiver, _amount)| receiver))
-                    .filter_map(|x| extract_fog_uri(x).transpose())
-                    .collect::<Result<Vec<_>, _>>()?;
-                (self.fog_resolver_factory)(&fog_uris)
-                    .map_err(WalletTransactionBuilderError::FogPubkeyResolver)?
-            };
-
-            // Create transaction builder.
-            // TODO: After servers that support memos are deployed, use RTHMemoBuilder here
-            let memo_builder = NoMemoBuilder::default();
-            let mut transaction_builder = TransactionBuilder::new(fog_resolver, memo_builder);
-            transaction_builder.set_fee(self.fee.unwrap_or(Mob::MINIMUM_FEE))?;
-
-            // Get membership proofs for our inputs
-            let indexes = self
-                .inputs
+        // Collect all required FogUris from public addresses, then pass to resolver
+        // factory
+        let fog_resolver = {
+            let change_address =
+                from_account_key.subaddress(account.change_subaddress_index as u64);
+            let fog_uris = core::slice::from_ref(&change_address)
                 .iter()
-                .map(|utxo| {
-                    let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
-                    self.ledger_db.get_tx_out_index_by_hash(&txo.hash())
-                })
-                .collect::<Result<Vec<u64>, mc_ledger_db::Error>>()?;
-            let proofs = self.ledger_db.get_tx_out_proof_of_memberships(&indexes)?;
+                .chain(self.outlays.iter().map(|(receiver, _amount)| receiver))
+                .filter_map(|x| extract_fog_uri(x).transpose())
+                .collect::<Result<Vec<_>, _>>()?;
+            (self.fog_resolver_factory)(&fog_uris)
+                .map_err(WalletTransactionBuilderError::FogPubkeyResolver)?
+        };
 
-            let inputs_and_proofs: Vec<(Txo, TxOutMembershipProof)> = self
-                .inputs
-                .clone()
-                .into_iter()
-                .zip(proofs.into_iter())
-                .collect();
+        // Create transaction builder.
+        // TODO: After servers that support memos are deployed, use RTHMemoBuilder here
+        let memo_builder = NoMemoBuilder::default();
+        let mut transaction_builder = TransactionBuilder::new(fog_resolver, memo_builder);
+        transaction_builder.set_fee(self.fee.unwrap_or(Mob::MINIMUM_FEE))?;
 
-            let excluded_tx_out_indices: Vec<u64> = inputs_and_proofs
-                .iter()
-                .map(|(utxo, _membership_proof)| {
-                    let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
-                    self.ledger_db
-                        .get_tx_out_index_by_hash(&txo.hash())
-                        .map_err(WalletTransactionBuilderError::LedgerDB)
-                })
-                .collect::<Result<Vec<u64>, WalletTransactionBuilderError>>()?;
+        // Get membership proofs for our inputs
+        let indexes = self
+            .inputs
+            .iter()
+            .map(|utxo| {
+                let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
+                self.ledger_db.get_tx_out_index_by_hash(&txo.hash())
+            })
+            .collect::<Result<Vec<u64>, mc_ledger_db::Error>>()?;
+        let proofs = self.ledger_db.get_tx_out_proof_of_memberships(&indexes)?;
 
-            let rings = self.get_rings(inputs_and_proofs.len(), &excluded_tx_out_indices)?;
+        let inputs_and_proofs: Vec<(Txo, TxOutMembershipProof)> = self
+            .inputs
+            .clone()
+            .into_iter()
+            .zip(proofs.into_iter())
+            .collect();
 
-            if rings.len() != inputs_and_proofs.len() {
+        let excluded_tx_out_indices: Vec<u64> = inputs_and_proofs
+            .iter()
+            .map(|(utxo, _membership_proof)| {
+                let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
+                self.ledger_db
+                    .get_tx_out_index_by_hash(&txo.hash())
+                    .map_err(WalletTransactionBuilderError::LedgerDB)
+            })
+            .collect::<Result<Vec<u64>, WalletTransactionBuilderError>>()?;
+
+        let rings = self.get_rings(inputs_and_proofs.len(), &excluded_tx_out_indices)?;
+
+        if rings.len() != inputs_and_proofs.len() {
+            return Err(WalletTransactionBuilderError::RingSizeMismatch);
+        }
+
+        if self.outlays.is_empty() {
+            return Err(WalletTransactionBuilderError::NoRecipient);
+        }
+
+        // Unzip each vec of tuples into a tuple of vecs.
+        let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings
+            .into_iter()
+            .map(|tuples| tuples.into_iter().unzip())
+            .collect();
+
+        // Add inputs to the tx.
+        for (utxo, proof) in inputs_and_proofs.iter() {
+            let db_tx_out: TxOut = mc_util_serial::decode(&utxo.txo)?;
+            let (mut ring, mut membership_proofs) = rings_and_proofs
+                .pop()
+                .ok_or(WalletTransactionBuilderError::RingsAndProofsEmpty)?;
+            if ring.len() != membership_proofs.len() {
                 return Err(WalletTransactionBuilderError::RingSizeMismatch);
             }
 
-            if self.outlays.is_empty() {
-                return Err(WalletTransactionBuilderError::NoRecipient);
-            }
-
-            // Unzip each vec of tuples into a tuple of vecs.
-            let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings
-                .into_iter()
-                .map(|tuples| tuples.into_iter().unzip())
-                .collect();
-
-            // Add inputs to the tx.
-            for (utxo, proof) in inputs_and_proofs.iter() {
-                let db_tx_out: TxOut = mc_util_serial::decode(&utxo.txo)?;
-                let (mut ring, mut membership_proofs) = rings_and_proofs
-                    .pop()
-                    .ok_or(WalletTransactionBuilderError::RingsAndProofsEmpty)?;
-                if ring.len() != membership_proofs.len() {
-                    return Err(WalletTransactionBuilderError::RingSizeMismatch);
+            // Add the input to the ring.
+            let position_opt = ring.iter().position(|txo| *txo == db_tx_out);
+            let real_key_index = match position_opt {
+                Some(position) => {
+                    // The input is already present in the ring.
+                    // This could happen if ring elements are sampled randomly from the
+                    // ledger.
+                    position
                 }
-
-                // Add the input to the ring.
-                let position_opt = ring.iter().position(|txo| *txo == db_tx_out);
-                let real_key_index = match position_opt {
-                    Some(position) => {
-                        // The input is already present in the ring.
-                        // This could happen if ring elements are sampled randomly from the
-                        // ledger.
-                        position
+                None => {
+                    // The input is not already in the ring.
+                    if ring.is_empty() {
+                        // Append the input and its proof of membership.
+                        ring.push(db_tx_out.clone());
+                        membership_proofs.push(proof.clone());
+                    } else {
+                        // Replace the first element of the ring.
+                        ring[0] = db_tx_out.clone();
+                        membership_proofs[0] = proof.clone();
                     }
-                    None => {
-                        // The input is not already in the ring.
-                        if ring.is_empty() {
-                            // Append the input and its proof of membership.
-                            ring.push(db_tx_out.clone());
-                            membership_proofs.push(proof.clone());
-                        } else {
-                            // Replace the first element of the ring.
-                            ring[0] = db_tx_out.clone();
-                            membership_proofs[0] = proof.clone();
-                        }
-                        // The real input is always the first element. This is safe because
-                        // TransactionBuilder sorts each ring.
-                        0
-                    }
-                };
-
-                if ring.len() != membership_proofs.len() {
-                    return Err(WalletTransactionBuilderError::RingSizeMismatch);
+                    // The real input is always the first element. This is safe because
+                    // TransactionBuilder sorts each ring.
+                    0
                 }
+            };
 
-                let public_key = RistrettoPublic::try_from(&db_tx_out.public_key).unwrap();
-
-                let subaddress_index = if let Some(s) = utxo.subaddress_index {
-                    s
-                } else {
-                    return Err(WalletTransactionBuilderError::NullSubaddress(
-                        utxo.txo_id_hex.to_string(),
-                    ));
-                };
-
-                let onetime_private_key = recover_onetime_private_key(
-                    &public_key,
-                    from_account_key.view_private_key(),
-                    &from_account_key.subaddress_spend_private(subaddress_index as u64),
-                );
-
-                let key_image = KeyImage::from(&onetime_private_key);
-                log::debug!(
-                    self.logger,
-                    "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}",
-                    ring,
-                    real_key_index,
-                    key_image,
-                    public_key
-                );
-
-                transaction_builder.add_input(InputCredentials::new(
-                    ring,
-                    membership_proofs,
-                    real_key_index,
-                    onetime_private_key,
-                    *from_account_key.view_private_key(),
-                )?);
+            if ring.len() != membership_proofs.len() {
+                return Err(WalletTransactionBuilderError::RingSizeMismatch);
             }
 
-            // Add outputs to our destinations.
-            // Note that we make an assumption currently when logging submitted Txos that
-            // they were built  with only one recipient, and one change txo.
-            let mut total_value = 0;
-            let mut tx_out_to_outlay_index: HashMap<TxOut, usize> = HashMap::default();
-            let mut outlay_confirmation_numbers = Vec::default();
-            let mut rng = rand::thread_rng();
-            for (i, (recipient, out_value)) in self.outlays.iter().enumerate() {
-                let (tx_out, confirmation_number) =
-                    transaction_builder.add_output(*out_value as u64, recipient, &mut rng)?;
+            let public_key = RistrettoPublic::try_from(&db_tx_out.public_key).unwrap();
 
-                tx_out_to_outlay_index.insert(tx_out, i);
-                outlay_confirmation_numbers.push(confirmation_number);
-
-                total_value += *out_value;
-            }
-
-            // Figure out if we have change.
-            let input_value = inputs_and_proofs
-                .iter()
-                .fold(0, |acc, (utxo, _proof)| acc + utxo.value);
-            if (total_value + transaction_builder.get_fee()) > input_value as u64 {
-                return Err(WalletTransactionBuilderError::InsufficientInputFunds(
-                    format!(
-                        "Total value required to send transaction {:?}, but only {:?} in inputs",
-                        total_value + transaction_builder.get_fee(),
-                        input_value
-                    ),
+            let subaddress_index = if let Some(s) = utxo.subaddress_index {
+                s
+            } else {
+                return Err(WalletTransactionBuilderError::NullSubaddress(
+                    utxo.txo_id_hex.to_string(),
                 ));
-            }
+            };
 
-            let change = input_value as u64 - total_value - transaction_builder.get_fee();
+            let onetime_private_key = recover_onetime_private_key(
+                &public_key,
+                from_account_key.view_private_key(),
+                &from_account_key.subaddress_spend_private(subaddress_index as u64),
+            );
 
-            // If we do, add an output for that as well.
-            if change > 0 {
-                let change_public_address =
-                    from_account_key.subaddress(account.change_subaddress_index as u64);
-                // FIXME: verify that fog resolver knows to send change with hint encrypted to
-                // the main public address
-                transaction_builder.add_output(change, &change_public_address, &mut rng)?;
-                // FIXME: CBB - map error to indicate error with change
-            }
+            let key_image = KeyImage::from(&onetime_private_key);
+            log::debug!(
+                self.logger,
+                "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}",
+                ring,
+                real_key_index,
+                key_image,
+                public_key
+            );
 
-            // Set tombstone block.
-            transaction_builder.set_tombstone_block(self.tombstone);
+            transaction_builder.add_input(InputCredentials::new(
+                ring,
+                membership_proofs,
+                real_key_index,
+                onetime_private_key,
+                *from_account_key.view_private_key(),
+            )?);
+        }
 
-            // Build tx.
-            let tx = transaction_builder.build(&mut rng)?;
+        // Add outputs to our destinations.
+        // Note that we make an assumption currently when logging submitted Txos that
+        // they were built  with only one recipient, and one change txo.
+        let mut total_value = 0;
+        let mut tx_out_to_outlay_index: HashMap<TxOut, usize> = HashMap::default();
+        let mut outlay_confirmation_numbers = Vec::default();
+        let mut rng = rand::thread_rng();
+        for (i, (recipient, out_value)) in self.outlays.iter().enumerate() {
+            let (tx_out, confirmation_number) =
+                transaction_builder.add_output(*out_value as u64, recipient, &mut rng)?;
 
-            // Map each TxOut in the constructed transaction to its respective outlay.
-            let outlay_index_to_tx_out_index: HashMap<usize, usize> = tx
-                .prefix
-                .outputs
-                .iter()
-                .enumerate()
-                .filter_map(|(tx_out_index, tx_out)| {
-                    tx_out_to_outlay_index
-                        .get(tx_out)
-                        .map(|outlay_index| (*outlay_index, tx_out_index))
-                })
-                .collect();
+            tx_out_to_outlay_index.insert(tx_out, i);
+            outlay_confirmation_numbers.push(confirmation_number);
 
-            // Sanity check: All of our outlays should have a unique index in the map.
-            assert_eq!(outlay_index_to_tx_out_index.len(), self.outlays.len());
-            let mut found_tx_out_indices: HashSet<&usize> = HashSet::default();
-            for i in 0..self.outlays.len() {
-                let tx_out_index = outlay_index_to_tx_out_index
-                    .get(&i)
-                    .expect("index not in map");
-                if !found_tx_out_indices.insert(tx_out_index) {
-                    panic!("duplicate index {} found in map", tx_out_index);
-                }
-            }
+            total_value += *out_value;
+        }
 
-            // Make the UnspentTxOut for each Txo
-            // FIXME: WS-27 - I would prefer to provide just the txo_id_hex per txout, but
-            // this at least preserves some interoperability between
-            // mobilecoind and wallet-service. However, this is
-            // pretty clunky and I would rather not expose a storage
-            // type from mobilecoind just to get around having to write a bunch of
-            // tedious json conversions.
-            // Return the TxProposal
-            let selected_utxos = inputs_and_proofs
-                    .iter()
-                    .map(|(utxo, _membership_proof)| {
-                        let decoded_tx_out = mc_util_serial::decode(&utxo.txo).unwrap();
-                        let decoded_key_image =
-                            mc_util_serial::decode(&utxo.key_image.clone().unwrap()).unwrap();
+        // Figure out if we have change.
+        let input_value = inputs_and_proofs
+            .iter()
+            .fold(0, |acc, (utxo, _proof)| acc + utxo.value);
+        if (total_value + transaction_builder.get_fee()) > input_value as u64 {
+            return Err(WalletTransactionBuilderError::InsufficientInputFunds(
+                format!(
+                    "Total value required to send transaction {:?}, but only {:?} in inputs",
+                    total_value + transaction_builder.get_fee(),
+                    input_value
+                ),
+            ));
+        }
 
-                        UnspentTxOut {
-                            tx_out: decoded_tx_out,
-                            subaddress_index: utxo.subaddress_index.unwrap() as u64, // verified not null earlier
-                            key_image: decoded_key_image,
-                            value: utxo.value as u64,
-                            attempted_spend_height: 0, // NOTE: these are null because not tracked here
-                            attempted_spend_tombstone: 0,
-                        }
-                    })
-                    .collect();
-            Ok(TxProposal {
-                utxos: selected_utxos,
-                outlays: self
-                    .outlays
-                    .iter()
-                    .map(|(recipient, value)| Outlay {
-                        receiver: recipient.clone(),
-                        value: *value,
-                    })
-                    .collect::<Vec<Outlay>>(),
-                tx,
-                outlay_index_to_tx_out_index,
-                outlay_confirmation_numbers,
+        let change = input_value as u64 - total_value - transaction_builder.get_fee();
+
+        // If we do, add an output for that as well.
+        if change > 0 {
+            let change_public_address =
+                from_account_key.subaddress(account.change_subaddress_index as u64);
+            // FIXME: verify that fog resolver knows to send change with hint encrypted to
+            // the main public address
+            transaction_builder.add_output(change, &change_public_address, &mut rng)?;
+            // FIXME: CBB - map error to indicate error with change
+        }
+
+        // Set tombstone block.
+        transaction_builder.set_tombstone_block(self.tombstone);
+
+        // Build tx.
+        let tx = transaction_builder.build(&mut rng)?;
+
+        // Map each TxOut in the constructed transaction to its respective outlay.
+        let outlay_index_to_tx_out_index: HashMap<usize, usize> = tx
+            .prefix
+            .outputs
+            .iter()
+            .enumerate()
+            .filter_map(|(tx_out_index, tx_out)| {
+                tx_out_to_outlay_index
+                    .get(tx_out)
+                    .map(|outlay_index| (*outlay_index, tx_out_index))
             })
+            .collect();
+
+        // Sanity check: All of our outlays should have a unique index in the map.
+        assert_eq!(outlay_index_to_tx_out_index.len(), self.outlays.len());
+        let mut found_tx_out_indices: HashSet<&usize> = HashSet::default();
+        for i in 0..self.outlays.len() {
+            let tx_out_index = outlay_index_to_tx_out_index
+                .get(&i)
+                .expect("index not in map");
+            if !found_tx_out_indices.insert(tx_out_index) {
+                panic!("duplicate index {} found in map", tx_out_index);
+            }
+        }
+
+        // Make the UnspentTxOut for each Txo
+        // FIXME: WS-27 - I would prefer to provide just the txo_id_hex per txout, but
+        // this at least preserves some interoperability between
+        // mobilecoind and wallet-service. However, this is
+        // pretty clunky and I would rather not expose a storage
+        // type from mobilecoind just to get around having to write a bunch of
+        // tedious json conversions.
+        // Return the TxProposal
+        let selected_utxos = inputs_and_proofs
+            .iter()
+            .map(|(utxo, _membership_proof)| {
+                let decoded_tx_out = mc_util_serial::decode(&utxo.txo).unwrap();
+                let decoded_key_image =
+                    mc_util_serial::decode(&utxo.key_image.clone().unwrap()).unwrap();
+
+                UnspentTxOut {
+                    tx_out: decoded_tx_out,
+                    subaddress_index: utxo.subaddress_index.unwrap() as u64, /* verified not null
+                                                                              * earlier */
+                    key_image: decoded_key_image,
+                    value: utxo.value as u64,
+                    attempted_spend_height: 0, // NOTE: these are null because not tracked here
+                    attempted_spend_tombstone: 0,
+                }
+            })
+            .collect();
+        Ok(TxProposal {
+            utxos: selected_utxos,
+            outlays: self
+                .outlays
+                .iter()
+                .map(|(recipient, value)| Outlay {
+                    receiver: recipient.clone(),
+                    value: *value,
+                })
+                .collect::<Vec<Outlay>>(),
+            tx,
+            outlay_index_to_tx_out_index,
+            outlay_confirmation_numbers,
         })
     }
 
@@ -595,8 +578,9 @@ mod tests {
         );
 
         // Construct a transaction
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         // Send value specifically for your smallest Txo size. Should take 2 inputs
         // and also make change.
@@ -604,10 +588,10 @@ mod tests {
         builder.add_recipient(recipient.clone(), value).unwrap();
 
         // Select the txos for the recipient
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
 
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.outlays.len(), 1);
         assert_eq!(proposal.outlays[0].receiver, recipient);
         assert_eq!(proposal.outlays[0].value, value);
@@ -649,14 +633,15 @@ mod tests {
         assert_eq!(balance, 21_000_000 * MOB as u128);
 
         // Now try to send a transaction with a value > u64::MAX
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         let value = u64::MAX;
         builder.add_recipient(recipient.clone(), value).unwrap();
 
         // Select the txos for the recipient - should error because > u64::MAX
-        match builder.select_txos(None, false) {
+        match builder.select_txos(&conn, None, false) {
             Ok(_) => panic!("Should not be allowed to construct outbound values > u64::MAX"),
             Err(WalletTransactionBuilderError::OutboundValueTooLarge) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
@@ -693,8 +678,9 @@ mod tests {
         )
         .unwrap();
 
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         // Setting value to exactly the input will fail because you need funds for fee
         builder
@@ -702,10 +688,10 @@ mod tests {
             .unwrap();
 
         builder
-            .set_txos(&vec![txos[0].txo_id_hex.clone()], false)
+            .set_txos(&conn, &vec![txos[0].txo_id_hex.clone()], false)
             .unwrap();
         builder.set_tombstone(0).unwrap();
-        match builder.build() {
+        match builder.build(&conn) {
             Ok(_) => {
                 panic!("Should not be able to construct Tx with > inputs value as output value")
             }
@@ -715,7 +701,7 @@ mod tests {
 
         // Now build, setting to multiple TXOs
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         // Set value to just slightly more than what fits in the one TXO
         builder
@@ -724,12 +710,13 @@ mod tests {
 
         builder
             .set_txos(
+                &conn,
                 &vec![txos[0].txo_id_hex.clone(), txos[1].txo_id_hex.clone()],
                 false,
             )
             .unwrap();
         builder.set_tombstone(0).unwrap();
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.outlays.len(), 1);
         assert_eq!(proposal.outlays[0].receiver, recipient);
         assert_eq!(proposal.outlays[0].value, txos[0].value as u64 + 10);
@@ -759,14 +746,15 @@ mod tests {
             &logger,
         );
 
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         // Setting value to exactly the input will fail because you need funds for fee
         builder.add_recipient(recipient.clone(), 80 * MOB).unwrap();
 
         // Test that selecting Txos with max_spendable < all our txo values fails
-        match builder.select_txos(Some(10), false) {
+        match builder.select_txos(&conn, Some(10), false) {
             Ok(_) => panic!("Should not be able to construct tx when max_spendable < all txos"),
             Err(WalletTransactionBuilderError::WalletDb(WalletDbError::NoSpendableTxos)) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
@@ -774,7 +762,7 @@ mod tests {
 
         // We should be able to try again, with max_spendable at 70, but will not hit
         // our outlay target (80 * MOB)
-        match builder.select_txos(Some(70 * MOB), false) {
+        match builder.select_txos(&conn, Some(70 * MOB), false) {
             Ok(_) => panic!("Should not be able to construct tx when max_spendable < all txos"),
             Err(WalletTransactionBuilderError::WalletDb(
                 WalletDbError::InsufficientFundsUnderMaxSpendable(_),
@@ -784,9 +772,9 @@ mod tests {
 
         // Now, we should succeed if we set max_spendable = 80 * MOB, because we will
         // pick up both 70 and 80
-        builder.select_txos(Some(80 * MOB), false).unwrap();
+        builder.select_txos(&conn, Some(80 * MOB), false).unwrap();
         builder.set_tombstone(0).unwrap();
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.outlays.len(), 1);
         assert_eq!(proposal.outlays[0].receiver, recipient);
         assert_eq!(proposal.outlays[0].value, 80 * MOB);
@@ -804,6 +792,7 @@ mod tests {
         let wallet_db = db_test_context.get_db_instance(logger.clone());
         let known_recipients: Vec<PublicAddress> = Vec::new();
         let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+        let conn = wallet_db.get_conn().unwrap();
 
         // Start sync thread
         let _sync_thread = SyncThread::start(ledger_db.clone(), wallet_db.clone(), logger.clone());
@@ -817,48 +806,48 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
 
         // Sanity check that our ledger is the height we think it is
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
 
         // We must set tombstone block before building
-        match builder.build() {
+        match builder.build(&conn) {
             Ok(_) => panic!("Expected TombstoneNotSet error"),
             Err(WalletTransactionBuilderError::TombstoneNotSet) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
         }
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
 
         // Set to default
         builder.set_tombstone(0).unwrap();
 
         // Not setting the tombstone results in tombstone = 0. This is an acceptable
         // value,
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.tombstone_block, 23);
 
         // Build a transaction and explicitly set tombstone
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
 
         // Set to default
         builder.set_tombstone(20).unwrap();
 
         // Not setting the tombstone results in tombstone = 0. This is an acceptable
         // value,
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.tombstone_block, 20);
     }
 
@@ -883,23 +872,24 @@ mod tests {
             &logger,
         );
 
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
 
         // Verify that not setting fee results in default fee
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
 
         // You cannot set fee to 0
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
         match builder.set_fee(0) {
             Ok(_) => panic!("Should not be able to set fee to 0"),
@@ -908,15 +898,15 @@ mod tests {
         }
 
         // Verify that not setting fee results in default fee
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
 
         // Setting fee less than minimum fee should fail
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
         match builder.set_fee(0) {
             Ok(_) => panic!("Should not be able to set fee to 0"),
@@ -926,13 +916,13 @@ mod tests {
 
         // Setting fee greater than MINIMUM_FEE works
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
         builder.set_fee(Mob::MINIMUM_FEE * 10).unwrap();
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE * 10);
     }
 
@@ -957,17 +947,18 @@ mod tests {
             &logger,
         );
 
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         // Set value to consume the whole TXO and not produce change
         let value = 70 * MOB - Mob::MINIMUM_FEE;
         builder.add_recipient(recipient.clone(), value).unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
 
         // Verify that not setting fee results in default fee
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
         assert_eq!(proposal.outlays.len(), 1);
         assert_eq!(proposal.outlays[0].receiver, recipient);
@@ -999,19 +990,20 @@ mod tests {
             &logger,
         );
 
+        let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
         builder.add_recipient(recipient.clone(), 20 * MOB).unwrap();
         builder.add_recipient(recipient.clone(), 30 * MOB).unwrap();
         builder.add_recipient(recipient.clone(), 40 * MOB).unwrap();
 
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
 
         // Verify that not setting fee results in default fee
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
         assert_eq!(proposal.outlays.len(), 4);
         assert_eq!(proposal.outlays[0].receiver, recipient);
@@ -1053,7 +1045,7 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder
             .add_recipient(recipient.clone(), 7_000_000 * MOB)
@@ -1065,7 +1057,7 @@ mod tests {
             .add_recipient(recipient.clone(), 7_000_000 * MOB)
             .unwrap();
 
-        match builder.select_txos(None, false) {
+        match builder.select_txos(&wallet_db.get_conn().unwrap(), None, false) {
             Ok(_) => panic!("Should not be able to select txos with > u64::MAX output value"),
             Err(WalletTransactionBuilderError::OutboundValueTooLarge) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
@@ -1094,7 +1086,7 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &wallet_db, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
 
         builder.add_recipient(recipient.clone(), 10 * MOB).unwrap();
 

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -7,16 +7,14 @@ use crate::{
         account::AccountID,
         models::TransactionLog,
         transaction_log::{AssociatedTxos, TransactionLogModel},
+        WalletDbError,
     },
     error::WalletServiceError,
     WalletService,
 };
+use displaydoc::Display;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
-
-use crate::db::WalletDbError;
-use diesel::connection::Connection;
-use displaydoc::Display;
 
 /// Errors for the Transaction Log Service.
 #[derive(Display, Debug)]
@@ -82,14 +80,12 @@ where
         limit: Option<i64>,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         let conn = &self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(TransactionLog::list_all(
-                &account_id.to_string(),
-                offset,
-                limit,
-                conn,
-            )?)
-        })
+        Ok(TransactionLog::list_all(
+            &account_id.to_string(),
+            offset,
+            limit,
+            conn,
+        )?)
     }
 
     fn get_transaction_log(
@@ -97,12 +93,10 @@ where
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos), TransactionLogServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let transaction_log = TransactionLog::get(transaction_id_hex, &conn)?;
-            let associated = transaction_log.get_associated_txos(&conn)?;
+        let transaction_log = TransactionLog::get(transaction_id_hex, &conn)?;
+        let associated = transaction_log.get_associated_txos(&conn)?;
 
-            Ok((transaction_log, associated))
-        })
+        Ok((transaction_log, associated))
     }
 
     fn get_all_transaction_logs_for_block(
@@ -110,33 +104,29 @@ where
         block_index: u64,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let transaction_logs = TransactionLog::get_all_for_block_index(block_index, &conn)?;
-            let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
-            for transaction_log in transaction_logs {
-                res.push((
-                    transaction_log.clone(),
-                    transaction_log.get_associated_txos(&conn)?,
-                ));
-            }
-            Ok(res)
-        })
+        let transaction_logs = TransactionLog::get_all_for_block_index(block_index, &conn)?;
+        let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
+        for transaction_log in transaction_logs {
+            res.push((
+                transaction_log.clone(),
+                transaction_log.get_associated_txos(&conn)?,
+            ));
+        }
+        Ok(res)
     }
 
     fn get_all_transaction_logs_ordered_by_block(
         &self,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos)>, WalletServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
-            let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
-            for transaction_log in transaction_logs {
-                res.push((
-                    transaction_log.clone(),
-                    transaction_log.get_associated_txos(&conn)?,
-                ));
-            }
-            Ok(res)
-        })
+        let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
+        let mut res: Vec<(TransactionLog, AssociatedTxos)> = Vec::new();
+        for transaction_log in transaction_logs {
+            res.push((
+                transaction_log.clone(),
+                transaction_log.get_associated_txos(&conn)?,
+            ));
+        }
+        Ok(res)
     }
 }

--- a/full-service/src/service/view_only_account.rs
+++ b/full-service/src/service/view_only_account.rs
@@ -4,14 +4,13 @@
 
 use crate::{
     db::{
-        models::{ViewOnlyAccount, ViewOnlyTxo},
+        models::ViewOnlyAccount,
         view_only_account::{ViewOnlyAccountID, ViewOnlyAccountModel},
-        view_only_txo::ViewOnlyTxoModel,
+        transaction,
     },
     service::{account::AccountServiceError, WalletService},
     util::constants::DEFAULT_FIRST_BLOCK_INDEX,
 };
-use diesel::Connection;
 use mc_common::logger::log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_crypto_keys::RistrettoPrivate;
@@ -77,16 +76,14 @@ where
         let first_block_index = first_block_index.unwrap_or(DEFAULT_FIRST_BLOCK_INDEX);
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(ViewOnlyAccount::create(
-                &account_id_hex,
-                &view_private_key,
-                first_block_index,
-                import_block_index,
-                name,
-                &conn,
-            )?)
-        })
+        Ok(ViewOnlyAccount::create(
+            &account_id_hex,
+            &view_private_key,
+            first_block_index,
+            import_block_index,
+            name,
+            &conn,
+        )?)
     }
 
     fn get_view_only_account(
@@ -96,12 +93,12 @@ where
         log::info!(self.logger, "fetching view-only-account {:?}", account_id);
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| Ok(ViewOnlyAccount::get(account_id, &conn)?))
+        Ok(ViewOnlyAccount::get(account_id, &conn)?)
     }
 
     fn list_view_only_accounts(&self) -> Result<Vec<ViewOnlyAccount>, AccountServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| Ok(ViewOnlyAccount::list_all(&conn)?))
+        Ok(ViewOnlyAccount::list_all(&conn)?)
     }
 
     fn update_view_only_account_name(
@@ -110,23 +107,17 @@ where
         name: &str,
     ) -> Result<ViewOnlyAccount, AccountServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            ViewOnlyAccount::get(account_id, &conn)?.update_name(name, &conn)?;
-            Ok(ViewOnlyAccount::get(account_id, &conn)?)
-        })
+        ViewOnlyAccount::get(account_id, &conn)?.update_name(name, &conn)?;
+        Ok(ViewOnlyAccount::get(account_id, &conn)?)
     }
 
     fn remove_view_only_account(&self, account_id: &str) -> Result<bool, AccountServiceError> {
         log::info!(self.logger, "Deleting view only account {}", account_id,);
 
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            // delete associated view-only-txos
-            ViewOnlyTxo::delete_all_for_account(account_id, &conn)?;
-
-            let account = ViewOnlyAccount::get(account_id, &conn)?;
+        let account = ViewOnlyAccount::get(account_id, &conn)?;
+        transaction(&conn, || {
             account.delete(&conn)?;
-
             Ok(true)
         })
     }

--- a/full-service/src/service/view_only_account.rs
+++ b/full-service/src/service/view_only_account.rs
@@ -5,8 +5,8 @@
 use crate::{
     db::{
         models::ViewOnlyAccount,
-        view_only_account::{ViewOnlyAccountID, ViewOnlyAccountModel},
         transaction,
+        view_only_account::{ViewOnlyAccountID, ViewOnlyAccountModel},
     },
     service::{account::AccountServiceError, WalletService},
     util::constants::DEFAULT_FIRST_BLOCK_INDEX,

--- a/full-service/src/service/view_only_transaction_log.rs
+++ b/full-service/src/service/view_only_transaction_log.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     WalletService,
 };
-use diesel::prelude::*;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_mobilecoind::payments::TxProposal;

--- a/full-service/src/service/view_only_transaction_log.rs
+++ b/full-service/src/service/view_only_transaction_log.rs
@@ -4,8 +4,7 @@
 
 use crate::{
     db::{
-        models::ViewOnlyTransactionLog, txo::TxoID,
-        transaction,
+        models::ViewOnlyTransactionLog, transaction, txo::TxoID,
         view_only_transaction_log::ViewOnlyTransactionLogModel, WalletDbError,
     },
     WalletService,
@@ -170,10 +169,10 @@ mod tests {
         // Create TxProposal from the sender account, which contains the Confirmation
         // Number
         log::info!(logger, "Creating transaction builder");
+        let conn = wallet_db.get_conn().unwrap();
         let mut builder: WalletTransactionBuilder<MockFogPubkeyResolver> =
             WalletTransactionBuilder::new(
                 AccountID::from(&sender_account_key).to_string(),
-                wallet_db.clone(),
                 ledger_db.clone(),
                 get_resolver_factory(&mut rng).unwrap(),
                 logger.clone(),
@@ -181,9 +180,9 @@ mod tests {
         builder
             .add_recipient(recipient_account_key.default_subaddress(), 40 * MOB)
             .unwrap();
-        builder.select_txos(None, false).unwrap();
+        builder.select_txos(&conn, None, false).unwrap();
         builder.set_tombstone(0).unwrap();
-        let proposal = builder.build().unwrap();
+        let proposal = builder.build(&conn).unwrap();
 
         // find change txo from proposal
         let change_txo = get_change_txout_from_proposal(&proposal).unwrap();

--- a/full-service/src/service/view_only_txo.rs
+++ b/full-service/src/service/view_only_txo.rs
@@ -3,7 +3,7 @@
 //! Service for managing view-only Txos.
 
 use crate::{
-    db::{models::ViewOnlyTxo, view_only_txo::ViewOnlyTxoModel},
+    db::{models::ViewOnlyTxo, transaction, view_only_txo::ViewOnlyTxoModel},
     service::txo::TxoServiceError,
     WalletService,
 };
@@ -38,16 +38,14 @@ where
         offset: Option<i64>,
     ) -> Result<Vec<ViewOnlyTxo>, TxoServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
-            Ok(ViewOnlyTxo::list_for_account(
-                account_id, limit, offset, &conn,
-            )?)
-        })
+        Ok(ViewOnlyTxo::list_for_account(
+            account_id, limit, offset, &conn,
+        )?)
     }
 
     fn set_view_only_txos_spent(&self, txo_ids: Vec<String>) -> Result<bool, TxoServiceError> {
         let conn = self.wallet_db.get_conn()?;
-        conn.transaction(|| {
+        transaction(&conn, || {
             ViewOnlyTxo::set_spent(txo_ids, &conn)?;
             Ok(true)
         })

--- a/full-service/src/service/view_only_txo.rs
+++ b/full-service/src/service/view_only_txo.rs
@@ -7,7 +7,6 @@ use crate::{
     service::txo::TxoServiceError,
     WalletService,
 };
-use diesel::prelude::*;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 


### PR DESCRIPTION
- Fix DB locking in assign_address_for_account.
- Fix database locking during account creation and deletion.
- Remove unnecessary transactions from account service functions.
- Redo usage of transactions for view-only accounts.
- Use a type alias for Diesel connections.
- Move transaction for select-unspent-txos into service layer
- Use new transaction fn in gift code service
- Move db transactions from db layer to service layer.
- Remove unnexessary transactions
- Remove or replace more instances of conn.transaction
- Finish converting transactions to new style.

