### PR TITLE
Make .mobconf and rust-toolchain reference mobilecoin submodule

### DIFF
--- a/.mobconf
+++ b/.mobconf
@@ -1,4 +1,4 @@
 [image]
 target = builder-install
 repository = gcr.io/mobilenode-211420/
-Dockerfile-version = 1_14
+dockerfile = mobilecoin/docker/Dockerfile

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-07-21
+mobilecoin/rust-toolchain


### PR DESCRIPTION
This makes `full-service` follow whatever versions are in the `mobilecoin` submodule, i.e. fewer references to update when upgrading the `rust-toolchain` or `builder-install` image. Updates can then be propagated when updating the submodule.