### PR TITLE
Add change output for zero change

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn test_log_submitted_no_change(logger: Logger) {
+    fn test_log_submitted_zero_change(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
 
         let db_test_context = WalletDbTestContext::default();
@@ -871,7 +871,7 @@ mod tests {
             .unwrap();
         assert_eq!(associated.inputs.len(), 1);
         assert_eq!(associated.outputs.len(), 1);
-        assert_eq!(associated.change.len(), 0);
+        assert_eq!(associated.change.len(), 1);
     }
 
     #[test_with_logger]


### PR DESCRIPTION
### Motivation

To better support RTH, a change TXO should always be included in a transaction, even when the total change would be 0 MOB.

### In this PR
* Add change output, regardless of change value

https://github.com/mobilecoinofficial/full-service/issues/310

