### PR TITLE
Updating export VO package for normal accounts

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,7 +16,7 @@
     * [Remove Account](accounts/account/remove\_account.md)
   * [Account Secrets](accounts/account-secrets/README.md)
     * [Export Account Secrets](accounts/account-secrets/export\_account\_secrets.md)
-    * [Export View Only Account Package](accounts/account-secrets/export_view_only_account_package.md)
+    * [Export View Only Account Package](accounts/account-secrets/export\_view\_only\_account\_package.md)
   * [Address](accounts/address/README.md)
     * [Assign Address For Account](accounts/address/assign\_address\_for\_account.md)
     * [Get Addresses For Account](accounts/address/get\_addresses\_for\_account.md)
@@ -97,4 +97,3 @@
   * [Transaction Signer](usage/view-only-account/transaction-signer.md)
 
 ## Frequently Asked Questions
-[FAQ](FAQ.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
     * [Remove Account](accounts/account/remove\_account.md)
   * [Account Secrets](accounts/account-secrets/README.md)
     * [Export Account Secrets](accounts/account-secrets/export\_account\_secrets.md)
+    * [Export View Only Account Package](accounts/account-secrets/export_view_only_account_package.md)
   * [Address](accounts/address/README.md)
     * [Assign Address For Account](accounts/address/assign\_address\_for\_account.md)
     * [Get Addresses For Account](accounts/address/get\_addresses\_for\_account.md)

--- a/docs/accounts/account-secrets/export_view_only_account_package.md
+++ b/docs/accounts/account-secrets/export_view_only_account_package.md
@@ -1,65 +1,77 @@
----
-description: >-
-  Exporting the secret mnemonic an account is the only way to recover it when
-  lost.
----
-
-# Export Account Secrets
+# Export View Only Account Package
 
 ## Parameters
 
-| Required Param | Purpose | Requirements |
-| :--- | :--- | :--- |
-| `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
+| Required Param | Purpose                                      | Requirements                      |
+| -------------- | -------------------------------------------- | --------------------------------- |
+| `account_id`   | The account on which to perform this action. | Account must exist in the wallet. |
 
 ## Example
 
 {% tabs %}
 {% tab title="Request Body" %}
-```text
+```
 {
-  "method": "export_account_secrets",
-  "params": {
-    "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52"
-  },
-  "jsonrpc": "2.0",
-  "id": 1
+    "method": "export_view_only_account_package",
+    "params": {
+        "account_id": "6d95067c5fcc0dd7bbcdd42d49cc3571fe1bb2597a9c397c75b7280eca534208"
+    },
+    "jsonrpc": "2.0",
+    "id": 1
 }
 ```
 {% endtab %}
 
 {% tab title="Response" %}
-```text
+```
 {
-  "method": "export_account_secrets",
-  "result": {
-    "account_secrets": {
-      "object": "account_secrets",
-      "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
-      "entropy": "c0b285cc589447c7d47f3yfdc466e7e946753fd412337bfc1a7008f0184b0479",
-      "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
-      "key_derivation_version": "2",
-      "account_key": {
-        "object": "account_key",
-        "view_private_key": "0a20be48e147741246f09adb195b110c4ec39302778c4554cd3c9ff877f8392ce605",
-        "spend_private_key": "0a201f33b194e13176341b4e696b70be5ba5c4e0021f5a79664ab9a8b128f0d6d40d",
-        "fog_report_url": "",
-        "fog_report_id": "",
-        "fog_authority_spki": ""
-      }
-    }
-  },
-  "error": null,
-  "jsonrpc": "2.0",
-  "id": 1,
+    "method": "export_view_only_account_package",
+    "result": {
+        "json_rpc_request": {
+            "method": "import_view_only_account",
+            "params": {
+                "account": {
+                    "object": "view_only_account",
+                    "account_id": "6d95067c5fcc0dd7bbcdd42d49cc3571fe1bb2597a9c397c75b7280eca534208",
+                    "name": "testing",
+                    "first_block_index": "661194",
+                    "next_block_index": "693043",
+                    "main_subaddress_index": "0",
+                    "change_subaddress_index": "1",
+                    "next_subaddress_index": "2"
+                },
+                "secrets": {
+                    "object": "view_only_account_secrets",
+                    "view_private_key": "0a20ec42a30f81c5367042516bcbe499def7346f39870ef0f7d1a467e5325d845007",
+                    "account_id": "6d95067c5fcc0dd7bbcdd42d49cc3571fe1bb2597a9c397c75b7280eca534208"
+                },
+                "subaddresses": [
+                    {
+                        "object": "view_only_subaddress",
+                        "public_address": "3b63EnYDAaGCoeZ473YwcsoHk47qDcuFo6emkFKtiEfSrNy5NuzLpLCau7yJJ5WfavVjMsK8Qa7FKBDEQF5UkRadFVFKEBEaji2FvfLJRTh",
+                        "account_id": "6d95067c5fcc0dd7bbcdd42d49cc3571fe1bb2597a9c397c75b7280eca534208",
+                        "comment": "Main",
+                        "subaddress_index": "0",
+                        "public_spend_key": "0a203cbe82bc9af6cc20d485534f79c5cc41a887099f424d64b8d9ee3ae4599d7544"
+                    },
+                    {
+                        "object": "view_only_subaddress",
+                        "public_address": "88hRd28N7srH1wtydh9hWBq8EFfgPy492prHXqvuF4kRu6i6rk6dMNNsGN7H8rdDUcTCCBGDzN14nDEvfWS8W5GytJuUVkD9emCYr9cX7Sr",
+                        "account_id": "6d95067c5fcc0dd7bbcdd42d49cc3571fe1bb2597a9c397c75b7280eca534208",
+                        "comment": "Change",
+                        "subaddress_index": "1",
+                        "public_spend_key": "0a20c61def43c7b62ca7caeec567c23c1fd62d8a627e385b4206f9f91e80af85ea53"
+                    }
+                ]
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        }
+    },
+    "jsonrpc": "2.0",
+    "id": 1
 }
 ```
 {% endtab %}
 {% endtabs %}
-
-## Outputs
-
-If the account was generated using version 1 of the key derivation, entropy will be provided as a hex-encoded string.
-
-If the account was generated using version 2 of the key derivation, mnemonic will be provided as a 24-word mnemonic string.
 

--- a/docs/accounts/account-secrets/export_view_only_account_package.md
+++ b/docs/accounts/account-secrets/export_view_only_account_package.md
@@ -1,0 +1,65 @@
+---
+description: >-
+  Exporting the secret mnemonic an account is the only way to recover it when
+  lost.
+---
+
+# Export Account Secrets
+
+## Parameters
+
+| Required Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
+
+## Example
+
+{% tabs %}
+{% tab title="Request Body" %}
+```text
+{
+  "method": "export_account_secrets",
+  "params": {
+    "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52"
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```text
+{
+  "method": "export_account_secrets",
+  "result": {
+    "account_secrets": {
+      "object": "account_secrets",
+      "account_id": "3407fbbc250799f5ce9089658380c5fe152403643a525f581f359917d8d59d52",
+      "entropy": "c0b285cc589447c7d47f3yfdc466e7e946753fd412337bfc1a7008f0184b0479",
+      "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
+      "key_derivation_version": "2",
+      "account_key": {
+        "object": "account_key",
+        "view_private_key": "0a20be48e147741246f09adb195b110c4ec39302778c4554cd3c9ff877f8392ce605",
+        "spend_private_key": "0a201f33b194e13176341b4e696b70be5ba5c4e0021f5a79664ab9a8b128f0d6d40d",
+        "fog_report_url": "",
+        "fog_report_id": "",
+        "fog_authority_spki": ""
+      }
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1,
+}
+```
+{% endtab %}
+{% endtabs %}
+
+## Outputs
+
+If the account was generated using version 1 of the key derivation, entropy will be provided as a hex-encoded string.
+
+If the account was generated using version 2 of the key derivation, mnemonic will be provided as a 24-word mnemonic string.
+

--- a/full-service/src/json_rpc/json_rpc_response.rs
+++ b/full-service/src/json_rpc/json_rpc_response.rs
@@ -13,7 +13,7 @@ use crate::{
         block::{Block, BlockContents},
         confirmation_number::Confirmation,
         gift_code::GiftCode,
-        json_rpc_request::JsonCommandRequest,
+        json_rpc_request::JsonRPCRequest,
         network_status::NetworkStatus,
         receiver_receipt::ReceiverReceipt,
         transaction_log::TransactionLog,
@@ -196,7 +196,7 @@ pub enum JsonCommandResponse {
         spent_txo_ids: Vec<String>,
     },
     export_view_only_account_package {
-        package: JsonCommandRequest,
+        json_rpc_request: JsonRPCRequest,
     },
     export_view_only_account_secrets {
         view_only_account_secrets: ViewOnlyAccountSecretsJSON,

--- a/full-service/src/json_rpc/view_only_account.rs
+++ b/full-service/src/json_rpc/view_only_account.rs
@@ -5,7 +5,8 @@
 use crate::{
     db,
     json_rpc::{
-        json_rpc_request::JsonCommandRequest, view_only_subaddress::ViewOnlySubaddressJSON,
+        json_rpc_request::{JsonCommandRequest, JsonRPCRequest},
+        view_only_subaddress::ViewOnlySubaddressJSON,
     },
     util::encoding_helpers::ristretto_to_hex,
 };
@@ -107,12 +108,10 @@ impl TryFrom<&db::models::Account> for ViewOnlyAccountSecretsJSON {
     }
 }
 
-impl TryFrom<&db::account::ViewOnlyAccountImportPackage> for JsonCommandRequest {
+impl TryFrom<&db::account::ViewOnlyAccountImportPackage> for JsonRPCRequest {
     type Error = String;
 
-    fn try_from(
-        src: &db::account::ViewOnlyAccountImportPackage,
-    ) -> Result<JsonCommandRequest, String> {
+    fn try_from(src: &db::account::ViewOnlyAccountImportPackage) -> Result<JsonRPCRequest, String> {
         let account = ViewOnlyAccountJSON::from(&src.account);
         let secrets = ViewOnlyAccountSecretsJSON::try_from(&src.account)?;
         let subaddresses = src
@@ -121,10 +120,27 @@ impl TryFrom<&db::account::ViewOnlyAccountImportPackage> for JsonCommandRequest 
             .map(ViewOnlySubaddressJSON::from)
             .collect();
 
-        Ok(JsonCommandRequest::import_view_only_account {
+        let json_command_request = JsonCommandRequest::import_view_only_account {
             account,
             secrets,
             subaddresses,
-        })
+        };
+
+        let src_json: serde_json::Value = serde_json::json!(json_command_request);
+        let method = src_json
+            .get("method")
+            .ok_or("missing method")?
+            .as_str()
+            .ok_or("could not cast to str")?;
+        let params = src_json.get("params").ok_or("missing params")?;
+
+        let json_rpc_request = JsonRPCRequest {
+            method: method.to_string(),
+            params: Some(params.clone()),
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::Value::Number(serde_json::Number::from(1)),
+        };
+
+        Ok(json_rpc_request)
     }
 }

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -503,9 +503,10 @@ where
             let package = service
                 .get_view_only_import_package(&AccountID(account_id))
                 .map_err(format_error)?;
-            let package = JsonCommandRequest::try_from(&package).map_err(format_error)?;
 
-            JsonCommandResponse::export_view_only_account_package { package }
+            let json_rpc_request = JsonRPCRequest::try_from(&package).map_err(format_error)?;
+
+            JsonCommandResponse::export_view_only_account_package { json_rpc_request }
         }
         JsonCommandRequest::export_view_only_account_secrets { account_id } => {
             let account = service


### PR DESCRIPTION
The API endpoint was exporting the VO account import package as an encapsulated "package" object instead of returning the internal structure flattened. This change also returns the full json_rpc_request body as a response, identical to how the transaction signer functions.