### PR TITLE
Add Intel SA 615 to MrSigner verifier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "cookie 0.16.0",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-connection",
  "mc-consensus-enclave-api",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "maplit",
  "mc-common",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aead",
  "digest 0.10.3",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.10",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "blake2",
  "digest 0.10.3",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.3",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap 3.1.18",
  "lmdb-rkv",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "clap 3.1.18",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "sha2 0.10.2",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2923,11 +2923,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.14.1",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3022,14 +3022,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64 0.13.0",
  "binascii",
@@ -3063,14 +3063,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64 0.13.0",
  "clap 3.1.18",
@@ -3101,11 +3101,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.10",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "grpcio",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "itertools",
  "mc-sgx-css",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "generic-array",
  "prost",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "prost",
  "serde",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64 0.13.0",
  "displaydoc",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -102,7 +102,7 @@ fn consensus_backed_full_service(
     // Verifier
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisory("INTEL-SA-00334");
+    mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -102,7 +102,7 @@ fn consensus_backed_full_service(
     // Verifier
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+    mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -92,11 +92,7 @@ impl APIConfig {
     pub fn get_fog_ingest_verifier(&self) -> Option<Verifier> {
         self.fog_ingest_enclave_css.as_ref().map(|signature| {
             let mr_signer_verifier = {
-                let mut mr_signer_verifier = MrSignerVerifier::new(
-                    signature.mrsigner().into(),
-                    signature.product_id(),
-                    signature.version(),
-                );
+                let mut mr_signer_verifier = MrSignerVerifier::from(signature);
                 mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
                 mr_signer_verifier
             };

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -97,7 +97,7 @@ impl APIConfig {
                     signature.product_id(),
                     signature.version(),
                 );
-                mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334"]);
+                mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
                 mr_signer_verifier
             };
 

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -97,7 +97,7 @@ impl APIConfig {
                     signature.product_id(),
                     signature.version(),
                 );
-                mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+                mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
                 mr_signer_verifier
             };
 

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -35,7 +35,7 @@ fn main() {
     // Create enclave verifier.
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisory("INTEL-SA-00334");
+    mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -35,7 +35,7 @@ fn main() {
     // Create enclave verifier.
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+    mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);


### PR DESCRIPTION
This should be included in a full-service wallet release by July 14th to comply with the Intel SGX security advisory deadline.