### PR TITLE
Add status option for get txos endpoint

### DIFF
--- a/docs/transactions/txo/get_txos_for_account.md
+++ b/docs/transactions/txo/get_txos_for_account.md
@@ -11,6 +11,7 @@ description: Get TXOs for a given account with offset and limit parameters
 | `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
 | `offset` | The pagination offset. Results start at the offset index. Optional, defaults to 0. | |
 | `limit` | Limit for the number of results. Optional, defaults to 100 | |
+| `status` | Optional txo status filer. Available status': "txo_status_unspent", "txo_status_spent", "txo_status_orphaned", "txo_status_pending", "txo_status_secreted", | |
 
 ## Example
 

--- a/full-service/src/db/assigned_subaddress.rs
+++ b/full-service/src/db/assigned_subaddress.rs
@@ -167,7 +167,7 @@ impl AssignedSubaddressModel for AssignedSubaddress {
             .execute(conn)?;
 
         // Find and repair orphaned txos at this subaddress.
-        let orphaned_txos = Txo::list_orphaned(account_id_hex, None, conn)?;
+        let orphaned_txos = Txo::list_orphaned(account_id_hex, None, None, None, conn)?;
 
         for orphaned_txo in orphaned_txos.iter() {
             let tx_out_target_key: RistrettoPublic =

--- a/full-service/src/db/migration_testing/seed_txos.rs
+++ b/full-service/src/db/migration_testing/seed_txos.rs
@@ -100,7 +100,7 @@ pub fn test_txos(
 
     // Check that we have one orphaned - went from [Minted, Secreted] -> [Minted,
     // Orphaned]
-    let orphaned = Txo::list_orphaned(&account_id.to_string(), Some(0), &conn).unwrap();
+    let orphaned = Txo::list_orphaned(&account_id.to_string(), Some(0), None, None, &conn).unwrap();
     assert_eq!(orphaned.len(), 1);
     assert!(orphaned[0].key_image.is_none());
     assert_eq!(orphaned[0].received_block_index.clone().unwrap(), 13);

--- a/full-service/src/db/migration_testing/seed_txos.rs
+++ b/full-service/src/db/migration_testing/seed_txos.rs
@@ -83,7 +83,8 @@ pub fn test_txos(
     conn: &PooledConnection<ConnectionManager<SqliteConnection>>,
 ) {
     // validate expected txo states
-    let txos = Txo::list_for_account(&account_id.to_string(), None, None, Some(0), &conn).unwrap();
+    let txos =
+        Txo::list_for_account(&account_id.to_string(), None, None, None, Some(0), &conn).unwrap();
     assert_eq!(txos.len(), 3);
 
     // Check that we have 2 spendable (1 is orphaned)

--- a/full-service/src/db/migration_testing/seed_txos.rs
+++ b/full-service/src/db/migration_testing/seed_txos.rs
@@ -93,7 +93,7 @@ pub fn test_txos(
 
     // Check that we have one spent - went from [Received, Unspent] -> [Received,
     // Spent]
-    let spent = Txo::list_spent(&account_id.to_string(), None, Some(0), &conn).unwrap();
+    let spent = Txo::list_spent(&account_id.to_string(), None, Some(0), None, None, &conn).unwrap();
     assert_eq!(spent.len(), 1);
     assert_eq!(spent[0].spent_block_index.clone().unwrap(), 13);
     assert_eq!(spent[0].minted_account_id_hex, None);
@@ -109,7 +109,8 @@ pub fn test_txos(
 
     // Check that we have one unspent (change) - went from [Minted, Secreted] ->
     // [Minted, Unspent]
-    let unspent = Txo::list_unspent(&account_id.to_string(), None, Some(0), &conn).unwrap();
+    let unspent =
+        Txo::list_unspent(&account_id.to_string(), None, Some(0), None, None, &conn).unwrap();
     assert_eq!(unspent.len(), 1);
     assert_eq!(unspent[0].received_block_index.clone().unwrap(), 13);
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1298,7 +1298,7 @@ mod tests {
         // test spent
         let spent_txos = Txo::list_for_account(
             &alice_account_id.to_string(),
-            Some("spent".to_string()),
+            Some(TXO_STATUS_SPENT.to_string()),
             None,
             None,
             Some(0),
@@ -1310,14 +1310,14 @@ mod tests {
         // test unspent
         let unspent_txos = Txo::list_for_account(
             &alice_account_id.to_string(),
-            Some("unspent".to_string()),
+            Some(TXO_STATUS_UNSPENT.to_string()),
             None,
             None,
             Some(0),
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
-        assert_eq!(unspent_txos.len(), 2);
+        assert_eq!(unspent_txos.len(), 1);
 
         // println!("{}", serde_json::to_string_pretty(&txos).unwrap());
         // Check that we have 2 spendable (1 is orphaned)

--- a/full-service/src/db/wallet_db_error.rs
+++ b/full-service/src/db/wallet_db_error.rs
@@ -64,8 +64,8 @@ pub enum WalletDbError {
     /// Insufficient funds from Txos under max_spendable_value: {0}
     InsufficientFundsUnderMaxSpendable(String),
 
-    /// Multiple AccountTxoStatus entries for Txo
-    MultipleStatusesForTxo,
+    /// Invalid argument for query
+    InvalidArgument(String),
 
     /// Unexpected TXO Type: {0}
     UnexpectedTransactionTxoType(String),

--- a/full-service/src/json_rpc/e2e.rs
+++ b/full-service/src/json_rpc/e2e.rs
@@ -3006,6 +3006,32 @@ mod e2e {
         assert_eq!(balance.get("spent_pmob").unwrap(), "0");
         assert_eq!(balance.get("orphaned_pmob").unwrap(), "600000000000000");
 
+        // Verify orphaned txos.
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "get_txos_for_account",
+            "params": {
+                "account_id": *account_id,
+                "status": "txo_status_orphaned"
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        assert_eq!(result["txo_ids"].as_array().unwrap().len(), 2,);
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "get_txos_for_account",
+            "params": {
+                "account_id": *account_id,
+                "status": "txo_status_unspent"
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        assert_eq!(result["txo_ids"].as_array().unwrap().len(), 0);
+
         // Add back next subaddress. Txos are detected as unspent.
         let body = json!({
             "jsonrpc": "2.0",
@@ -3032,6 +3058,32 @@ mod e2e {
         assert_eq!(balance.get("unspent_pmob").unwrap(), "600000000000000");
         assert_eq!(balance.get("spent_pmob").unwrap(), "0");
         assert_eq!(balance.get("orphaned_pmob").unwrap(), "0");
+
+        // Verify unspent txos.
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "get_txos_for_account",
+            "params": {
+                "account_id": *account_id,
+                "status": "txo_status_unspent"
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        assert_eq!(result["txo_ids"].as_array().unwrap().len(), 2,);
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "get_txos_for_account",
+            "params": {
+                "account_id": *account_id,
+                "status": "txo_status_orphaned"
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        assert_eq!(result["txo_ids"].as_array().unwrap().len(), 0);
 
         // Create a second account.
         let body = json!({

--- a/full-service/src/json_rpc/json_rpc_request.rs
+++ b/full-service/src/json_rpc/json_rpc_request.rs
@@ -239,6 +239,7 @@ pub enum JsonCommandRequest {
     },
     get_txos_for_account {
         account_id: String,
+        status: Option<String>,
         offset: Option<String>,
         limit: Option<String>,
     },

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -881,12 +881,13 @@ where
         }
         JsonCommandRequest::get_txos_for_account {
             account_id,
+            status,
             offset,
             limit,
         } => {
             let (o, l) = page_helper(offset, limit)?;
             let txos = service
-                .list_txos(&AccountID(account_id), Some(o), Some(l))
+                .list_txos(&AccountID(account_id), status, Some(o), Some(l))
                 .map_err(format_error)?;
             let txo_map: Map<String, serde_json::Value> = Map::from_iter(
                 txos.iter()

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -412,6 +412,7 @@ mod tests {
             &account.account_id_hex,
             None,
             None,
+            None,
             Some(0),
             &wallet_db.get_conn().unwrap(),
         )
@@ -425,6 +426,7 @@ mod tests {
 
         let txos = Txo::list_for_account(
             &account.account_id_hex,
+            None,
             None,
             None,
             Some(0),

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -340,14 +340,28 @@ where
         let max_spendable =
             Txo::list_spendable(account_id_hex, None, assigned_subaddress_b58, Some(0), conn)?
                 .max_spendable_in_wallet;
-        let unspent = Txo::list_unspent(account_id_hex, assigned_subaddress_b58, Some(0), conn)?
-            .iter()
-            .map(|t| (t.value as u64) as u128)
-            .sum::<u128>();
-        let spent = Txo::list_spent(account_id_hex, assigned_subaddress_b58, Some(0), conn)?
-            .iter()
-            .map(|t| (t.value as u64) as u128)
-            .sum::<u128>();
+        let unspent = Txo::list_unspent(
+            account_id_hex,
+            assigned_subaddress_b58,
+            Some(0),
+            None,
+            None,
+            conn,
+        )?
+        .iter()
+        .map(|t| (t.value as u64) as u128)
+        .sum::<u128>();
+        let spent = Txo::list_spent(
+            account_id_hex,
+            assigned_subaddress_b58,
+            Some(0),
+            None,
+            None,
+            conn,
+        )?
+        .iter()
+        .map(|t| (t.value as u64) as u128)
+        .sum::<u128>();
         let pending = Txo::list_pending(account_id_hex, assigned_subaddress_b58, Some(0), conn)?
             .iter()
             .map(|t| (t.value as u64) as u128)

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -362,15 +362,22 @@ where
         .iter()
         .map(|t| (t.value as u64) as u128)
         .sum::<u128>();
-        let pending = Txo::list_pending(account_id_hex, assigned_subaddress_b58, Some(0), conn)?
-            .iter()
-            .map(|t| (t.value as u64) as u128)
-            .sum::<u128>();
+        let pending = Txo::list_pending(
+            account_id_hex,
+            assigned_subaddress_b58,
+            Some(0),
+            None,
+            None,
+            conn,
+        )?
+        .iter()
+        .map(|t| (t.value as u64) as u128)
+        .sum::<u128>();
 
         let secreted = if assigned_subaddress_b58.is_some() {
             0
         } else {
-            Txo::list_secreted(account_id_hex, Some(0), conn)?
+            Txo::list_secreted(account_id_hex, Some(0), None, None, conn)?
                 .iter()
                 .map(|t| t.value as u128)
                 .sum::<u128>()
@@ -379,7 +386,7 @@ where
         let orphaned = if assigned_subaddress_b58.is_some() {
             0
         } else {
-            Txo::list_orphaned(account_id_hex, Some(0), conn)?
+            Txo::list_orphaned(account_id_hex, Some(0), None, None, conn)?
                 .iter()
                 .map(|t| t.value as u128)
                 .sum::<u128>()

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -418,7 +418,7 @@ mod tests {
 
         // Get corresponding Txo for Bob
         let txos = service
-            .list_txos(&AccountID(bob.account_id_hex), None, None)
+            .list_txos(&AccountID(bob.account_id_hex), None, None, None)
             .expect("Could not get Bob Txos");
         assert_eq!(txos.len(), 1);
 

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -655,7 +655,7 @@ mod tests {
         let expected_value = 15_625_000 * MOB;
 
         let txos = service
-            .list_txos(&AccountID::from(&account_key), None, None)
+            .list_txos(&AccountID::from(&account_key), None, None, None)
             .unwrap();
 
         for txo in txos {

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -820,6 +820,8 @@ mod tests {
             &AccountID::from(&account_key).to_string(),
             None,
             Some(0),
+            None,
+            None,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -868,6 +868,7 @@ mod tests {
             &AccountID::from(&account_key).to_string(),
             None,
             None,
+            None,
             Some(0),
             &wallet_db.get_conn().unwrap(),
         )

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -129,6 +129,8 @@ where
             &account_id.to_string(),
             None,
             Some(0),
+            None,
+            None,
             &conn,
         )?)
     }

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -75,6 +75,7 @@ pub trait TxoService {
     fn list_txos(
         &self,
         account_id: &AccountID,
+        status: Option<String>,
         limit: Option<u64>,
         offset: Option<u64>,
     ) -> Result<Vec<Txo>, TxoServiceError>;
@@ -107,12 +108,14 @@ where
     fn list_txos(
         &self,
         account_id: &AccountID,
+        status: Option<String>,
         limit: Option<u64>,
         offset: Option<u64>,
     ) -> Result<Vec<Txo>, TxoServiceError> {
         let conn = self.wallet_db.get_conn()?;
         Ok(Txo::list_for_account(
             &account_id.to_string(),
+            status,
             limit,
             offset,
             Some(0),
@@ -245,7 +248,9 @@ mod tests {
         assert_eq!(balance.unspent, 100 * MOB as u128);
 
         // Verify that we have 1 txo
-        let txos = service.list_txos(&alice_account_id, None, None).unwrap();
+        let txos = service
+            .list_txos(&alice_account_id, None, None, None)
+            .unwrap();
         assert_eq!(txos.len(), 1);
 
         // Add another account
@@ -284,7 +289,7 @@ mod tests {
         // We should now have 3 txos - one pending, two minted (one of which will be
         // change)
         let txos = service
-            .list_txos(&AccountID(alice.account_id_hex.clone()), None, None)
+            .list_txos(&AccountID(alice.account_id_hex.clone()), None, None, None)
             .unwrap();
         assert_eq!(txos.len(), 3);
         assert_eq!(

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -634,6 +634,7 @@ pub fn random_account_with_seed_values(
                 &AccountID::from(&account_key).to_string(),
                 None,
                 None,
+                None,
                 Some(0),
                 &wallet_db.get_conn().unwrap(),
             )


### PR DESCRIPTION
### Motivation

Allow users to query for txos with a specific status.

### In this PR
* Add optional status field to get txos query
* Inside of get txos db model fn, route query to appropriate fn based on status argument.
* Update txo db model queries to use optional pagination args


