### PR TITLE
Release 1.9.x Remove non-mob-tokens from queries

### DIFF
--- a/full-service/src/db/view_only_txo.rs
+++ b/full-service/src/db/view_only_txo.rs
@@ -589,13 +589,14 @@ impl ViewOnlyTxoModel for ViewOnlyTxo {
         conn: &Conn,
     ) -> Result<Vec<TxOut>, WalletDbError> {
         use schema::view_only_txos::dsl::{
-            key_image as dsl_key_image, subaddress_index as dsl_subaddress_index,
+            key_image as dsl_key_image, subaddress_index as dsl_subaddress_index, token_id,
             view_only_account_id_hex as dsl_account_id,
         };
 
         let txos: Vec<ViewOnlyTxo> = schema::view_only_txos::table
             .filter(dsl_account_id.eq(account_id_hex))
             .filter(dsl_key_image.is_null().or(dsl_subaddress_index.is_null()))
+            .filter(token_id.eq(0))
             .load(conn)?;
 
         let mut txouts: Vec<TxOut> = Vec::new();


### PR DESCRIPTION
Update queries for transaction logs to remove logs + txos for non-mob-tokens from results.

Update the one VO txo query that didn't already filter out non-mob-tokens.

Went through all other models and services to make sure that queries that return/relate to txos filter out non-mob-tokens.

Did not change sync logic. figured that queries involved in sync should still apply to non-mob-tokens

