### PR TITLE
assigns new change subaddress on startup if missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "mc-full-service"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-full-service"
-version = "1.9.1"
+version = "1.9.2"
 authors = ["MobileCoin"]
 edition = "2018"
 build = "build.rs"

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -13,6 +13,7 @@ use mc_fog_report_validation::FogResolver;
 use mc_full_service::{
     check_host,
     config::APIConfig,
+    service::address::AddressService,
     wallet::{consensus_backed_rocket, validator_backed_rocket, APIKeyState, WalletState},
     ValidatorLedgerSyncThread, WalletDb, WalletService,
 };
@@ -102,7 +103,8 @@ fn consensus_backed_full_service(
     // Verifier
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
+    mr_signer_verifier
+        .allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
@@ -163,6 +165,11 @@ fn consensus_backed_full_service(
         config.offline,
         logger,
     );
+
+    service
+        .assign_missing_reserved_subaddresses_for_accounts()
+        .unwrap();
+
     let state = WalletState { service };
 
     let rocket = consensus_backed_rocket(rocket_config, state);
@@ -250,6 +257,11 @@ fn validator_backed_full_service(
         false,
         logger,
     );
+
+    service
+        .assign_missing_reserved_subaddresses_for_accounts()
+        .unwrap();
+
     let state = WalletState { service };
 
     let rocket = validator_backed_rocket(rocket_config, state);

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -93,7 +93,9 @@ impl APIConfig {
         self.fog_ingest_enclave_css.as_ref().map(|signature| {
             let mr_signer_verifier = {
                 let mut mr_signer_verifier = MrSignerVerifier::from(signature);
-                mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
+                mr_signer_verifier.allow_hardening_advisories(
+                    mc_consensus_enclave_measurement::HARDENING_ADVISORIES,
+                );
                 mr_signer_verifier
             };
 

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -585,6 +585,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -597,6 +598,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -906,6 +908,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger.clone());
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         // Populate our DB with some received txos in the same block.
         // Do this for two different accounts.
@@ -922,6 +925,7 @@ mod tests {
                 "".to_string(),
                 "".to_string(),
                 "".to_string(),
+                &ledger_db,
                 &wallet_db.get_conn().unwrap(),
             )
             .unwrap();
@@ -1269,6 +1273,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -1281,6 +1286,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1185,6 +1185,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1467,6 +1468,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1520,6 +1522,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -1532,6 +1535,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1635,6 +1639,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -1647,6 +1652,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1698,6 +1704,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -1710,6 +1717,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1768,6 +1776,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1833,6 +1842,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -1964,6 +1974,8 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -1976,6 +1988,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -2015,6 +2028,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -2027,6 +2041,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
@@ -2099,6 +2114,7 @@ mod tests {
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
         let conn = wallet_db.get_conn().unwrap();
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -2111,6 +2127,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &conn,
         )
         .unwrap();
@@ -2147,6 +2164,7 @@ mod tests {
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
         let conn = wallet_db.get_conn().unwrap();
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -2159,6 +2177,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &conn,
         )
         .unwrap();
@@ -2192,6 +2211,7 @@ mod tests {
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
         let conn = wallet_db.get_conn().unwrap();
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -2204,6 +2224,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &conn,
         )
         .unwrap();
@@ -2277,6 +2298,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -2289,6 +2311,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/json_rpc/txo.rs
+++ b/full-service/src/json_rpc/txo.rs
@@ -170,7 +170,7 @@ mod tests {
     use crate::{
         db,
         db::{account::AccountModel, models::Account, txo::TxoModel},
-        test_utils::{create_test_received_txo, WalletDbTestContext, MOB},
+        test_utils::{create_test_received_txo, get_test_ledger, WalletDbTestContext, MOB},
     };
     use mc_account_keys::{AccountKey, RootIdentity};
     use mc_common::logger::{test_with_logger, Logger};
@@ -184,6 +184,7 @@ mod tests {
 
         let db_test_context = WalletDbTestContext::default();
         let wallet_db = db_test_context.get_db_instance(logger);
+        let ledger_db = get_test_ledger(5, &[], 12, &mut rng);
 
         let root_id = RootIdentity::from_random(&mut rng);
         let account_key = AccountKey::from(&root_id);
@@ -196,6 +197,7 @@ mod tests {
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -211,6 +211,7 @@ where
                 fog_report_url,
                 fog_report_id,
                 fog_authority_spki,
+                &self.ledger_db,
                 &conn,
             )?;
             let account = Account::get(&account_id, &conn)?;
@@ -267,6 +268,7 @@ where
                 fog_report_url,
                 fog_report_id,
                 fog_authority_spki,
+                &self.ledger_db,
                 &conn,
             )?)
         })
@@ -307,6 +309,7 @@ where
                 fog_report_url,
                 fog_report_id,
                 fog_authority_spki,
+                &self.ledger_db,
                 &conn,
             )?)
         })

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -605,6 +605,7 @@ pub fn random_account_with_seed_values(
             "".to_string(),
             "".to_string(),
             "".to_string(),
+            &ledger_db,
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();

--- a/validator/service/src/bin/main.rs
+++ b/validator/service/src/bin/main.rs
@@ -35,7 +35,8 @@ fn main() {
     // Create enclave verifier.
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());
-    mr_signer_verifier.allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
+    mr_signer_verifier
+        .allow_hardening_advisories(mc_consensus_enclave_measurement::HARDENING_ADVISORIES);
 
     let mut verifier = Verifier::default();
     verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);


### PR DESCRIPTION
fixes accounts that are migrating from 1.8 -> 1.9+ that are using the legacy change address by auto assigning the new change subaddress, which will collect any orphaned txos sent to that address by transactions made with 1.9+