### PR TITLE
Update AssignedAddress db schema and JSON model

### DIFF
--- a/full-service/migrations/2022-06-13-204000_api_v3/up.sql
+++ b/full-service/migrations/2022-06-13-204000_api_v3/up.sql
@@ -29,18 +29,13 @@ CREATE TABLE txos (
 );
 
 CREATE TABLE assigned_subaddresses (
-  id INTEGER NOT NULL PRIMARY KEY,
-  assigned_subaddress_b58 VARCHAR NOT NULL UNIQUE,
+  public_address_b58 VARCHAR NOT NULL PRIMARY KEY,
   account_id VARCHAR NOT NULL,
-  address_book_entry UNSIGNED BIG INT, -- FIXME: WS-8 add foreign key to address book table, also address_book_entry_id
-  public_address BLOB NOT NULL,
   subaddress_index UNSIGNED BIG INT NOT NULL,
   comment VARCHAR NOT NULL DEFAULT '',
-  subaddress_spend_key BLOB NOT NULL,
+  spend_public_key BLOB NOT NULL,
   FOREIGN KEY (account_id) REFERENCES accounts(id)
 );
-
-CREATE UNIQUE INDEX idx_assigned_subaddresses__assigned_subaddress_b58 ON assigned_subaddresses (assigned_subaddress_b58);
 
 CREATE TABLE transaction_logs (
     id VARCHAR NOT NULL PRIMARY KEY,

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -308,35 +308,21 @@ impl AccountModel for Account {
             .values(&new_account)
             .execute(conn)?;
 
-        let main_subaddress_b58 = AssignedSubaddress::create(
-            account_key,
-            None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
-                   * always for main? */
-            DEFAULT_SUBADDRESS_INDEX,
-            "Main",
-            conn,
-        )?;
+        let main_subaddress_b58 =
+            AssignedSubaddress::create(account_key, DEFAULT_SUBADDRESS_INDEX, "Main", conn)?;
 
-        AssignedSubaddress::create(
-            account_key,
-            None, /* FIXME: WS-8 - Address Book Entry if details provided, or None
-                   * always for main? */
-            CHANGE_SUBADDRESS_INDEX,
-            "Change",
-            conn,
-        )?;
+        AssignedSubaddress::create(account_key, CHANGE_SUBADDRESS_INDEX, "Change", conn)?;
 
         if !fog_enabled {
             AssignedSubaddress::create(
                 account_key,
-                None,
                 LEGACY_CHANGE_SUBADDRESS_INDEX,
                 "Legacy Change",
                 conn,
             )?;
 
-            for subaddress_index in 2..next_subaddress_index {
-                AssignedSubaddress::create(account_key, None, subaddress_index as u64, "", conn)?;
+            for subaddress_index in DEFAULT_NEXT_SUBADDRESS_INDEX..next_subaddress_index as u64 {
+                AssignedSubaddress::create(account_key, subaddress_index as u64, "", conn)?;
             }
         }
 
@@ -432,7 +418,6 @@ impl AccountModel for Account {
 
         AssignedSubaddress::create_for_view_only_account(
             &view_account_key,
-            None,
             DEFAULT_SUBADDRESS_INDEX,
             "Main",
             conn,
@@ -440,7 +425,6 @@ impl AccountModel for Account {
 
         AssignedSubaddress::create_for_view_only_account(
             &view_account_key,
-            None,
             LEGACY_CHANGE_SUBADDRESS_INDEX,
             "Legacy Change",
             conn,
@@ -448,16 +432,14 @@ impl AccountModel for Account {
 
         AssignedSubaddress::create_for_view_only_account(
             &view_account_key,
-            None,
             CHANGE_SUBADDRESS_INDEX,
             "Change",
             conn,
         )?;
 
-        for subaddress_index in 2..next_subaddress_index {
+        for subaddress_index in DEFAULT_NEXT_SUBADDRESS_INDEX..next_subaddress_index as u64 {
             AssignedSubaddress::create_for_view_only_account(
                 &view_account_key,
-                None,
                 subaddress_index as u64,
                 "",
                 conn,

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -108,30 +108,25 @@ pub struct NewTxo<'a> {
 /// funds received from that contact.
 #[derive(Clone, Serialize, Associations, Identifiable, Queryable, PartialEq, Debug)]
 #[belongs_to(Account, foreign_key = "account_id")]
-#[primary_key(id)]
+#[primary_key(public_address_b58)]
 #[table_name = "assigned_subaddresses"]
 pub struct AssignedSubaddress {
-    pub id: i32,
-    pub assigned_subaddress_b58: String,
+    pub public_address_b58: String,
     pub account_id: String,
-    pub address_book_entry: Option<i64>,
-    pub public_address: Vec<u8>,
     pub subaddress_index: i64,
-    pub comment: String,               // empty string for nullable
-    pub subaddress_spend_key: Vec<u8>, // FIXME: WS-28 - Index on subaddress_spend_key?
+    pub comment: String,
+    pub spend_public_key: Vec<u8>,
 }
 
 /// A structure that can be inserted to create a new AssignedSubaddress entity.
 #[derive(Insertable)]
 #[table_name = "assigned_subaddresses"]
 pub struct NewAssignedSubaddress<'a> {
-    pub assigned_subaddress_b58: &'a str,
+    pub public_address_b58: &'a str,
     pub account_id: &'a str,
-    pub address_book_entry: Option<i64>,
-    pub public_address: &'a [u8],
     pub subaddress_index: i64,
     pub comment: &'a str,
-    pub subaddress_spend_key: &'a [u8],
+    pub spend_public_key: &'a [u8],
 }
 
 /// The status of a sent transaction OR a received transaction output.

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -14,15 +14,12 @@ table! {
 }
 
 table! {
-    assigned_subaddresses (id) {
-        id -> Integer,
-        assigned_subaddress_b58 -> Text,
+    assigned_subaddresses (public_address_b58) {
+        public_address_b58 -> Text,
         account_id -> Text,
-        address_book_entry -> Nullable<BigInt>,
-        public_address -> Binary,
         subaddress_index -> BigInt,
         comment -> Text,
-        subaddress_spend_key -> Binary,
+        spend_public_key -> Binary,
     }
 }
 

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -459,7 +459,7 @@ where
                     .iter()
                     .map(|a| {
                         (
-                            a.assigned_subaddress_b58.clone(),
+                            a.public_address_b58.clone(),
                             serde_json::to_value(&(Address::from(a)))
                                 .expect("Could not get json value"),
                         )
@@ -470,7 +470,7 @@ where
             JsonCommandResponse::get_addresses_for_account {
                 public_addresses: addresses
                     .iter()
-                    .map(|a| a.assigned_subaddress_b58.clone())
+                    .map(|a| a.public_address_b58.clone())
                     .collect(),
                 address_map,
             }

--- a/full-service/src/json_rpc/v1/models/address.rs
+++ b/full-service/src/json_rpc/v1/models/address.rs
@@ -37,7 +37,7 @@ impl From<&AssignedSubaddress> for Address {
     fn from(src: &AssignedSubaddress) -> Address {
         Address {
             object: "address".to_string(),
-            public_address: src.assigned_subaddress_b58.clone(),
+            public_address: src.public_address_b58.clone(),
             account_id: src.account_id.clone(),
             metadata: src.comment.clone(),
             subaddress_index: (src.subaddress_index as u64).to_string(),

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -428,14 +428,14 @@ where
             let address_map = AddressMap(
                 addresses
                     .iter()
-                    .map(|a| (a.assigned_subaddress_b58.clone(), Address::from(a)))
+                    .map(|a| (a.public_address_b58.clone(), Address::from(a)))
                     .collect(),
             );
 
             JsonCommandResponse::get_addresses {
                 public_addresses: addresses
                     .iter()
-                    .map(|a| a.assigned_subaddress_b58.clone())
+                    .map(|a| a.public_address_b58.clone())
                     .collect(),
                 address_map,
             }

--- a/full-service/src/json_rpc/v2/e2e_tests/account/account_address.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/account/account_address.rs
@@ -50,7 +50,7 @@ mod e2e_account {
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
         let address = result.get("address").unwrap();
-        let b58_public_address = address.get("public_address").unwrap().as_str().unwrap();
+        let b58_public_address = address.get("public_address_b58").unwrap().as_str().unwrap();
         let public_address = b58_decode_public_address(b58_public_address).unwrap();
 
         // Add a block to fund account at the new subaddress.
@@ -359,7 +359,7 @@ mod e2e_account {
         let b58_public_address = result
             .get("address")
             .unwrap()
-            .get("public_address")
+            .get("public_address_b58")
             .unwrap()
             .as_str()
             .unwrap();

--- a/full-service/src/json_rpc/v2/e2e_tests/account/account_balance.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/account/account_balance.rs
@@ -148,7 +148,7 @@ mod e2e_account {
         let from_bob_b58_public_address = result
             .get("address")
             .unwrap()
-            .get("public_address")
+            .get("public_address_b58")
             .unwrap()
             .as_str()
             .unwrap();

--- a/full-service/src/json_rpc/v2/e2e_tests/account/account_other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/account/account_other.rs
@@ -382,7 +382,7 @@ mod e2e_account {
         let b58_public_address = result
             .get("address")
             .unwrap()
-            .get("public_address")
+            .get("public_address_b58")
             .unwrap()
             .as_str()
             .unwrap();
@@ -612,7 +612,7 @@ mod e2e_account {
         let from_bob_b58_public_address = result
             .get("address")
             .unwrap()
-            .get("public_address")
+            .get("public_address_b58")
             .unwrap()
             .as_str()
             .unwrap();

--- a/full-service/src/json_rpc/v2/e2e_tests/account/create_import/import_account.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/account/create_import/import_account.rs
@@ -288,7 +288,7 @@ mod e2e_account {
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
         let address = result.get("address").unwrap();
-        let b58_public_address = address.get("public_address").unwrap().as_str().unwrap();
+        let b58_public_address = address.get("public_address_b58").unwrap().as_str().unwrap();
         let public_address = b58_decode_public_address(b58_public_address).unwrap();
 
         // Add a block to fund account at the new subaddress.

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/transaction_txo.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/transaction_txo.rs
@@ -275,7 +275,7 @@ mod e2e_transaction {
         let res = dispatch(&client, body, &logger);
         let result = res.get("result").unwrap();
         let address = result.get("address").unwrap();
-        let b58_public_address = address.get("public_address").unwrap().as_str().unwrap();
+        let b58_public_address = address.get("public_address_b58").unwrap().as_str().unwrap();
         let public_address = b58_decode_public_address(b58_public_address).unwrap();
 
         // Add a block to fund account at the new subaddress.

--- a/full-service/src/json_rpc/v2/models/address.rs
+++ b/full-service/src/json_rpc/v2/models/address.rs
@@ -22,7 +22,7 @@ pub struct Address {
     /// A b58 encoding of the public address materials.
     ///
     /// The public_address is the unique identifier for the address.
-    pub public_address: String,
+    pub public_address_b58: String,
 
     /// The account which owns this address.
     pub account_id: String,
@@ -37,7 +37,7 @@ pub struct Address {
 impl From<&AssignedSubaddress> for Address {
     fn from(src: &AssignedSubaddress) -> Address {
         Address {
-            public_address: src.assigned_subaddress_b58.clone(),
+            public_address_b58: src.public_address_b58.clone(),
             account_id: src.account_id.clone(),
             metadata: src.comment.clone(),
             subaddress_index: (src.subaddress_index as u64).to_string(),

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -273,13 +273,13 @@ where
     #[allow(clippy::type_complexity)]
     fn get_balance_inner(
         account_id_hex: Option<&str>,
-        assigned_subaddress_b58: Option<&str>,
+        public_address_b58: Option<&str>,
         token_id: TokenId,
         conn: &Conn,
     ) -> Result<Balance, BalanceServiceError> {
         let unspent = sum_query_result(Txo::list_unspent(
             account_id_hex,
-            assigned_subaddress_b58,
+            public_address_b58,
             Some(*token_id),
             None,
             None,
@@ -290,7 +290,7 @@ where
 
         let spent = sum_query_result(Txo::list_spent(
             account_id_hex,
-            assigned_subaddress_b58,
+            public_address_b58,
             Some(*token_id),
             None,
             None,
@@ -301,7 +301,7 @@ where
 
         let pending = sum_query_result(Txo::list_pending(
             account_id_hex,
-            assigned_subaddress_b58,
+            public_address_b58,
             Some(*token_id),
             None,
             None,
@@ -312,7 +312,7 @@ where
 
         let unverified = sum_query_result(Txo::list_unverified(
             account_id_hex,
-            assigned_subaddress_b58,
+            public_address_b58,
             Some(*token_id),
             None,
             None,
@@ -323,7 +323,7 @@ where
 
         let secreted = 0;
 
-        let orphaned = if assigned_subaddress_b58.is_some() {
+        let orphaned = if public_address_b58.is_some() {
             0
         } else {
             sum_query_result(Txo::list_orphaned(
@@ -337,13 +337,8 @@ where
             )?)
         };
 
-        let spendable_txos_result = Txo::list_spendable(
-            account_id_hex,
-            None,
-            assigned_subaddress_b58,
-            *token_id,
-            conn,
-        )?;
+        let spendable_txos_result =
+            Txo::list_spendable(account_id_hex, None, public_address_b58, *token_id, conn)?;
 
         Ok(Balance {
             max_spendable: spendable_txos_result.max_spendable_in_wallet,
@@ -456,7 +451,7 @@ mod tests {
         assert_eq!(address_balance_pmob.orphaned, 0);
 
         let address_balance2 = service
-            .get_balance_for_address(&address.assigned_subaddress_b58)
+            .get_balance_for_address(&address.public_address_b58)
             .expect("Could not get balance for address");
         let address_balance2_pmob = address_balance2.get(&Mob::ID).unwrap();
         assert_eq!(address_balance2_pmob.unspent, 60_000 * MOB as u128);

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -350,13 +350,13 @@ pub trait GiftCodeService {
 
     /// Execute a transaction from the gift code account to drain the account to
     /// the destination specified by the account_id_hex and
-    /// assigned_subaddress_b58. If no assigned_subaddress_b58 is provided,
+    /// public_address_b58. If no public_address_b58 is provided,
     /// then a new AssignedSubaddress will be created to receive the funds.
     fn claim_gift_code(
         &self,
         gift_code_b58: &EncodedGiftCode,
         account_id: &AccountID,
-        assigned_subaddress_b58: Option<String>,
+        public_address_b58: Option<String>,
     ) -> Result<Tx, GiftCodeServiceError>;
 
     fn remove_gift_code(
@@ -572,7 +572,7 @@ where
         &self,
         gift_code_b58: &EncodedGiftCode,
         account_id: &AccountID,
-        assigned_subaddress_b58: Option<String>,
+        public_address_b58: Option<String>,
     ) -> Result<Tx, GiftCodeServiceError> {
         let (status, gift_value, _memo) = self.check_gift_code_status(gift_code_b58)?;
 
@@ -589,14 +589,14 @@ where
         let transfer_payload = decode_transfer_payload(gift_code_b58)?;
         let gift_account_key = transfer_payload.account_key;
 
-        let default_subaddress = if assigned_subaddress_b58.is_some() {
-            assigned_subaddress_b58.ok_or(GiftCodeServiceError::AccountNotFound)
+        let default_subaddress = if public_address_b58.is_some() {
+            public_address_b58.ok_or(GiftCodeServiceError::AccountNotFound)
         } else {
             let address = self.assign_address_for_account(
                 account_id,
                 Some(&json!({"gift_code_memo": transfer_payload.memo}).to_string()),
             )?;
-            Ok(address.assigned_subaddress_b58)
+            Ok(address.public_address_b58)
         }?;
 
         let recipient_public_address = b58_decode_public_address(&default_subaddress)?;

--- a/full-service/src/service/payment_request.rs
+++ b/full-service/src/service/payment_request.rs
@@ -108,8 +108,7 @@ where
             &conn,
         )?;
 
-        let public_address =
-            b58_decode_public_address(&assigned_subaddress.assigned_subaddress_b58)?;
+        let public_address = b58_decode_public_address(&assigned_subaddress.public_address_b58)?;
 
         let payment_request_b58 = b58_encode_payment_request(
             &public_address,

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -376,7 +376,7 @@ mod tests {
         let bob_addresses = service
             .get_addresses(Some(bob.id.clone()), None, None)
             .expect("Could not get addresses for Bob");
-        let bob_address = bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = bob_addresses[0].public_address_b58.clone();
 
         // Create a TxProposal to Bob
         let tx_proposal = service
@@ -502,7 +502,7 @@ mod tests {
         let bob_addresses = service
             .get_addresses(Some(bob.id.clone()), None, None)
             .expect("Could not get addresses for Bob");
-        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = &bob_addresses[0].public_address_b58.clone();
 
         // Create a TxProposal to Bob
         let tx_proposal = service
@@ -624,7 +624,7 @@ mod tests {
         let bob_addresses = service
             .get_addresses(Some(bob.id.clone()), None, None)
             .expect("Could not get addresses for Bob");
-        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = &bob_addresses[0].public_address_b58.clone();
         let bob_account_id = AccountID(bob.id.to_string());
 
         // Create a TxProposal to Bob
@@ -754,7 +754,7 @@ mod tests {
         let bob_addresses = service
             .get_addresses(Some(bob.id.clone()), None, None)
             .expect("Could not get addresses for Bob");
-        let bob_address = &bob_addresses[0].assigned_subaddress_b58.clone();
+        let bob_address = &bob_addresses[0].public_address_b58.clone();
         let bob_account_id = AccountID(bob.id.to_string());
 
         // Create a TxProposal to Bob

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -559,7 +559,7 @@ mod tests {
             .build_transaction(
                 &alice.id,
                 &[(
-                    bob_address_from_alice.assigned_subaddress_b58,
+                    bob_address_from_alice.public_address_b58,
                     AmountJSON::new(42 * MOB, Mob::ID),
                 )],
                 None,
@@ -587,7 +587,7 @@ mod tests {
             .build_transaction(
                 &alice.id,
                 &[(
-                    bob_address_from_alice_2.assigned_subaddress_b58,
+                    bob_address_from_alice_2.public_address_b58,
                     AmountJSON::new(42 * MOB, Mob::ID),
                 )],
                 None,
@@ -615,7 +615,7 @@ mod tests {
             .build_transaction(
                 &alice.id,
                 &[(
-                    bob_address_from_alice_3.clone().assigned_subaddress_b58,
+                    bob_address_from_alice_3.clone().public_address_b58,
                     AmountJSON::new(42 * MOB, Mob::ID),
                 )],
                 None,
@@ -699,7 +699,7 @@ mod tests {
             .build_and_submit(
                 &alice.id,
                 &[(
-                    bob_address_from_alice.assigned_subaddress_b58,
+                    bob_address_from_alice.public_address_b58,
                     AmountJSON::new(42 * MOB, Mob::ID),
                 )],
                 None,

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -211,7 +211,7 @@ mod tests {
                 .build_and_submit(
                     &alice_account_id.to_string(),
                     &[(
-                        address.assigned_subaddress_b58.clone(),
+                        address.public_address_b58.clone(),
                         Amount::new(50 * MOB, Mob::ID),
                     )],
                     None,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -205,7 +205,7 @@ where
         let mut addresses_and_amounts = Vec::new();
         for output_value in output_values.iter() {
             addresses_and_amounts.push((
-                address_to_split_into.assigned_subaddress_b58.clone(),
+                address_to_split_into.public_address_b58.clone(),
                 Amount {
                     value: output_value.to_string(),
                     token_id: txo_details.token_id.to_string(),


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

We were storing duplicate data that didn't need to be stored, and had unnecessary fields.

### In this PR
* Removed address book entry (unused)
* Removed encoded public address (can be obtained from the public address b58)
* Renamed other fields to be more explicit
* Updated model to reflect these changes where necessary

### Future Work
* Remove assigned addresses for reserved subaddresses defined in the mc library (currently default subaddress, change subaddress, and gift code subaddress).

