### PR TITLE
Error report for invalid token network fee and getting max spendable for token

### DIFF
--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -88,6 +88,9 @@ pub enum TransactionServiceError {
 
     /// Invalid Amount: {0}
     InvalidAmount(String),
+
+    /// No default fee found for token id: {0}
+    DefaultFeeNotFoundForToken(TokenId),
 }
 
 impl From<WalletDbError> for TransactionServiceError {
@@ -250,7 +253,9 @@ where
 
             let fee_value = match fee_value {
                 Some(f) => f.parse::<u64>()?,
-                None => self.get_network_fees()[&fee_token_id],
+                None => *self.get_network_fees().get(&fee_token_id).ok_or(
+                    TransactionServiceError::DefaultFeeNotFoundForToken(fee_token_id),
+                )?,
             };
 
             builder.set_fee(fee_value, fee_token_id)?;
@@ -326,7 +331,9 @@ where
 
             let fee_value = match fee_value {
                 Some(f) => f.parse::<u64>()?,
-                None => self.get_network_fees()[&fee_token_id],
+                None => *self.get_network_fees().get(&fee_token_id).ok_or(
+                    TransactionServiceError::DefaultFeeNotFoundForToken(fee_token_id),
+                )?,
             };
 
             builder.set_fee(fee_value, fee_token_id)?;


### PR DESCRIPTION
Now returns an error if the default fee for a selected token cannot be found and isn't provided.

Also updated the max spendable logic to take in a default_token_fee that is specified by the calling function, which will eventually support mixed token transactions