### PR TITLE
Refactor Transaction Building

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -629,7 +629,7 @@ mod tests {
         // Build a transaction
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
         builder
             .add_recipient(recipient.clone(), 50 * MOB, Mob::ID)
             .unwrap();
@@ -787,7 +787,7 @@ mod tests {
         // Build a transaction
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
         // Add outlays all to the same recipient, so that we exceed u64::MAX in this tx
         let value = 100 * MOB - Mob::MINIMUM_FEE;
         builder
@@ -870,7 +870,7 @@ mod tests {
         // Build a transaction
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
         builder
             .add_recipient(recipient.clone(), 50 * MOB, Mob::ID)
             .unwrap();
@@ -969,7 +969,7 @@ mod tests {
         // Build a transaction for > i64::Max
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
         builder
             .add_recipient(recipient.clone(), 10_000_000 * MOB, Mob::ID)
             .unwrap();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1408,15 +1408,14 @@ mod tests {
         },
         service::{
             sync::{sync_account, SyncThread},
-            transaction::{TransactionMemo, TransactionService},
+            transaction::TransactionMemo,
             transaction_builder::WalletTransactionBuilder,
         },
         test_utils::{
             add_block_with_db_txos, add_block_with_tx, add_block_with_tx_outs,
             create_test_minted_and_change_txos, create_test_received_txo,
             create_test_txo_for_recipient, get_resolver_factory, get_test_ledger,
-            manually_sync_account, random_account_with_seed_values, setup_wallet_service,
-            WalletDbTestContext, MOB,
+            manually_sync_account, random_account_with_seed_values, WalletDbTestContext, MOB,
         },
         WalletDb,
     };
@@ -1527,7 +1526,6 @@ mod tests {
             33 * MOB,
             wallet_db.clone(),
             ledger_db.clone(),
-            logger.clone(),
         );
 
         let associated_txos = transaction_log
@@ -1744,7 +1742,6 @@ mod tests {
             72 * MOB,
             wallet_db.clone(),
             ledger_db.clone(),
-            logger.clone(),
         );
 
         let associated_txos = transaction_log
@@ -2084,7 +2081,6 @@ mod tests {
             1 * MOB,
             wallet_db.clone(),
             ledger_db,
-            logger,
         );
 
         let associated_txos = transaction_log
@@ -2110,7 +2106,6 @@ mod tests {
         let wallet_db = db_test_context.get_db_instance(logger.clone());
         let known_recipients: Vec<PublicAddress> = Vec::new();
         let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
-        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
 
         // The account which will receive the Txo
         log::info!(logger, "Creating account");

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -51,7 +51,6 @@ use crate::{
         PrintableWrapperType,
     },
 };
-use mc_account_keys::AccountKey;
 use mc_common::logger::global_log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -51,6 +51,7 @@ use crate::{
         PrintableWrapperType,
     },
 };
+use mc_account_keys::AccountKey;
 use mc_common::logger::global_log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
@@ -157,8 +158,9 @@ where
                     )
                 })
                 .collect();
-            let (transaction_log, associated_txos, _value_map, tx_proposal) = service
-                .build_and_submit(
+
+            let (unsigned_tx, fog_resolver) = service
+                .build_unsigned_transaction(
                     &account_id,
                     &addresses_and_amounts,
                     input_txo_ids.as_ref(),
@@ -166,14 +168,33 @@ where
                     Some(Mob::ID.to_string()),
                     tombstone_block,
                     max_spendable_value,
-                    comment,
+                    TransactionMemo::RTH,
                 )
                 .map_err(format_error)?;
+
+            let account = service
+                .get_account(&AccountID(account_id.clone()))
+                .map_err(format_error)?;
+            let account_key: AccountKey =
+                mc_util_serial::decode(&account.account_key).map_err(format_error)?;
+
+            let tx_proposal = unsigned_tx
+                .sign(&account_key, fog_resolver)
+                .map_err(format_error)?;
+
+            let transaction_log = service
+                .submit_transaction(&tx_proposal, comment, Some(account_id))
+                .map_err(format_error)?
+                .map(|(transaction_log, associated_txos, _)| {
+                    json_rpc::v1::models::transaction_log::TransactionLog::new(
+                        &transaction_log,
+                        &associated_txos,
+                    )
+                })
+                .ok_or(format_error(""))?;
+
             JsonCommandResponse::build_and_submit_transaction {
-                transaction_log: json_rpc::v1::models::transaction_log::TransactionLog::new(
-                    &transaction_log,
-                    &associated_txos,
-                ),
+                transaction_log,
                 tx_proposal: TxProposal::try_from(&tx_proposal).map_err(format_error)?,
             }
         }
@@ -266,8 +287,8 @@ where
                 })
                 .collect();
 
-            let tx_proposal = service
-                .build_transaction(
+            let (unsigned_tx, fog_resolver) = service
+                .build_unsigned_transaction(
                     &account_id,
                     &addresses_and_amounts,
                     input_txo_ids.as_ref(),
@@ -275,9 +296,18 @@ where
                     Some(Mob::ID.to_string()),
                     tombstone_block,
                     max_spendable_value,
-                    None,
                     TransactionMemo::RTH,
                 )
+                .map_err(format_error)?;
+
+            let account = service
+                .get_account(&AccountID(account_id.clone()))
+                .map_err(format_error)?;
+            let account_key: AccountKey =
+                mc_util_serial::decode(&account.account_key).map_err(format_error)?;
+
+            let tx_proposal = unsigned_tx
+                .sign(&account_key, fog_resolver)
                 .map_err(format_error)?;
 
             JsonCommandResponse::build_transaction {

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -170,7 +170,6 @@ pub fn setup_with_api_key(
 pub fn dispatch(client: &Client, request_body: JsonValue, logger: &Logger) -> JsonValue {
     log::info!(logger, "Attempting dispatch of\n{:?}\n", request_body,);
     let request_body = request_body.to_string();
-    log::info!(logger, "Attempting dispatch of\n{}\n", request_body,);
 
     let mut res = client
         .post("/wallet/v2")

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -48,7 +48,7 @@ use crate::{
         PrintableWrapperType,
     },
 };
-use mc_account_keys::{burn_address, AccountKey};
+use mc_account_keys::burn_address;
 use mc_common::logger::global_log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -431,7 +431,7 @@ where
 
         let fee_value = fee.map(|f| f.to_string());
 
-        let (unsigned_tx, fog_resolver) = self.build_unsigned_transaction(
+        let (unsigned_tx, fog_resolver) = self.build_transaction(
             &from_account.id,
             &[(
                 gift_code_account_main_subaddress_b58,

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -14,6 +14,7 @@ use crate::{
         models::{Account, GiftCode},
         transaction, WalletDbError,
     },
+    error::WalletTransactionBuilderError,
     service::{
         account::AccountServiceError,
         address::{AddressService, AddressServiceError},
@@ -154,6 +155,9 @@ pub enum GiftCodeServiceError {
 
     /// Amount Error: {0}
     Amount(mc_transaction_core::AmountError),
+
+    /// Wallet Transaction Builder Error: {0}
+    WalletTransactionBuilder(WalletTransactionBuilderError),
 }
 
 impl From<WalletDbError> for GiftCodeServiceError {
@@ -249,6 +253,12 @@ impl From<AddressServiceError> for GiftCodeServiceError {
 impl From<mc_transaction_core::AmountError> for GiftCodeServiceError {
     fn from(src: mc_transaction_core::AmountError) -> Self {
         Self::Amount(src)
+    }
+}
+
+impl From<WalletTransactionBuilderError> for GiftCodeServiceError {
+    fn from(src: WalletTransactionBuilderError) -> Self {
+        Self::WalletTransactionBuilder(src)
     }
 }
 
@@ -421,7 +431,7 @@ where
 
         let fee_value = fee.map(|f| f.to_string());
 
-        let tx_proposal = self.build_transaction(
+        let (unsigned_tx, fog_resolver) = self.build_unsigned_transaction(
             &from_account.id,
             &[(
                 gift_code_account_main_subaddress_b58,
@@ -435,9 +445,11 @@ where
             None,
             tombstone_block.map(|t| t.to_string()),
             max_spendable_value.map(|f| f.to_string()),
-            None,
             TransactionMemo::RTH,
         )?;
+
+        let account_key: AccountKey = mc_util_serial::decode(&from_account.account_key)?;
+        let tx_proposal = unsigned_tx.sign(&account_key, fog_resolver)?;
 
         if tx_proposal.payload_txos.len() != 1 {
             return Err(GiftCodeServiceError::UnexpectedTxProposalFormat);

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -383,10 +383,9 @@ mod tests {
 
         // Create a TxProposal to Bob
         let tx_proposal = service
-            .build_transaction(
+            .build_and_sign_transaction(
                 &alice.id,
                 &vec![(bob_address.to_string(), AmountJSON::new(24 * MOB, Mob::ID))],
-                None,
                 None,
                 None,
                 None,
@@ -510,10 +509,9 @@ mod tests {
 
         // Create a TxProposal to Bob
         let tx_proposal = service
-            .build_transaction(
+            .build_and_sign_transaction(
                 &alice.id,
                 &vec![(bob_address.to_string(), AmountJSON::new(24 * MOB, Mob::ID))],
-                None,
                 None,
                 None,
                 None,
@@ -634,10 +632,9 @@ mod tests {
 
         // Create a TxProposal to Bob
         let tx_proposal0 = service
-            .build_transaction(
+            .build_and_sign_transaction(
                 &alice.id,
                 &vec![(bob_address.to_string(), AmountJSON::new(24 * MOB, Mob::ID))],
-                None,
                 None,
                 None,
                 None,
@@ -765,10 +762,9 @@ mod tests {
 
         // Create a TxProposal to Bob
         let tx_proposal0 = service
-            .build_transaction(
+            .build_and_sign_transaction(
                 &alice.id,
                 &vec![(bob_address.to_string(), AmountJSON::new(24 * MOB, Mob::ID))],
-                None,
                 None,
                 None,
                 None,

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -19,7 +19,7 @@ use crate::{
     util::b58::{b58_decode_public_address, B58Error},
 };
 use mc_account_keys::AccountKey;
-use mc_common::logger::{log, slog::debug};
+use mc_common::logger::log;
 use mc_connection::{BlockchainConnection, RetryableUserTxConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -18,37 +18,25 @@ use crate::{
     },
     error::WalletTransactionBuilderError,
     fog_resolver::{FullServiceFogResolver, FullServiceFullyValidatedFogPubkey},
-    service::{
-        models::tx_proposal::{InputTxo, OutputTxo, TxProposal},
-        transaction::TransactionMemo,
-    },
+    service::transaction::TransactionMemo,
     unsigned_tx::UnsignedTx,
     util::b58::b58_encode_public_address,
 };
-use mc_account_keys::{AccountKey, PublicAddress};
-use mc_common::{
-    logger::{log, Logger},
-    HashMap, HashSet,
-};
-use mc_crypto_keys::RistrettoPublic;
-use mc_crypto_ring_signature_signer::NoKeysRingSigner;
+use mc_account_keys::PublicAddress;
+use mc_common::{HashMap, HashSet};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
     constants::RING_SIZE,
-    onetime_keys::recover_onetime_private_key,
-    ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxIn, TxOut, TxOutMembershipProof},
-    Amount, BlockVersion, Token, TokenId,
+    BlockVersion, Token, TokenId,
 };
-use mc_transaction_std::{
-    EmptyMemoBuilder, InputCredentials, MemoBuilder, ReservedSubaddresses, TransactionBuilder,
-};
+
 use mc_util_uri::FogUri;
 
 use rand::Rng;
-use std::{collections::BTreeMap, convert::TryFrom, str::FromStr, sync::Arc};
+use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
 /// Default number of blocks used for calculating transaction tombstone block
 /// number.
@@ -83,9 +71,6 @@ pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {
     /// This is abstracted because in tests, we don't want to form grpc
     /// connections to fog.
     fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
-
-    /// Logger.
-    logger: Logger,
 }
 
 impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
@@ -93,7 +78,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
         account_id_hex: String,
         ledger_db: LedgerDB,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync + 'static>,
-        logger: Logger,
     ) -> Self {
         WalletTransactionBuilder {
             account_id_hex,
@@ -104,7 +88,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             fee: None,
             block_version: None,
             fog_resolver_factory,
-            logger,
         }
     }
 
@@ -396,309 +379,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             tombstone_block_index: self.tombstone,
             block_version: self.block_version.unwrap_or(BlockVersion::MAX),
             memo,
-        })
-    }
-
-    /// Consumes self
-    pub fn build(
-        &self,
-        memo_builder: Option<Box<dyn MemoBuilder + 'static + Send + Sync>>,
-        conn: &Conn,
-    ) -> Result<TxProposal, WalletTransactionBuilderError> {
-        if self.inputs.is_empty() {
-            return Err(WalletTransactionBuilderError::NoInputs);
-        }
-
-        if self.tombstone == 0 {
-            return Err(WalletTransactionBuilderError::TombstoneNotSet);
-        }
-
-        let account: Account = Account::get(&AccountID(self.account_id_hex.to_string()), conn)?;
-        let from_account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
-
-        // Collect all required FogUris from public addresses, then pass to resolver
-        // factory
-        let fog_resolver = {
-            let change_address = from_account_key.change_subaddress();
-            let fog_uris = core::slice::from_ref(&change_address)
-                .iter()
-                .chain(
-                    self.outlays
-                        .iter()
-                        .map(|(receiver, _amount, _token_id)| receiver),
-                )
-                .filter_map(|x| extract_fog_uri(x).transpose())
-                .collect::<Result<Vec<_>, _>>()?;
-            (self.fog_resolver_factory)(&fog_uris)
-                .map_err(WalletTransactionBuilderError::FogPubkeyResolver)?
-        };
-
-        // Create transaction builder.
-        let block_version = self.block_version.unwrap_or(BlockVersion::MAX);
-        let (fee, token_id) = self.fee.unwrap_or((Mob::MINIMUM_FEE, Mob::ID));
-        let fee = Amount::new(fee, token_id);
-        let memo_builder: Box<dyn MemoBuilder + Send + Sync> =
-            memo_builder.unwrap_or_else(|| Box::new(EmptyMemoBuilder::default()));
-        let mut transaction_builder =
-            TransactionBuilder::new_with_box(block_version, fee, fog_resolver, memo_builder)?;
-
-        // Get membership proofs for our inputs
-        let indexes = self
-            .inputs
-            .iter()
-            .map(|utxo| {
-                let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
-                self.ledger_db.get_tx_out_index_by_hash(&txo.hash())
-            })
-            .collect::<Result<Vec<u64>, mc_ledger_db::Error>>()?;
-        let proofs = self.ledger_db.get_tx_out_proof_of_memberships(&indexes)?;
-
-        let inputs_and_proofs: Vec<(Txo, TxOutMembershipProof)> = self
-            .inputs
-            .clone()
-            .into_iter()
-            .zip(proofs.into_iter())
-            .collect();
-
-        let excluded_tx_out_indices: Vec<u64> = inputs_and_proofs
-            .iter()
-            .map(|(utxo, _membership_proof)| {
-                let txo: TxOut = mc_util_serial::decode(&utxo.txo)?;
-                self.ledger_db
-                    .get_tx_out_index_by_hash(&txo.hash())
-                    .map_err(WalletTransactionBuilderError::LedgerDB)
-            })
-            .collect::<Result<Vec<u64>, WalletTransactionBuilderError>>()?;
-
-        let rings = self.get_rings(inputs_and_proofs.len(), &excluded_tx_out_indices)?;
-
-        if rings.len() != inputs_and_proofs.len() {
-            return Err(WalletTransactionBuilderError::RingSizeMismatch);
-        }
-
-        if self.outlays.is_empty() {
-            return Err(WalletTransactionBuilderError::NoRecipient);
-        }
-
-        // Unzip each vec of tuples into a tuple of vecs.
-        let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings
-            .into_iter()
-            .map(|tuples| tuples.into_iter().unzip())
-            .collect();
-
-        // Add inputs to the tx.
-        for (utxo, proof) in inputs_and_proofs.iter() {
-            let db_tx_out: TxOut = mc_util_serial::decode(&utxo.txo)?;
-            let (mut ring, mut membership_proofs) = rings_and_proofs
-                .pop()
-                .ok_or(WalletTransactionBuilderError::RingsAndProofsEmpty)?;
-            if ring.len() != membership_proofs.len() {
-                return Err(WalletTransactionBuilderError::RingSizeMismatch);
-            }
-
-            // Add the input to the ring.
-            let position_opt = ring.iter().position(|txo| *txo == db_tx_out);
-            let real_key_index = match position_opt {
-                Some(position) => {
-                    // The input is already present in the ring.
-                    // This could happen if ring elements are sampled randomly from the
-                    // ledger.
-                    position
-                }
-                None => {
-                    // The input is not already in the ring.
-                    if ring.is_empty() {
-                        // Append the input and its proof of membership.
-                        ring.push(db_tx_out.clone());
-                        membership_proofs.push(proof.clone());
-                    } else {
-                        // Replace the first element of the ring.
-                        ring[0] = db_tx_out.clone();
-                        membership_proofs[0] = proof.clone();
-                    }
-                    // The real input is always the first element. This is safe because
-                    // TransactionBuilder sorts each ring.
-                    0
-                }
-            };
-
-            if ring.len() != membership_proofs.len() {
-                return Err(WalletTransactionBuilderError::RingSizeMismatch);
-            }
-
-            let public_key = RistrettoPublic::try_from(&db_tx_out.public_key).unwrap();
-
-            let subaddress_index = if let Some(s) = utxo.subaddress_index {
-                s
-            } else {
-                return Err(WalletTransactionBuilderError::NullSubaddress(
-                    utxo.id.to_string(),
-                ));
-            };
-
-            let onetime_private_key = recover_onetime_private_key(
-                &public_key,
-                from_account_key.view_private_key(),
-                &from_account_key.subaddress_spend_private(subaddress_index as u64),
-            );
-
-            let key_image = KeyImage::from(&onetime_private_key);
-            log::debug!(
-                self.logger,
-                "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}",
-                ring,
-                real_key_index,
-                key_image,
-                public_key
-            );
-
-            transaction_builder.add_input(InputCredentials::new(
-                ring,
-                membership_proofs,
-                real_key_index,
-                onetime_private_key,
-                *from_account_key.view_private_key(),
-            )?);
-        }
-
-        // Add outputs to our destinations.
-        // Note that we make an assumption currently when logging submitted Txos that
-        // they were built  with only one recip ient, and one change txo.
-        let mut total_value_per_token: BTreeMap<TokenId, u64> = BTreeMap::new();
-        total_value_per_token.insert(
-            transaction_builder.get_fee_token_id(),
-            transaction_builder.get_fee(),
-        );
-        let mut payload_txos: Vec<OutputTxo> = Vec::new();
-        let mut change_txos: Vec<OutputTxo> = Vec::new();
-        let mut tx_out_to_outlay_index: HashMap<TxOut, usize> = HashMap::default();
-        let mut outlay_confirmation_numbers = Vec::default();
-        let mut rng = rand::thread_rng();
-        for (i, (recipient, out_value, token_id)) in self.outlays.iter().enumerate() {
-            let amount = Amount::new(*out_value, *token_id);
-
-            let tx_out_context = transaction_builder.add_output(amount, recipient, &mut rng)?;
-
-            payload_txos.push(OutputTxo {
-                tx_out: tx_out_context.tx_out.clone(),
-                recipient_public_address: recipient.clone(),
-                confirmation_number: tx_out_context.confirmation.clone(),
-                amount,
-            });
-
-            tx_out_to_outlay_index.insert(tx_out_context.tx_out, i);
-            outlay_confirmation_numbers.push(tx_out_context.confirmation);
-
-            total_value_per_token
-                .entry(*token_id)
-                .and_modify(|v| *v += *out_value)
-                .or_insert(*out_value);
-        }
-
-        // Figure out if we have change.
-        let input_value_per_token =
-            inputs_and_proofs
-                .iter()
-                .fold(BTreeMap::new(), |mut acc, (utxo, _proof)| {
-                    acc.entry(TokenId::from(utxo.token_id as u64))
-                        .and_modify(|v| *v += utxo.value as u64)
-                        .or_insert(utxo.value as u64);
-                    acc
-                });
-
-        for (token_id, total_value) in total_value_per_token.iter() {
-            let input_value = input_value_per_token.get(token_id).ok_or_else(|| {
-                WalletTransactionBuilderError::MissingInputsForTokenId(token_id.to_string())
-            })?;
-            if total_value > input_value {
-                return Err(WalletTransactionBuilderError::InsufficientInputFunds(
-                    format!(
-                        "Total value required to send transaction {:?}, but only {:?} in inputs for token_id {:?}",
-                        total_value,
-                        input_value,
-                        token_id.to_string()
-                    ),
-                ));
-            }
-
-            let change_value = input_value - total_value;
-            let change_amount = Amount::new(change_value, *token_id);
-
-            let reserved_subaddresses = ReservedSubaddresses::from(&from_account_key);
-            let tx_out_context = transaction_builder.add_change_output(
-                change_amount,
-                &reserved_subaddresses,
-                &mut rng,
-            )?;
-
-            change_txos.push(OutputTxo {
-                tx_out: tx_out_context.tx_out,
-                recipient_public_address: reserved_subaddresses.change_subaddress,
-                confirmation_number: tx_out_context.confirmation,
-                amount: change_amount,
-            });
-        }
-
-        // Set tombstone block.
-        transaction_builder.set_tombstone_block(self.tombstone);
-
-        // Build tx.
-        let tx = transaction_builder.build(&NoKeysRingSigner {}, &mut rng)?;
-
-        // Map each TxOut in the constructed transaction to its respective outlay.
-        let outlay_index_to_tx_out_index: HashMap<usize, usize> = tx
-            .prefix
-            .outputs
-            .iter()
-            .enumerate()
-            .filter_map(|(tx_out_index, tx_out)| {
-                tx_out_to_outlay_index
-                    .get(tx_out)
-                    .map(|outlay_index| (*outlay_index, tx_out_index))
-            })
-            .collect();
-
-        // Sanity check: All of our outlays should have a unique index in the map.
-        assert_eq!(outlay_index_to_tx_out_index.len(), self.outlays.len());
-        let mut found_tx_out_indices: HashSet<&usize> = HashSet::default();
-        for i in 0..self.outlays.len() {
-            let tx_out_index = outlay_index_to_tx_out_index
-                .get(&i)
-                .expect("index not in map");
-            if !found_tx_out_indices.insert(tx_out_index) {
-                panic!("duplicate index {} found in map", tx_out_index);
-            }
-        }
-
-        // Make the UnspentTxOut for each Txo
-        // FIXME: WS-27 - I would prefer to provide just the txo_id_hex per txout, but
-        // this at least preserves some interoperability between
-        // mobilecoind and wallet-service. However, this is
-        // pretty clunky and I would rather not expose a storage
-        // type from mobilecoind just to get around having to write a bunch of
-        // tedious json conversions.
-        // Return the TxProposal
-        let input_txos = inputs_and_proofs
-            .iter()
-            .map(|(utxo, _membership_proof)| {
-                let decoded_tx_out = mc_util_serial::decode(&utxo.txo).unwrap();
-                let decoded_key_image =
-                    mc_util_serial::decode(&utxo.key_image.clone().unwrap()).unwrap();
-
-                InputTxo {
-                    tx_out: decoded_tx_out,
-                    subaddress_index: utxo.subaddress_index.unwrap() as u64,
-                    key_image: decoded_key_image,
-                    amount: utxo.amount(),
-                }
-            })
-            .collect();
-
-        Ok(TxProposal {
-            tx,
-            input_txos,
-            payload_txos,
-            change_txos,
         })
     }
 

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -220,7 +220,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
         &self,
         conn: &Conn,
     ) -> Result<FullServiceFogResolver, WalletTransactionBuilderError> {
-        println!("Getting fog resolver");
         let account = Account::get(&AccountID(self.account_id_hex.clone()), conn)?;
         let change_subaddress = account.change_subaddress(conn)?;
         let change_public_address = change_subaddress.public_address()?;
@@ -237,9 +236,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
 
         let mut fully_validated_fog_pubkeys: HashMap<String, FullServiceFullyValidatedFogPubkey> =
             HashMap::default();
-        println!("-----Getting fully validated fog pubkeys");
         for (public_address, _, _) in self.outlays.iter() {
-            println!("\tGetting fog pubkey for {}", public_address);
             let b58_public_address = b58_encode_public_address(public_address)?;
             if fully_validated_fog_pubkeys.contains_key(&b58_public_address) {
                 continue;
@@ -254,7 +251,6 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
                 fully_validated_fog_pubkeys.insert(b58_public_address, fs_fog_pubkey);
             }
         }
-        println!("-----Done getting fully validated fog pubkeys");
 
         Ok(FullServiceFogResolver(fully_validated_fog_pubkeys))
     }
@@ -528,7 +524,7 @@ mod tests {
         // Construct a transaction
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         // Send value specifically for your smallest Txo size. Should take 2 inputs
         // and also make change.
@@ -592,7 +588,7 @@ mod tests {
         // Now try to send a transaction with a value > u64::MAX
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         let value = u64::MAX;
         builder
@@ -643,7 +639,7 @@ mod tests {
 
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         // Setting value to exactly the input will fail because you need funds for fee
         builder
@@ -662,7 +658,7 @@ mod tests {
 
         // Now build, setting to multiple TXOs
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         // Set value to just slightly more than what fits in the one TXO
         builder
@@ -710,7 +706,7 @@ mod tests {
 
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         // Setting value to exactly the input will fail because you need funds for fee
         builder
@@ -772,7 +768,7 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -790,7 +786,7 @@ mod tests {
         }
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -809,7 +805,7 @@ mod tests {
 
         // Build a transaction and explicitly set tombstone
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -850,7 +846,7 @@ mod tests {
 
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -866,7 +862,7 @@ mod tests {
 
         // You cannot set fee to 0
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -887,7 +883,7 @@ mod tests {
 
         // Setting fee less than minimum fee should fail
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -902,7 +898,7 @@ mod tests {
 
         // Setting fee greater than MINIMUM_FEE works
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -939,7 +935,7 @@ mod tests {
 
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         // Set value to consume the whole TXO and not produce change
         let value = 70 * MOB - Mob::MINIMUM_FEE;
@@ -986,7 +982,7 @@ mod tests {
 
         let conn = wallet_db.get_conn().unwrap();
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)
@@ -1049,7 +1045,7 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 7_000_000 * MOB, Mob::ID)
@@ -1090,7 +1086,7 @@ mod tests {
         );
 
         let (recipient, mut builder) =
-            builder_for_random_recipient(&account_key, &ledger_db, &mut rng, &logger);
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
 
         builder
             .add_recipient(recipient.clone(), 10 * MOB, Mob::ID)

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -146,7 +146,9 @@ mod tests {
         db::account::AccountID,
         json_rpc::v2::models::amount::Amount,
         service::{
-            account::AccountService, address::AddressService, transaction::TransactionService,
+            account::AccountService,
+            address::AddressService,
+            transaction::{TransactionMemo, TransactionService},
             transaction_log::TransactionLogService,
         },
         test_utils::{
@@ -208,7 +210,7 @@ mod tests {
 
         for _ in 0..5 {
             let (transaction_log, _, _, _) = service
-                .build_and_submit(
+                .build_sign_and_submit_transaction(
                     &alice_account_id.to_string(),
                     &[(
                         address.public_address_b58.clone(),
@@ -220,6 +222,7 @@ mod tests {
                     None,
                     None,
                     None,
+                    TransactionMemo::RTH,
                 )
                 .unwrap();
 

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -245,7 +245,7 @@ where
             TransactionMemo::RTH,
         )?;
 
-        let account = Account::get(&AccountID(account_id_hex.clone()), &conn)?;
+        let account = Account::get(&AccountID(account_id_hex), &conn)?;
         let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
 
         Ok(unsigned_tx.sign(&account_key, fog_resolver)?)

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -234,7 +234,7 @@ where
             ))
         }
 
-        let (unsigned_tx, fog_resolver) = self.build_unsigned_transaction(
+        let (unsigned_tx, fog_resolver) = self.build_transaction(
             &account_id_hex,
             &addresses_and_amounts,
             Some(&[txo_id.to_string()].to_vec()),
@@ -338,13 +338,12 @@ mod tests {
         // Construct a new transaction to Bob
         let bob_account_key: AccountKey = mc_util_serial::decode(&bob.account_key).unwrap();
         let tx_proposal = service
-            .build_transaction(
+            .build_and_sign_transaction(
                 &alice.id,
                 &vec![(
                     b58_encode_public_address(&bob_account_key.default_subaddress()).unwrap(),
                     Amount::new(42 * MOB, Mob::ID),
                 )],
-                None,
                 None,
                 None,
                 None,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -4,11 +4,13 @@
 
 use crate::{
     db::{
+        account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
-        models::{AssignedSubaddress, Txo},
+        models::{Account, AssignedSubaddress, Txo},
         txo::{TxoID, TxoModel, TxoStatus},
         WalletDbError,
     },
+    error::WalletTransactionBuilderError,
     json_rpc::v2::models::amount::Amount,
     service::{
         models::tx_proposal::TxProposal,
@@ -17,6 +19,7 @@ use crate::{
     WalletService,
 };
 use displaydoc::Display;
+use mc_account_keys::AccountKey;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 
@@ -47,6 +50,12 @@ pub enum TxoServiceError {
 
     /// Must query with either an account ID or a subaddress b58.
     InvalidQuery(String),
+
+    /// Error decoding
+    Decode(mc_util_serial::DecodeError),
+
+    /// Wallet Transaction Builder Error: {0}
+    WalletTransactionBuilder(WalletTransactionBuilderError),
 }
 
 impl From<WalletDbError> for TxoServiceError {
@@ -70,6 +79,18 @@ impl From<diesel::result::Error> for TxoServiceError {
 impl From<TransactionServiceError> for TxoServiceError {
     fn from(src: TransactionServiceError) -> Self {
         Self::TransactionService(src)
+    }
+}
+
+impl From<mc_util_serial::DecodeError> for TxoServiceError {
+    fn from(src: mc_util_serial::DecodeError) -> Self {
+        Self::Decode(src)
+    }
+}
+
+impl From<WalletTransactionBuilderError> for TxoServiceError {
+    fn from(src: WalletTransactionBuilderError) -> Self {
+        Self::WalletTransactionBuilder(src)
     }
 }
 
@@ -213,7 +234,7 @@ where
             ))
         }
 
-        Ok(self.build_transaction(
+        let (unsigned_tx, fog_resolver) = self.build_unsigned_transaction(
             &account_id_hex,
             &addresses_and_amounts,
             Some(&[txo_id.to_string()].to_vec()),
@@ -221,9 +242,13 @@ where
             fee_token_id,
             tombstone_block,
             None,
-            None,
             TransactionMemo::RTH,
-        )?)
+        )?;
+
+        let account = Account::get(&AccountID(account_id_hex.clone()), &conn)?;
+        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+
+        Ok(unsigned_tx.sign(&account_key, fog_resolver)?)
     }
 }
 

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -31,7 +31,7 @@ use mc_consensus_enclave_api::FeeMap;
 use mc_consensus_scp::QuorumSet;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_crypto_rand::{CryptoRng, RngCore};
-use mc_fog_report_validation::{FogPubkeyResolver, FullyValidatedFogPubkey, MockFogPubkeyResolver};
+use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogPubkeyResolver};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_ledger_sync::PollingNetworkState;
 use mc_transaction_core::{
@@ -516,7 +516,6 @@ pub fn create_test_minted_and_change_txos(
     value: u64,
     wallet_db: WalletDb,
     ledger_db: LedgerDB,
-    logger: Logger,
 ) -> TransactionLog {
     let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
 
@@ -616,7 +615,6 @@ pub fn builder_for_random_recipient(
     account_key: &AccountKey,
     ledger_db: &LedgerDB,
     mut rng: &mut StdRng,
-    logger: &Logger,
 ) -> (
     PublicAddress,
     WalletTransactionBuilder<MockFogPubkeyResolver>,


### PR DESCRIPTION
In an effort to simplify and centralize the logic around building and signing transactions, this moves all duplicate/similar logic into a single source of truth