### PR TITLE
Get Block Index by TXO public key

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,7 +38,7 @@
       * [Get MobileCoin Protocol TXO](v2/api-endpoints/get_mc_protocol_txo.md)
       * [Get TXO Membership Proofs](v2/api-endpoints/get_txo_membership_proofs.md)
       * [Sample Mixins](v2/api-endpoints/sample_mixins.md)
-      * [Validate TXO](v2/api-endpoints/validate_tx_out.md)
+      * [Get TXO Block Index](v2/api-endpoints/get_txo_block_index.md)
     * [Confirmation](v2/transactions/transaction-confirmation/README.md)
       * [Get Confirmations](v2/api-endpoints/get_confirmations.md)
       * [Validate Confirmations](v2/api-endpoints/validate_confirmation.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
       * [Get MobileCoin Protocol TXO](v2/api-endpoints/get_mc_protocol_txo.md)
       * [Get TXO Membership Proofs](v2/api-endpoints/get_txo_membership_proofs.md)
       * [Sample Mixins](v2/api-endpoints/sample_mixins.md)
+      * [Validate TXO](v2/api-endpoints/validate_tx_out.md)
     * [Confirmation](v2/transactions/transaction-confirmation/README.md)
       * [Get Confirmations](v2/api-endpoints/get_confirmations.md)
       * [Validate Confirmations](v2/api-endpoints/validate_confirmation.md)

--- a/docs/v2/api-endpoints/get_txo_block_index.md
+++ b/docs/v2/api-endpoints/get_txo_block_index.md
@@ -1,4 +1,4 @@
-# Validate TxOut
+# Get TXO Block Index
 
 Allows the public key of a tx out to be checked against the ledger, and if it exists will return the block index
 
@@ -16,7 +16,7 @@ Allows the public key of a tx out to be checked against the ledger, and if it ex
 {% tab title="Request Body" %}
 ```text
 {
-    "method": "validate_tx_out",
+    "method": "get_txo_block_index",
     "params": {
         "public_key": "6607d6189a4dc24823f8da6d42884a046947d00d9400e7033d7425d9df152269"
     },
@@ -29,7 +29,7 @@ Allows the public key of a tx out to be checked against the ledger, and if it ex
 {% tab title="Response Success" %}
 ```text
 {
-    "method": "validate_tx_out",
+    "method": "get_txo_block_index",
     "result": {
         "block_index": "682053"
     },
@@ -42,7 +42,7 @@ Allows the public key of a tx out to be checked against the ledger, and if it ex
 {% tab title="Response Failed" %}
 ```text
 {
-    "method": "validate_tx_out",
+    "method": "get_txo_block_index",
     "error": {
         "code": -32603,
         "message": "InternalError",

--- a/docs/v2/api-endpoints/validate_tx_out.md
+++ b/docs/v2/api-endpoints/validate_tx_out.md
@@ -1,0 +1,60 @@
+# Validate TxOut
+
+Allows the public key of a tx out to be checked against the ledger, and if it exists will return the block index
+
+## Request
+
+| Param | Description |  |
+| :--- | :--- | :--- |
+| `public_key` | The public key of the txo. | public key is hex encoded bytes |
+
+## Response
+
+## Example
+
+{% tabs %}
+{% tab title="Request Body" %}
+```text
+{
+    "method": "validate_tx_out",
+    "params": {
+        "public_key": "6607d6189a4dc24823f8da6d42884a046947d00d9400e7033d7425d9df152269"
+    },
+    "jsonrpc": "2.0",
+    "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response Success" %}
+```text
+{
+    "method": "validate_tx_out",
+    "result": {
+        "block_index": "682053"
+    },
+    "jsonrpc": "2.0",
+    "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response Failed" %}
+```text
+{
+    "method": "validate_tx_out",
+    "error": {
+        "code": -32603,
+        "message": "InternalError",
+        "data": {
+            "server_error": "LedgerDB(NotFound)",
+            "details": "Error with LedgerDB: Record not found"
+        }
+    },
+    "jsonrpc": "2.0",
+    "id": 1
+}
+```
+{% endtab %}
+{% endtabs %}
+

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -173,6 +173,9 @@ pub enum JsonCommandRequest {
     get_txo {
         txo_id: String,
     },
+    get_txo_block_index {
+        public_key: String,
+    },
     get_txos {
         account_id: Option<String>,
         address: Option<String>,
@@ -234,9 +237,6 @@ pub enum JsonCommandRequest {
         account_id: String,
         txo_id: String,
         confirmation: String,
-    },
-    validate_tx_out {
-        public_key: String,
     },
     verify_address {
         address: String,

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -235,6 +235,9 @@ pub enum JsonCommandRequest {
         txo_id: String,
         confirmation: String,
     },
+    validate_tx_out {
+        public_key: String,
+    },
     verify_address {
         address: String,
     },

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -176,6 +176,9 @@ pub enum JsonCommandResponse {
     validate_confirmation {
         validated: bool,
     },
+    validate_tx_out {
+        block_index: String,
+    },
     verify_address {
         verified: bool,
     },

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -139,6 +139,9 @@ pub enum JsonCommandResponse {
     get_txo {
         txo: Txo,
     },
+    get_txo_block_index {
+        block_index: String,
+    },
     get_txos {
         txo_ids: Vec<String>,
         txo_map: TxoMap,
@@ -175,9 +178,6 @@ pub enum JsonCommandResponse {
     },
     validate_confirmation {
         validated: bool,
-    },
-    validate_tx_out {
-        block_index: String,
     },
     verify_address {
         verified: bool,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -970,6 +970,19 @@ where
                 .map_err(format_error)?;
             JsonCommandResponse::validate_confirmation { validated: result }
         }
+        JsonCommandRequest::validate_tx_out { public_key } => {
+            let public_key_bytes = hex::decode(public_key).map_err(format_error)?;
+            let public_key: CompressedRistrettoPublic = public_key_bytes
+                .as_slice()
+                .try_into()
+                .map_err(format_error)?;
+            let block_index = service
+                .get_block_index_from_txo_public_key(&public_key)
+                .map_err(format_error)?;
+            JsonCommandResponse::validate_tx_out {
+                block_index: block_index.to_string(),
+            }
+        }
         JsonCommandRequest::verify_address { address } => JsonCommandResponse::verify_address {
             verified: service.verify_address(&address).map_err(format_error)?,
         },

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -673,6 +673,19 @@ where
                 txo: Txo::new(&txo, &status),
             }
         }
+        JsonCommandRequest::get_txo_block_index { public_key } => {
+            let public_key_bytes = hex::decode(public_key).map_err(format_error)?;
+            let public_key: CompressedRistrettoPublic = public_key_bytes
+                .as_slice()
+                .try_into()
+                .map_err(format_error)?;
+            let block_index = service
+                .get_block_index_from_txo_public_key(&public_key)
+                .map_err(format_error)?;
+            JsonCommandResponse::get_txo_block_index {
+                block_index: block_index.to_string(),
+            }
+        }
         JsonCommandRequest::get_txos {
             account_id,
             address,
@@ -969,19 +982,6 @@ where
                 .validate_confirmation(&AccountID(account_id), &TxoID(txo_id), &confirmation)
                 .map_err(format_error)?;
             JsonCommandResponse::validate_confirmation { validated: result }
-        }
-        JsonCommandRequest::validate_tx_out { public_key } => {
-            let public_key_bytes = hex::decode(public_key).map_err(format_error)?;
-            let public_key: CompressedRistrettoPublic = public_key_bytes
-                .as_slice()
-                .try_into()
-                .map_err(format_error)?;
-            let block_index = service
-                .get_block_index_from_txo_public_key(&public_key)
-                .map_err(format_error)?;
-            JsonCommandResponse::validate_tx_out {
-                block_index: block_index.to_string(),
-            }
         }
         JsonCommandRequest::verify_address { address } => JsonCommandResponse::verify_address {
             verified: service.verify_address(&address).map_err(format_error)?,

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -4,15 +4,18 @@
 
 #[cfg(test)]
 mod e2e_misc {
-    use crate::json_rpc::v2::api::test_utils::{
-        dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
-        setup_with_api_key,
+    use crate::{
+        json_rpc::v2::api::test_utils::{
+            dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
+            setup_with_api_key, wait_for_sync,
+        },
+        test_utils::{
+            add_block_with_tx_outs, create_test_received_txo, random_account_with_seed_values, MOB,
+        },
     };
-
     use mc_common::logger::{test_with_logger, Logger};
-
-    use mc_transaction_core::{tokens::Mob, BlockVersion, Token};
-
+    use mc_crypto_rand::RngCore;
+    use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Amount, BlockVersion, Token};
     use rand::{rngs::StdRng, SeedableRng};
     use rocket::http::{Header, Status};
 
@@ -117,6 +120,70 @@ mod e2e_misc {
         assert_eq!(
             fees.get(&Mob::ID.to_string()).unwrap().as_str().unwrap(),
             &Mob::MINIMUM_FEE.to_string()
+        );
+    }
+
+    #[test_with_logger]
+    fn test_validate_tx_out(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, mut ledger_db, db_ctx, network_state) = setup(&mut rng, logger.clone());
+        let wallet_db = db_ctx.get_db_instance(logger.clone());
+        let account_key = random_account_with_seed_values(
+            &wallet_db,
+            &mut ledger_db,
+            &vec![70 * MOB],
+            &mut rng,
+            &logger,
+        );
+
+        let (_, tx_out, _) = create_test_received_txo(
+            &account_key,
+            0,
+            Amount::new(70, Mob::ID),
+            13,
+            &mut rng,
+            &wallet_db,
+        );
+
+        add_block_with_tx_outs(
+            &mut ledger_db,
+            &[tx_out.clone()],
+            &[KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        wait_for_sync(&client, &ledger_db, &network_state, &logger);
+
+        // A valid public key on the ledger
+        let public_key = hex::encode(tx_out.public_key.as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "validate_tx_out",
+            "params": {
+                "public_key": public_key
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        assert_eq!(result.get("block_index").unwrap(), "13");
+
+        // An invalid public key on the ledger
+        let target_key = hex::encode(tx_out.target_key.as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "validate_tx_out",
+            "params": {
+                "public_key": target_key
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let error = res.get("error").unwrap();
+        assert_eq!(
+            error.get("data").unwrap().get("server_error").unwrap(),
+            "LedgerDB(NotFound)"
         );
     }
 }

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -124,7 +124,7 @@ mod e2e_misc {
     }
 
     #[test_with_logger]
-    fn test_validate_tx_out(logger: Logger) {
+    fn test_get_txo_block_index(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
         let (client, mut ledger_db, db_ctx, network_state) = setup(&mut rng, logger.clone());
         let wallet_db = db_ctx.get_db_instance(logger.clone());
@@ -159,7 +159,7 @@ mod e2e_misc {
         let body = json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "validate_tx_out",
+            "method": "get_txo_block_index",
             "params": {
                 "public_key": public_key
             }
@@ -174,7 +174,7 @@ mod e2e_misc {
         let body = json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "validate_tx_out",
+            "method": "get_txo_block_index",
             "params": {
                 "public_key": target_key
             }

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -127,6 +127,11 @@ pub trait LedgerService {
         num_mixins: usize,
         excluded_indices: &[u64],
     ) -> Result<(Vec<TxOut>, Vec<TxOutMembershipProof>), LedgerServiceError>;
+
+    fn get_block_index_from_txo_public_key(
+        &self,
+        public_key: &CompressedRistrettoPublic,
+    ) -> Result<u64, LedgerServiceError>;
 }
 
 impl<T, FPR> LedgerService for WalletService<T, FPR>
@@ -267,5 +272,13 @@ where
             .collect::<Result<Vec<TxOut>, _>>()?;
 
         Ok((tx_outs, proofs))
+    }
+
+    fn get_block_index_from_txo_public_key(
+        &self,
+        public_key: &CompressedRistrettoPublic,
+    ) -> Result<u64, LedgerServiceError> {
+        let index = self.ledger_db.get_tx_out_index_by_public_key(public_key)?;
+        Ok(self.ledger_db.get_block_index_by_tx_out_index(index)?)
     }
 }


### PR DESCRIPTION
Adds the ability to check the block index of a txo's public key, if it exists on the ledger

Todo:

- [x] functionality
- [x] documentation
- [x] test(s)