### PR TITLE
Feature/No Wallet Db Mode (Partial-Service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ sudo xcode-select -s /Applications/<name of xcode application>.app/Contents/Deve
 
 | Param            | Purpose                  | Requirements              |
 | :--------------- | :----------------------- | :------------------------ |
-| `wallet-db`      | Path to wallet file      | Created if does not exist |
 | `ledger-db`      | Path to ledger directory | Created if does not exist |
 | `peer`           | URI of consensus node. Used to submit <br /> transactions and to check the network <br /> block height. | MC URI format |
 | `tx-source-url`  | S3 location of archived ledger. Used to <br /> sync transactions to the local ledger. | S3 URI format |
@@ -239,6 +238,7 @@ sudo xcode-select -s /Applications/<name of xcode application>.app/Contents/Deve
 
 | Opional Param | Purpose                  | Requirements              |
 | :------------ | :----------------------- | :------------------------ |
+| `wallet-db`   | Path to wallet file. If not set, will disable any endpoints that require a wallet_db  | Created if does not exist |
 | `listen-host` | Host to listen on.      | Default: 127.0.0.1 |
 | `listen-port` | Port to start webserver on. | Default: 9090 |
 | `ledger-db-bootstrap` | Path to existing ledger_db that contains the origin block, <br /> used when initializing new ledger dbs. |  |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -133,5 +133,6 @@
 * [Resolve Disputes](tutorials/resolve-disputes.md)
 * [View Only Account](usage/view-only-account/README.md)
   * [Transaction Signer](usage/view-only-account/transaction-signer.md)
+* [No Wallet Mode](usage/no-wallet-db/no-wallet-db.md)
 
 ## Frequently Asked Questions

--- a/docs/usage/no-wallet-db/no-wallet-db.md
+++ b/docs/usage/no-wallet-db/no-wallet-db.md
@@ -1,0 +1,7 @@
+---
+description: How to start in no wallet mode
+---
+
+# No Wallet Mode (Partial-Service)
+
+You can optionally start Full Service without specifying a path for the wallet-db, which will cause it to start in No Wallet Mode. When this is true, any endpoints that require interaction with a wallet_db will be disabled.

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -40,7 +40,7 @@ pub struct APIConfig {
 
     /// Path to WalletDb.
     #[structopt(long, parse(from_os_str))]
-    pub wallet_db: PathBuf,
+    pub wallet_db: Option<PathBuf>,
 
     #[structopt(flatten)]
     pub ledger_db_config: LedgerDbConfig,

--- a/full-service/src/db/wallet_db_error.rs
+++ b/full-service/src/db/wallet_db_error.rs
@@ -6,6 +6,9 @@ use displaydoc::Display;
 
 #[derive(Display, Debug)]
 pub enum WalletDbError {
+    /// Wallet functions are currently disabled
+    WalletFunctionsDisabled,
+
     /// View Only Account already exists: {0}
     ViewOnlyAccountAlreadyExists(String),
 

--- a/full-service/src/error.rs
+++ b/full-service/src/error.rs
@@ -27,6 +27,9 @@ pub enum WalletServiceError {
     /// Error parsing u64
     U64Parse,
 
+    /// Wallet functions are currently disabled
+    WalletFunctionsDisabled,
+
     /// Error with LedgerDB: {0}
     LedgerDB(mc_ledger_db::Error),
 

--- a/full-service/src/error.rs
+++ b/full-service/src/error.rs
@@ -27,9 +27,6 @@ pub enum WalletServiceError {
     /// Error parsing u64
     U64Parse,
 
-    /// Wallet functions are currently disabled
-    WalletFunctionsDisabled,
-
     /// Error with LedgerDB: {0}
     LedgerDB(mc_ledger_db::Error),
 

--- a/full-service/src/json_rpc/v1/api/test_utils.rs
+++ b/full-service/src/json_rpc/v1/api/test_utils.rs
@@ -104,7 +104,7 @@ pub fn create_test_setup(
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
     let service = WalletService::new(
-        wallet_db,
+        Some(wallet_db),
         ledger_db.clone(),
         peer_manager,
         network_state.clone(),

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -89,6 +89,7 @@ pub const BASE_TEST_BLOCK_HEIGHT: usize = 12;
 
 pub fn create_test_setup(
     mut rng: &mut StdRng,
+    use_wallet_db: bool,
     logger: Logger,
 ) -> (
     rocket::Rocket,
@@ -97,14 +98,17 @@ pub fn create_test_setup(
     Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
 ) {
     let db_test_context = WalletDbTestContext::default();
-    let wallet_db = db_test_context.get_db_instance(logger.clone());
+    let wallet_db = match use_wallet_db {
+        true => Some(db_test_context.get_db_instance(logger.clone())),
+        false => None,
+    };
     let known_recipients: Vec<PublicAddress> = Vec::new();
     let ledger_db = get_test_ledger(5, &known_recipients, BASE_TEST_BLOCK_HEIGHT, &mut rng);
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
     let service = WalletService::new(
-        Some(wallet_db),
+        wallet_db,
         ledger_db.clone(),
         peer_manager,
         network_state.clone(),
@@ -133,7 +137,28 @@ pub fn setup(
     Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
 ) {
     let (rocket_instance, ledger_db, db_test_context, network_state) =
-        create_test_setup(rng, logger);
+        create_test_setup(rng, true, logger);
+
+    let rocket = rocket_instance.manage(APIKeyState("".to_string()));
+    (
+        Client::new(rocket).expect("valid rocket instance"),
+        ledger_db,
+        db_test_context,
+        network_state,
+    )
+}
+
+pub fn setup_no_wallet_db(
+    rng: &mut StdRng,
+    logger: Logger,
+) -> (
+    Client,
+    LedgerDB,
+    WalletDbTestContext,
+    Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
+) {
+    let (rocket_instance, ledger_db, db_test_context, network_state) =
+        create_test_setup(rng, false, logger);
 
     let rocket = rocket_instance.manage(APIKeyState("".to_string()));
     (
@@ -155,7 +180,7 @@ pub fn setup_with_api_key(
     Arc<RwLock<PollingNetworkState<MockBlockchainConnection<LedgerDB>>>>,
 ) {
     let (rocket_instance, ledger_db, db_test_context, network_state) =
-        create_test_setup(rng, logger);
+        create_test_setup(rng, true, logger);
 
     let rocket = rocket_instance.manage(APIKeyState(api_key));
 

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -104,7 +104,7 @@ pub fn create_test_setup(
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
     let service = WalletService::new(
-        wallet_db,
+        Some(wallet_db),
         ledger_db.clone(),
         peer_manager,
         network_state.clone(),

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -246,7 +246,7 @@ where
         let first_block_index = network_block_height; // -1 +1
         let import_block_index = local_block_height; // -1 +1
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             let (account_id, _public_address_b58) = Account::create_from_mnemonic(
                 &mnemonic,
@@ -302,7 +302,7 @@ where
         // start scanning.
         let import_block = self.ledger_db.num_blocks()? - 1;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             Ok(Account::import(
                 &mnemonic,
@@ -342,7 +342,7 @@ where
         // start scanning.
         let import_block = self.ledger_db.num_blocks()? - 1;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             Ok(Account::import_legacy(
                 &RootEntropy::from(&entropy_bytes),
@@ -380,7 +380,7 @@ where
 
         let import_block_index = self.ledger_db.num_blocks()? - 1;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             Ok(Account::import_view_only(
                 &view_private_key,
@@ -398,7 +398,7 @@ where
         &self,
         account_id: &AccountID,
     ) -> Result<JsonRPCRequest, AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let account = Account::get(account_id, &conn)?;
 
         if account.view_only {
@@ -440,12 +440,12 @@ where
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<Account>, AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Ok(Account::list_all(&conn, offset, limit)?)
     }
 
     fn get_account(&self, account_id: &AccountID) -> Result<Account, AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Ok(Account::get(account_id, &conn)?)
     }
 
@@ -453,7 +453,7 @@ where
         &self,
         account_id: &AccountID,
     ) -> Result<u64, AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let account = Account::get(account_id, &conn)?;
         Ok(account.next_subaddress_index(&conn)?)
     }
@@ -463,7 +463,7 @@ where
         account_id: &AccountID,
         name: String,
     ) -> Result<Account, AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Account::get(account_id, &conn)?.update_name(name, &conn)?;
         Ok(Account::get(account_id, &conn)?)
     }
@@ -474,7 +474,7 @@ where
         txo_ids_and_key_images: Vec<(String, String)>,
         next_subaddress_index: u64,
     ) -> Result<(), AccountServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let account = Account::get(account_id, &conn)?;
 
         if !account.view_only {
@@ -503,7 +503,7 @@ where
 
     fn remove_account(&self, account_id: &AccountID) -> Result<bool, AccountServiceError> {
         log::info!(self.logger, "Deleting account {}", account_id,);
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             let account = Account::get(account_id, &conn)?;
             account.delete(&conn)?;

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -539,7 +539,7 @@ mod tests {
         let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
-        let wallet_db = &service.wallet_db;
+        let wallet_db = &service.wallet_db.as_ref().unwrap();
 
         // Create an account.
         let account = service
@@ -622,7 +622,12 @@ mod tests {
         // Syncing the account does nothing to the block indices since there are no new
         // blocks.
         let account_id = AccountID(account.id);
-        manually_sync_account(&ledger_db, &service.wallet_db, &account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &account_id,
+            &logger,
+        );
         let account = service.get_account(&account_id).unwrap();
         assert_eq!(account.first_block_index, 12);
         assert_eq!(account.next_block_index, 12);
@@ -654,7 +659,12 @@ mod tests {
         // Syncing the account does nothing to the block indices since there are no
         // blocks in the ledger.
         let account_id = AccountID(account.id);
-        manually_sync_account(&ledger_db, &service.wallet_db, &account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &account_id,
+            &logger,
+        );
         let account = service.get_account(&account_id).unwrap();
         assert_eq!(account.first_block_index, 0);
         assert_eq!(account.next_block_index, 0);
@@ -669,7 +679,7 @@ mod tests {
         let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
-        let wallet_db = &service.wallet_db;
+        let wallet_db = &service.wallet_db.as_ref().unwrap();
         let conn = wallet_db.get_conn().unwrap();
 
         let view_private_key = RistrettoPrivate::from_random(&mut rng);

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -80,7 +80,7 @@ where
         account_id: &AccountID,
         metadata: Option<&str>,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             let (public_address_b58, _subaddress_index) =
                 AssignedSubaddress::create_next_for_account(
@@ -94,7 +94,7 @@ where
     }
 
     fn get_address(&self, address_b58: &str) -> Result<AssignedSubaddress, AddressServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Ok(AssignedSubaddress::get(address_b58, &conn)?)
     }
 
@@ -103,7 +103,7 @@ where
         account_id: &AccountID,
         index: i64,
     ) -> Result<AssignedSubaddress, AddressServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Ok(AssignedSubaddress::get_for_account_by_index(
             &account_id.to_string(),
             index,
@@ -117,7 +117,7 @@ where
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         Ok(AssignedSubaddress::list_all(
             account_id, offset, limit, &conn,
         )?)

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -158,7 +158,7 @@ mod tests {
 
         let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
-        let conn = service.wallet_db.get_conn().unwrap();
+        let conn = service.get_conn().unwrap();
 
         // Create an account.
         let account = service
@@ -184,7 +184,7 @@ mod tests {
 
         let ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
-        let conn = service.wallet_db.get_conn().unwrap();
+        let conn = service.get_conn().unwrap();
 
         let view_private_key = RistrettoPrivate::from_random(&mut rng);
         let spend_public_key = RistrettoPublic::from_random(&mut rng);

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -439,7 +439,7 @@ mod tests {
 
         let _account = manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(account.id.to_string()),
             &logger,
         );

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -161,7 +161,7 @@ where
         &self,
         account_id: &AccountID,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
+        let conn = &self.get_conn()?;
         let account = self.get_account(account_id)?;
         let distinct_token_ids = account.get_token_ids(conn)?;
 
@@ -189,7 +189,7 @@ where
         &self,
         address: &str,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
+        let conn = &self.get_conn()?;
         let assigned_address = AssignedSubaddress::get(address, conn)?;
         let account_id = AccountID::from(assigned_address.account_id);
         let account = self.get_account(&account_id)?;
@@ -227,7 +227,7 @@ where
     fn get_wallet_status(&self) -> Result<WalletStatus, BalanceServiceError> {
         let network_block_height = self.get_network_block_height()?;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let accounts = Account::list_all(&conn, None, None)?;
         let mut account_map = HashMap::default();
 

--- a/full-service/src/service/confirmation_number.rs
+++ b/full-service/src/service/confirmation_number.rs
@@ -157,7 +157,7 @@ where
         txo_id: &TxoID,
         confirmation_hex: &str,
     ) -> Result<bool, ConfirmationServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let confirmation: TxOutConfirmationNumber =
             mc_util_serial::decode(&hex::decode(confirmation_hex)?)?;
         Ok(Txo::validate_confirmation(

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -436,7 +436,7 @@ where
         let gift_code_account_main_subaddress_b58 =
             b58_encode_public_address(&gift_code_account_key.default_subaddress())?;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let from_account = Account::get(from_account_id, &conn)?;
 
         let fee_value = fee.map(|f| f.to_string());
@@ -494,7 +494,7 @@ where
         );
 
         // Save the gift code to the database before attempting to send it out.
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let gift_code = transaction(&conn, || GiftCode::create(gift_code_b58, value, &conn))?;
 
         self.submit_transaction(
@@ -517,7 +517,7 @@ where
         &self,
         gift_code_b58: &EncodedGiftCode,
     ) -> Result<DecodedGiftCode, GiftCodeServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let gift_code = GiftCode::get(gift_code_b58, &conn)?;
         DecodedGiftCode::try_from(gift_code)
     }
@@ -527,7 +527,7 @@ where
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<DecodedGiftCode>, GiftCodeServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         GiftCode::list_all(&conn, offset, limit)?
             .into_iter()
             .map(DecodedGiftCode::try_from)
@@ -749,7 +749,7 @@ where
         &self,
         gift_code_b58: &EncodedGiftCode,
     ) -> Result<bool, GiftCodeServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || GiftCode::get(gift_code_b58, &conn)?.delete(&conn))?;
         Ok(true)
     }

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -809,7 +809,12 @@ mod tests {
             &vec![KeyImage::from(rng.next_u64())],
             &mut rng,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Verify balance for Alice
         let balance = service
@@ -848,7 +853,12 @@ mod tests {
         assert!(gift_code_value_opt.is_none());
 
         add_block_with_tx(&mut ledger_db, tx_proposal.tx, &mut rng);
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Now the Gift Code should be Available
         let (status, gift_code_value_opt, _memo) = service
@@ -908,7 +918,7 @@ mod tests {
             .unwrap();
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(bob.id.clone()),
             &logger,
         );
@@ -933,7 +943,7 @@ mod tests {
         add_block_with_tx(&mut ledger_db, tx, &mut rng);
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(bob.id.clone()),
             &logger,
         );
@@ -985,7 +995,12 @@ mod tests {
             &vec![KeyImage::from(rng.next_u64())],
             &mut rng,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Verify balance for Alice
         let balance = service
@@ -1025,7 +1040,12 @@ mod tests {
 
         // Let transaction hit the ledger
         add_block_with_tx(&mut ledger_db, tx_proposal.tx, &mut rng);
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Check that it landed
         let (status, gift_code_value_opt, _memo) = service

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -148,7 +148,7 @@ where
     }
 
     fn get_transaction_object(&self, transaction_id_hex: &str) -> Result<Tx, LedgerServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let transaction_log =
             TransactionLog::get(&TransactionID(transaction_id_hex.to_string()), &conn)?;
         let tx: Tx = mc_util_serial::decode(&transaction_log.tx)?;
@@ -156,7 +156,7 @@ where
     }
 
     fn get_txo_object(&self, txo_id_hex: &str) -> Result<TxOut, LedgerServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let txo_details = Txo::get(txo_id_hex, &conn)?;
 
         let txo: TxOut = mc_util_serial::decode(&txo_details.txo)?;

--- a/full-service/src/service/payment_request.rs
+++ b/full-service/src/service/payment_request.rs
@@ -100,7 +100,7 @@ where
         amount: Amount,
         memo: Option<String>,
     ) -> Result<String, PaymentRequestServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
 
         let assigned_subaddress = AssignedSubaddress::get_for_account_by_index(
             &account_id,

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -388,7 +388,7 @@ mod tests {
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
@@ -434,7 +434,7 @@ mod tests {
             14,
             "".to_string(),
             &alice.id,
-            &service.wallet_db.get_conn().unwrap(),
+            &service.get_conn().unwrap(),
         )
         .expect("Could not log submitted");
 
@@ -442,13 +442,13 @@ mod tests {
         add_block_with_tx(&mut ledger_db, tx_proposal.tx, &mut rng);
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(bob.id.to_string()),
             &logger,
         );
@@ -514,7 +514,7 @@ mod tests {
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
@@ -565,7 +565,7 @@ mod tests {
             14,
             "".to_string(),
             &alice.id,
-            &service.wallet_db.get_conn().unwrap(),
+            &service.get_conn().unwrap(),
         )
         .expect("Could not log submitted");
 
@@ -580,13 +580,13 @@ mod tests {
         add_block_with_tx(&mut ledger_db, tx_proposal.tx, &mut rng);
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(bob.id.to_string()),
             &logger,
         );
@@ -636,7 +636,7 @@ mod tests {
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
@@ -680,17 +680,22 @@ mod tests {
             14,
             "".to_string(),
             &alice.id,
-            &service.wallet_db.get_conn().unwrap(),
+            &service.get_conn().unwrap(),
         )
         .expect("Could not log submitted");
         add_block_with_tx(&mut ledger_db, tx_proposal0.tx, &mut rng);
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &bob_account_id,
+            &logger,
+        );
 
         // Bob checks the status, and is expecting an incorrect value, from a
         // transaction with a different shared secret
@@ -707,7 +712,7 @@ mod tests {
 
         // Now check status with a correct shared secret, but the wrong value
         let bob_account_key: AccountKey = mc_util_serial::decode(
-            &Account::get(&bob_account_id, &service.wallet_db.get_conn().unwrap())
+            &Account::get(&bob_account_id, &service.get_conn().unwrap())
                 .expect("Could not get bob account")
                 .account_key,
         )
@@ -771,7 +776,7 @@ mod tests {
         );
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
@@ -815,17 +820,22 @@ mod tests {
             14,
             "".to_string(),
             &alice.id,
-            &service.wallet_db.get_conn().unwrap(),
+            &service.get_conn().unwrap(),
         )
         .expect("Could not log submitted");
         add_block_with_tx(&mut ledger_db, tx_proposal0.tx, &mut rng);
         manually_sync_account(
             &ledger_db,
-            &service.wallet_db,
+            &service.wallet_db.as_ref().unwrap(),
             &AccountID(alice.id.to_string()),
             &logger,
         );
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &bob_account_id,
+            &logger,
+        );
 
         // Construct an invalid receipt with an incorrect confirmation number.
         let mut receipt = receipt0.clone();

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -199,7 +199,7 @@ where
         address: &str,
         receiver_receipt: &ReceiverReceipt,
     ) -> Result<(ReceiptTransactionStatus, Option<(Txo, TxoStatus)>), ReceiptServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
+        let conn = &self.get_conn()?;
         let assigned_address = AssignedSubaddress::get(address, conn)?;
         let account_id = AccountID(assigned_address.account_id);
         let account = Account::get(&account_id, conn)?;

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -499,7 +499,7 @@ mod tests {
         );
 
         let service = setup_wallet_service(ledger_db.clone(), logger.clone());
-        let wallet_db = &service.wallet_db;
+        let wallet_db = &service.wallet_db.as_ref().unwrap();
 
         // Import the account
         let _account = service
@@ -574,7 +574,8 @@ mod tests {
     //     );
 
     //     let service = setup_wallet_service(ledger_db.clone(),
-    // logger.clone());     let wallet_db = &service.wallet_db;
+    // logger.clone());     let wallet_db =
+    // &service.wallet_db.as_ref().unwrap();
 
     //     // create view only account
     //     let account = service

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -576,7 +576,12 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         let tx_logs = service
             .list_transaction_logs(Some(alice_account_id.to_string()), None, None, None, None)
@@ -721,7 +726,12 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Verify balance for Alice
         let balance = service
@@ -772,21 +782,31 @@ mod tests {
         // workaround.
         {
             log::info!(logger, "Adding block from transaction log");
-            let conn = service.wallet_db.get_conn().unwrap();
+            let conn = service.get_conn().unwrap();
             add_block_from_transaction_log(&mut ledger_db, &conn, &transaction_log, &mut rng);
         }
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &bob_account_id,
+            &logger,
+        );
 
         // Get the Txos from the transaction log
         let transaction_txos = transaction_log
-            .get_associated_txos(&service.wallet_db.get_conn().unwrap())
+            .get_associated_txos(&service.get_conn().unwrap())
             .unwrap();
         let secreted = transaction_txos
             .outputs
             .iter()
-            .map(|(t, _)| Txo::get(&t.id, &service.wallet_db.get_conn().unwrap()).unwrap())
+            .map(|(t, _)| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
             .collect::<Vec<Txo>>();
         assert_eq!(secreted.len(), 1);
         assert_eq!(secreted[0].value as u64, 42 * MOB);
@@ -794,7 +814,7 @@ mod tests {
         let change = transaction_txos
             .change
             .iter()
-            .map(|(t, _)| Txo::get(&t.id, &service.wallet_db.get_conn().unwrap()).unwrap())
+            .map(|(t, _)| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
             .collect::<Vec<Txo>>();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].value as u64, 58 * MOB - Mob::MINIMUM_FEE);
@@ -802,7 +822,7 @@ mod tests {
         let inputs = transaction_txos
             .inputs
             .iter()
-            .map(|t| Txo::get(&t.id, &service.wallet_db.get_conn().unwrap()).unwrap())
+            .map(|t| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
             .collect::<Vec<Txo>>();
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].value as u64, 100 * MOB);
@@ -845,12 +865,22 @@ mod tests {
 
         {
             log::info!(logger, "Adding block from transaction log");
-            let conn = service.wallet_db.get_conn().unwrap();
+            let conn = service.get_conn().unwrap();
             add_block_from_transaction_log(&mut ledger_db, &conn, &transaction_log, &mut rng);
         }
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
-        manually_sync_account(&ledger_db, &service.wallet_db, &bob_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &bob_account_id,
+            &logger,
+        );
 
         let alice_balance = service
             .get_balance_for_account(&AccountID(alice.id))
@@ -902,7 +932,12 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         match service.build_and_sign_transaction(
             &alice.id,
@@ -953,7 +988,12 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // test ouputs
         let mut outputs = Vec::new();

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -301,7 +301,7 @@ where
         validate_number_inputs(input_txo_ids.unwrap_or(&Vec::new()).len() as u64)?;
         validate_number_outputs(addresses_and_amounts.len() as u64)?;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             let mut builder = WalletTransactionBuilder::new(
                 account_id_hex.to_string(),
@@ -384,7 +384,7 @@ where
             max_spendable_value,
             memo,
         )?;
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         transaction(&conn, || {
             let account = Account::get(&AccountID(account_id_hex.to_string()), &conn)?;
             let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
@@ -430,7 +430,7 @@ where
         );
 
         if let Some(account_id_hex) = account_id_hex {
-            let conn = self.wallet_db.get_conn()?;
+            let conn = self.get_conn()?;
             let account_id = AccountID(account_id_hex.to_string());
 
             transaction(&conn, || {

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -82,7 +82,7 @@ where
         min_block_index: Option<u64>,
         max_block_index: Option<u64>,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
+        let conn = &self.get_conn()?;
         Ok(TransactionLog::list_all(
             account_id,
             offset,
@@ -97,7 +97,7 @@ where
         &self,
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos, ValueMap), TransactionLogServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let transaction_log =
             TransactionLog::get(&TransactionID(transaction_id_hex.to_string()), &conn)?;
         let associated = transaction_log.get_associated_txos(&conn)?;
@@ -110,7 +110,7 @@ where
         &self,
         block_index: u64,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let transaction_logs = TransactionLog::get_all_for_block_index(block_index, &conn)?;
         let mut res: Vec<(TransactionLog, AssociatedTxos, ValueMap)> = Vec::new();
         for transaction_log in transaction_logs {
@@ -126,7 +126,7 @@ where
     fn get_all_transaction_logs_ordered_by_block(
         &self,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
         let mut res: Vec<(TransactionLog, AssociatedTxos, ValueMap)> = Vec::new();
         for transaction_log in transaction_logs {

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -202,7 +202,12 @@ mod tests {
             );
         }
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         let address = service
             .assign_address_for_account(&alice_account_id, None)
@@ -227,11 +232,16 @@ mod tests {
                 .unwrap();
 
             {
-                let conn = service.wallet_db.get_conn().unwrap();
+                let conn = service.get_conn().unwrap();
                 add_block_from_transaction_log(&mut ledger_db, &conn, &transaction_log, &mut rng);
             }
 
-            manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+            manually_sync_account(
+                &ledger_db,
+                &service.wallet_db.as_ref().unwrap(),
+                &alice_account_id,
+                &logger,
+            );
         }
 
         let tx_logs = service

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -169,7 +169,7 @@ where
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<(Txo, TxoStatus)>, TxoServiceError> {
-        let conn = &self.wallet_db.get_conn()?;
+        let conn = &self.get_conn()?;
 
         let txos;
 
@@ -219,7 +219,7 @@ where
     }
 
     fn get_txo(&self, txo_id: &TxoID) -> Result<(Txo, TxoStatus), TxoServiceError> {
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let txo = Txo::get(&txo_id.to_string(), &conn)?;
         let status = txo.status(&conn)?;
         Ok((txo, status))
@@ -236,7 +236,7 @@ where
     ) -> Result<TxProposal, TxoServiceError> {
         use crate::service::txo::TxoServiceError::TxoNotSpendableByAnyAccount;
 
-        let conn = self.wallet_db.get_conn()?;
+        let conn = self.get_conn()?;
         let txo_details = Txo::get(&txo_id.to_string(), &conn)?;
 
         let account_id_hex = txo_details

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -328,7 +328,12 @@ mod tests {
             &mut rng,
         );
 
-        manually_sync_account(&ledger_db, &service.wallet_db, &alice_account_id, &logger);
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
 
         // Verify balance for Alice
         let balance = service.get_balance_for_account(&alice_account_id).unwrap();

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -27,7 +27,7 @@ pub struct WalletService<
     FPR: FogPubkeyResolver + Send + Sync + 'static,
 > {
     /// Wallet database handle.
-    wallet_db: Option<WalletDb>,
+    pub wallet_db: Option<WalletDb>,
 
     /// Ledger database.
     pub ledger_db: LedgerDB,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -97,10 +97,9 @@ impl<
     }
 
     pub fn get_conn(&self) -> Result<Conn, WalletDbError> {
-        Ok(self
-            .wallet_db
+        self.wallet_db
             .as_ref()
             .ok_or(WalletDbError::WalletFunctionsDisabled)?
-            .get_conn()?)
+            .get_conn()
     }
 }

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -658,30 +658,41 @@ pub fn setup_wallet_service(
     ledger_db: LedgerDB,
     logger: Logger,
 ) -> WalletService<MockBlockchainConnection<LedgerDB>, MockFogPubkeyResolver> {
-    setup_wallet_service_impl(ledger_db, logger, false)
+    setup_wallet_service_impl(ledger_db, logger, false, false)
 }
 
 pub fn setup_wallet_service_offline(
     ledger_db: LedgerDB,
     logger: Logger,
 ) -> WalletService<MockBlockchainConnection<LedgerDB>, MockFogPubkeyResolver> {
-    setup_wallet_service_impl(ledger_db, logger, true)
+    setup_wallet_service_impl(ledger_db, logger, true, false)
+}
+
+pub fn setup_wallet_service_no_wallet_db(
+    ledger_db: LedgerDB,
+    logger: Logger,
+) -> WalletService<MockBlockchainConnection<LedgerDB>, MockFogPubkeyResolver> {
+    setup_wallet_service_impl(ledger_db, logger, false, true)
 }
 
 fn setup_wallet_service_impl(
     ledger_db: LedgerDB,
     logger: Logger,
     offline: bool,
+    no_wallet_db: bool,
 ) -> WalletService<MockBlockchainConnection<LedgerDB>, MockFogPubkeyResolver> {
     let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
 
     let db_test_context = WalletDbTestContext::default();
-    let wallet_db = db_test_context.get_db_instance(logger.clone());
+    let wallet_db = match no_wallet_db {
+        true => None,
+        false => Some(db_test_context.get_db_instance(logger.clone())),
+    };
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), offline);
 
     WalletService::new(
-        Some(wallet_db),
+        wallet_db,
         ledger_db,
         peer_manager,
         network_state,

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -681,7 +681,7 @@ fn setup_wallet_service_impl(
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), offline);
 
     WalletService::new(
-        wallet_db,
+        Some(wallet_db),
         ledger_db,
         peer_manager,
         network_state,

--- a/tools/run-testnet-no-wallet-db.sh
+++ b/tools/run-testnet-no-wallet-db.sh
@@ -1,0 +1,22 @@
+NAMESPACE=test
+
+WORK_DIR="$HOME/.mobilecoin/${NAMESPACE}"
+WALLET_DB_DIR="${WORK_DIR}/wallet-db"
+LEDGER_DB_DIR="${WORK_DIR}/ledger-db"
+mkdir -p ${WORK_DIR}
+
+(cd ${WORK_DIR} && CONSENSUS_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${NAMESPACE}.mobilecoin.com/production.json | grep consensus-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
+curl -O https://enclave-distribution.${NAMESPACE}.mobilecoin.com/${CONSENSUS_SIGSTRUCT_URI})
+
+(cd ${WORK_DIR} && INGEST_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${NAMESPACE}.mobilecoin.com/production.json | grep ingest-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
+curl -O https://enclave-distribution.${NAMESPACE}.mobilecoin.com/${INGEST_SIGSTRUCT_URI})
+
+mkdir -p ${WALLET_DB_DIR}
+${WORK_DIR}/full-service \
+    --ledger-db ${LEDGER_DB_DIR} \
+    --peer mc://node1.test.mobilecoin.com/ \
+    --peer mc://node2.test.mobilecoin.com/ \
+    --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/ \
+    --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/ \
+    --fog-ingest-enclave-css ${WORK_DIR}/ingest-enclave.css \
+    --chain-id ""


### PR DESCRIPTION
This enables full service to be started without a wallet_db config, which puts it into a mode that disables any endpoints that require interacting with the wallet_db.

Currently, if an existing endpoint that is disabled is called, it will return an error with an appropriate description.

```
{
    "method": "get_accounts",
    "error": {
        "code": -32603,
        "message": "InternalError",
        "data": {
            "server_error": "Database(WalletFunctionsDisabled)",
            "details": "Error interacting& with the database: Wallet functions are currently disabled"
        }
    },
    "jsonrpc": "2.0",
    "id": 1
}
```

but still allows for non wallet-db interacting API methods to be called as normal

```
{
    "method": "get_network_status",
    "result": {
        "network_status": {
            "network_block_height": "1031460",
            "local_block_height": "1031460",
            "fees": {
                "0": "400000000",
                "8192": "2560"
            },
            "block_version": "2"
        }
    },
    "jsonrpc": "2.0",
    "id": 1
}
```

Todo:

- [x] Implementation
- [x] Docs
- [x] Tests