### PR TITLE
updated fee_pmob to fees: {} in v2 api docs for get_network_status

### DIFF
--- a/docs/v2/api-endpoints/get_network_status.md
+++ b/docs/v2/api-endpoints/get_network_status.md
@@ -30,7 +30,10 @@ description: 'Get the current status of the network.'
       object: "network_status",
       "network_block_height": "152918",
       "local_block_height": ""152918,
-      "fee_pmob": "10000000000"
+        "fees": {
+            "0": "400000000",
+            "1": "2560"
+        },
 
     }
   },


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

On the v2 api docs, the example response for get_network_status is out of date.

### In this PR
Updated the v2 api docs for get_network_status  example response to show "fees": {}  in the response instead of the v1 api's "fee_pmob" response element.

### Future Work