### PR TITLE
Fix issues surfaced by block version 2

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -176,7 +176,11 @@ fn validator_backed_full_service(
     rocket_config: rocket::Config,
     logger: Logger,
 ) {
-    let validator_conn = ValidatorConnection::new(validator_uri, logger.clone());
+    let validator_conn = ValidatorConnection::new(
+        validator_uri,
+        config.peers_config.chain_id.clone(),
+        logger.clone(),
+    );
 
     // Create the ledger_db.
     let ledger_db = config.ledger_db_config.create_or_open_ledger_db(
@@ -210,6 +214,7 @@ fn validator_backed_full_service(
     // Create the ledger sync thread.
     let _ledger_sync_thread = ValidatorLedgerSyncThread::new(
         validator_uri,
+        config.peers_config.chain_id.clone(),
         config.poll_interval,
         ledger_db.clone(),
         network_state.clone(),

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -219,7 +219,7 @@ where
             network_block_height: self.get_network_block_height()?,
             local_block_height: self.ledger_db.num_blocks()?,
             fees: self.get_network_fees()?,
-            block_version: *self.get_network_block_version(),
+            block_version: *self.get_network_block_version()?,
         })
     }
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -165,7 +165,7 @@ where
         let account = self.get_account(account_id)?;
         let distinct_token_ids = account.get_token_ids(conn)?;
 
-        let network_fees = self.get_network_fees();
+        let network_fees = self.get_network_fees()?;
 
         let balances = distinct_token_ids
             .into_iter()
@@ -194,7 +194,7 @@ where
         let account_id = AccountID::from(assigned_address.account_id);
         let account = self.get_account(&account_id)?;
         let distinct_token_ids = account.get_token_ids(conn)?;
-        let network_fees = self.get_network_fees();
+        let network_fees = self.get_network_fees()?;
 
         let balances = distinct_token_ids
             .into_iter()
@@ -218,7 +218,7 @@ where
         Ok(NetworkStatus {
             network_block_height: self.get_network_block_height()?,
             local_block_height: self.ledger_db.num_blocks()?,
-            fees: self.get_network_fees(),
+            fees: self.get_network_fees()?,
             block_version: *self.get_network_block_version(),
         })
     }
@@ -235,7 +235,7 @@ where
 
         let mut min_synced_block_index = network_block_height.saturating_sub(1);
         let mut account_ids = Vec::new();
-        let network_fees = self.get_network_fees();
+        let network_fees = self.get_network_fees()?;
 
         for account in accounts {
             let account_id = AccountID(account.id.clone());

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -201,7 +201,7 @@ where
         }
 
         // Guaranteed not to fail since we verified last_block_infos is not empty.
-        return last_block_infos[0].minimum_fees.clone();
+        last_block_infos[0].minimum_fees.clone()
     }
 
     fn get_network_block_version(&self) -> BlockVersion {

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -355,7 +355,7 @@ where
 
             builder.set_fee(fee_value, fee_token_id)?;
 
-            builder.set_block_version(self.get_network_block_version());
+            builder.set_block_version(self.get_network_block_version()?);
 
             if let Some(inputs) = input_txo_ids {
                 builder.set_txos(&conn, inputs)?;

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -13,8 +13,10 @@ use crate::{
     error::WalletTransactionBuilderError,
     json_rpc::v2::models::amount::Amount as AmountJSON,
     service::{
-        ledger::LedgerService, models::tx_proposal::TxProposal,
-        transaction_builder::WalletTransactionBuilder, WalletService,
+        ledger::{LedgerService, LedgerServiceError},
+        models::tx_proposal::TxProposal,
+        transaction_builder::WalletTransactionBuilder,
+        WalletService,
     },
     util::b58::{b58_decode_public_address, B58Error},
 };
@@ -109,6 +111,9 @@ pub enum TransactionServiceError {
     /// Tx Builder Error: {0}
     TxBuilder(mc_transaction_std::TxBuilderError),
 
+    /// Ledger service error: {0}
+    LedgerService(LedgerServiceError),
+
     /// Key Error: {0}
     Key(mc_crypto_keys::KeyError),
 }
@@ -188,6 +193,12 @@ impl From<mc_transaction_std::TxBuilderError> for TransactionServiceError {
 impl From<mc_crypto_keys::KeyError> for TransactionServiceError {
     fn from(src: mc_crypto_keys::KeyError) -> Self {
         Self::Key(src)
+    }
+}
+
+impl From<LedgerServiceError> for TransactionServiceError {
+    fn from(src: LedgerServiceError) -> Self {
+        Self::LedgerService(src)
     }
 }
 
@@ -337,7 +348,7 @@ where
 
             let fee_value = match fee_value {
                 Some(f) => f.parse::<u64>()?,
-                None => *self.get_network_fees().get(&fee_token_id).ok_or(
+                None => *self.get_network_fees()?.get(&fee_token_id).ok_or(
                     TransactionServiceError::DefaultFeeNotFoundForToken(fee_token_id),
                 )?,
             };

--- a/full-service/src/validator_ledger_sync.rs
+++ b/full-service/src/validator_ledger_sync.rs
@@ -28,6 +28,7 @@ pub struct ValidatorLedgerSyncThread {
 impl ValidatorLedgerSyncThread {
     pub fn new(
         validator_uri: &ValidatorUri,
+        chain_id: String,
         poll_interval: Duration,
         ledger_db: LedgerDB,
         network_state: Arc<RwLock<PollingNetworkState<ValidatorConnection>>>,
@@ -35,7 +36,7 @@ impl ValidatorLedgerSyncThread {
     ) -> Self {
         let stop_requested = Arc::new(AtomicBool::new(false));
 
-        let validator_conn = ValidatorConnection::new(validator_uri, logger.clone());
+        let validator_conn = ValidatorConnection::new(validator_uri, chain_id, logger.clone());
 
         let thread_stop_requested = stop_requested.clone();
         let join_handle = Some(

--- a/validator/connection/src/lib.rs
+++ b/validator/connection/src/lib.rs
@@ -4,7 +4,7 @@
 
 mod error;
 
-use grpcio::{ChannelBuilder, EnvBuilder};
+use grpcio::{CallOption, ChannelBuilder, EnvBuilder, MetadataBuilder};
 use mc_blockchain_types::{Block, BlockData, BlockID, BlockIndex};
 use mc_common::logger::{log, Logger};
 use mc_connection::{
@@ -13,7 +13,7 @@ use mc_connection::{
 };
 use mc_fog_report_types::FogReportResponses;
 use mc_transaction_core::tx::Tx;
-use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_util_grpc::{ConnectionUriGrpcioChannel, CHAIN_ID_GRPC_HEADER};
 use mc_util_uri::{ConnectionUri, FogUri};
 use mc_validator_api::{
     blockchain::ArchiveBlock,
@@ -36,16 +36,33 @@ use std::{
 
 pub use error::Error;
 
+/// Helper which creates a grpcio CallOption with "common" headers attached
+/// TODO copied from `mobilecoin/util/grpc/src/lib.rs`, should be removed
+/// once upreved.
+pub fn common_headers_call_option(chain_id: &str) -> CallOption {
+    let mut metadata_builder = MetadataBuilder::new();
+
+    // Add the chain id header if we have a chain id specified
+    if !chain_id.is_empty() {
+        metadata_builder
+            .add_str(CHAIN_ID_GRPC_HEADER, chain_id)
+            .expect("Could not add chain-id header");
+    }
+
+    CallOption::default().headers(metadata_builder.build())
+}
+
 #[derive(Clone)]
 pub struct ValidatorConnection {
     uri: ValidatorUri,
     validator_api_client: ValidatorApiClient,
     blockchain_api_client: BlockchainApiClient,
+    chain_id: String,
     logger: Logger,
 }
 
 impl ValidatorConnection {
-    pub fn new(uri: &ValidatorUri, logger: Logger) -> Self {
+    pub fn new(uri: &ValidatorUri, chain_id: String, logger: Logger) -> Self {
         let env = Arc::new(EnvBuilder::new().name_prefix("ValidatorRPC").build());
         let ch = ChannelBuilder::new(env)
             .max_receive_message_len(std::i32::MAX)
@@ -59,6 +76,7 @@ impl ValidatorConnection {
             uri: uri.clone(),
             validator_api_client,
             blockchain_api_client,
+            chain_id,
             logger,
         }
     }
@@ -70,7 +88,7 @@ impl ValidatorConnection {
 
         let response = self
             .validator_api_client
-            .get_archive_blocks(&request)
+            .get_archive_blocks_opt(&request, common_headers_call_option(&self.chain_id))
             .map_err(|err| {
                 log::warn!(
                     self.logger,
@@ -101,7 +119,7 @@ impl ValidatorConnection {
 
         let response = self
             .validator_api_client
-            .fetch_fog_report(&request)
+            .fetch_fog_report_opt(&request, common_headers_call_option(&self.chain_id))
             .map_err(|err| {
                 log::warn!(
                     self.logger,
@@ -201,7 +219,7 @@ impl BlockchainConnection for ValidatorConnection {
     fn fetch_block_height(&mut self) -> ConnectionResult<BlockIndex> {
         let response = self
             .blockchain_api_client
-            .get_last_block_info(&Empty::new())
+            .get_last_block_info_opt(&Empty::new(), common_headers_call_option(&self.chain_id))
             .map_err(|err| {
                 log::warn!(
                     self.logger,
@@ -217,7 +235,7 @@ impl BlockchainConnection for ValidatorConnection {
     fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
         let response = self
             .blockchain_api_client
-            .get_last_block_info(&Empty::new())
+            .get_last_block_info_opt(&Empty::new(), common_headers_call_option(&self.chain_id))
             .map_err(|err| {
                 log::warn!(
                     self.logger,
@@ -234,7 +252,7 @@ impl UserTxConnection for ValidatorConnection {
     fn propose_tx(&mut self, tx: &Tx) -> ConnectionResult<u64> {
         let response = self
             .validator_api_client
-            .propose_tx(&tx.into())
+            .propose_tx_opt(&tx.into(), common_headers_call_option(&self.chain_id))
             .map_err(|err| {
                 log::warn!(self.logger, "validator propose_tx RPC call failed: {}", err);
                 err

--- a/validator/service/src/blockchain_api.rs
+++ b/validator/service/src/blockchain_api.rs
@@ -7,13 +7,14 @@ use mc_common::logger::Logger;
 use mc_connection::{BlockchainConnection, ConnectionManager, RetryableBlockchainConnection};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{tokens::Mob, Token};
-use mc_util_grpc::{rpc_database_err, rpc_logger, send_result};
+use mc_util_grpc::{rpc_database_err, rpc_logger, rpc_precondition_error, send_result};
 use mc_validator_api::{
     consensus_common::{BlocksRequest, BlocksResponse, LastBlockInfoResponse},
     consensus_common_grpc::{create_blockchain_api, BlockchainApi as GrpcBlockchainApi},
     empty::Empty,
 };
 use rayon::prelude::*; // For par_iter
+use std::{collections::HashMap, iter::FromIterator};
 
 pub struct BlockchainApi<BC: BlockchainConnection + 'static> {
     /// Ledger DB.
@@ -53,26 +54,70 @@ impl<BC: BlockchainConnection + 'static> BlockchainApi<BC> {
         &self,
         logger: &Logger,
     ) -> Result<LastBlockInfoResponse, RpcStatus> {
-        let num_blocks = self
+        let latest_local_block = self
             .ledger_db
-            .num_blocks()
+            .get_latest_block()
             .map_err(|err| rpc_database_err(err, logger))?;
 
-        let mut resp = LastBlockInfoResponse::new();
-        resp.set_index(num_blocks - 1);
-
-        // Iterate an owned list of connections in parallel, get the block info for
-        // each, and extract the fee. If no fees are returned, use the hard-coded
-        // minimum.
-        let minimum_fee = self
+        // Get the last block information from all nodes we are aware of, in parallel.
+        let last_block_infos = self
             .conn_manager
             .conns()
             .par_iter()
             .filter_map(|conn| conn.fetch_block_info(std::iter::empty()).ok())
-            .filter_map(|block_info| block_info.minimum_fee_or_none(&Mob::ID))
-            .max()
-            .unwrap_or(Mob::MINIMUM_FEE);
-        resp.set_mob_minimum_fee(minimum_fee);
+            .collect::<Vec<_>>();
+
+        // Must have at least one node to get the last block info from.
+        let latest_network_block = last_block_infos.first().ok_or(rpc_precondition_error(
+            "last_block_infos",
+            "No last block information available",
+            logger,
+        ))?;
+
+        // Ensure that all nodes agree on the minimum fee map.
+        if last_block_infos
+            .windows(2)
+            .any(|window| window[0].minimum_fees != window[1].minimum_fees)
+        {
+            return Err(rpc_precondition_error(
+                "minimum_fees",
+                "Some nodes do not agree on the minimum fees",
+                logger,
+            ));
+        }
+
+        let mut resp = LastBlockInfoResponse::new();
+
+        // It's possible the network is at a higher block index than we are, but until
+        // we have fully synced to that block index, there is no point in
+        // reporting it to full-service since we won't have block data for these blocks
+        // untill we have caught up.
+        resp.set_index(latest_local_block.index);
+
+        // In theory the network could be at a higher block version than we are, but
+        // this is an intermittent issue and will resolve itself once we are
+        // fully synced. The alternative would've been to try and get the block
+        // version from the last_block_infos array, but it is possible to run
+        // into an edgecase where not all nodes agree on the block version (which could
+        // happen at a very brief period when a new version is being enabled).
+        // Simply choosing the max block version will allow a malicious node to poison
+        // us, so we choose not to worry about any of that and instead use the
+        // local ledger as the source of truth.
+        resp.set_network_block_version(latest_local_block.version);
+
+        // Use minimum fee information from the network (which we previously verified
+        // all nodes agree on).
+        resp.set_mob_minimum_fee(
+            latest_network_block
+                .minimum_fee_or_none(&Mob::ID)
+                .unwrap_or(Mob::MINIMUM_FEE),
+        );
+        resp.set_minimum_fees(HashMap::from_iter(
+            latest_network_block
+                .minimum_fees
+                .iter()
+                .map(|(token_id, fee)| (**token_id, *fee)),
+        ));
 
         Ok(resp)
     }

--- a/validator/service/src/blockchain_api.rs
+++ b/validator/service/src/blockchain_api.rs
@@ -68,11 +68,13 @@ impl<BC: BlockchainConnection + 'static> BlockchainApi<BC> {
             .collect::<Vec<_>>();
 
         // Must have at least one node to get the last block info from.
-        let latest_network_block = last_block_infos.first().ok_or(rpc_precondition_error(
-            "last_block_infos",
-            "No last block information available",
-            logger,
-        ))?;
+        let latest_network_block = last_block_infos.first().ok_or_else(|| {
+            rpc_precondition_error(
+                "last_block_infos",
+                "No last block information available",
+                logger,
+            )
+        })?;
 
         // Ensure that all nodes agree on the minimum fee map.
         if last_block_infos


### PR DESCRIPTION
### Motivation

We discovered a few issues as a result of the recent switch to block version 2.

### In this PR
* Fixing `mc-validator-service` to properly forward the complete fee map and block version
* Change fee map handling - prior to this PR we chose the max fee for each token, but that allows a malicious node to do a grief attack and trick clients into higher than necessary fee. This PR changes the strategy around this, and instead enforces that all nodes are in agreement about the fee map. If they aren't, that indicates a network fork and should be carefully handled by the operator.
* Make `mc-validator-service` validate chain-id headers if the chain-id argument is passed to it.
