### PR TITLE
Ignore _pycache_ and generated bin folders/files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ dbml-error.log
 
 __pycache__
 
-*bin
+/tools/*.bin


### PR DESCRIPTION
Ignore locally generated files such as __pycache__ and bin files/folders

