### PR TITLE
making chain-id optional and default to empty string

### DIFF
--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -168,7 +168,7 @@ pub struct PeersConfig {
     pub tx_source_urls: Option<Vec<String>>,
 
     /// Chain Id
-    #[structopt(long)]
+    #[structopt(default_value = "", long)]
     pub chain_id: String,
 }
 


### PR DESCRIPTION
after discussion with @holtzman and reviewing discussion in Slack, we decided to make this field optional to not break existing scripts. May revisit in the future.