### PR TITLE
Feature/order responses by block height

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -329,15 +329,17 @@ impl TransactionLogModel for TransactionLog {
 
         if let Some(min_block_index) = min_block_index {
             query =
-                query.filter(transaction_logs::finalized_block_index.ge(min_block_index as i64));
+                query.filter(transaction_logs::submitted_block_index.ge(min_block_index as i64));
         }
 
         if let Some(max_block_index) = max_block_index {
             query =
-                query.filter(transaction_logs::finalized_block_index.le(max_block_index as i64));
+                query.filter(transaction_logs::submitted_block_index.le(max_block_index as i64));
         }
 
-        let transaction_logs: Vec<TransactionLog> = query.order(transaction_logs::id).load(conn)?;
+        let transaction_logs: Vec<TransactionLog> = query
+            .order(transaction_logs::submitted_block_index.desc())
+            .load(conn)?;
 
         let results = transaction_logs
             .into_iter()

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -118,15 +118,6 @@ pub trait TransactionLogModel {
     /// Get a transaction log from the TransactionId.
     fn get(id: &TransactionID, conn: &Conn) -> Result<TransactionLog, WalletDbError>;
 
-    /// Get all transaction logs for the given block index.
-    fn get_all_for_block_index(
-        block_index: u64,
-        conn: &Conn,
-    ) -> Result<Vec<TransactionLog>, WalletDbError>;
-
-    /// Get all transaction logs ordered by finalized_block_index.
-    fn get_all_ordered_by_block_index(conn: &Conn) -> Result<Vec<TransactionLog>, WalletDbError>;
-
     /// Get the Txos associated with a given TransactionId, grouped according to
     /// their type.
     ///
@@ -226,35 +217,6 @@ impl TransactionLogModel for TransactionLog {
             }
             Err(e) => Err(e.into()),
         }
-    }
-
-    fn get_all_for_block_index(
-        block_index: u64,
-        conn: &Conn,
-    ) -> Result<Vec<TransactionLog>, WalletDbError> {
-        use crate::db::schema::transaction_logs::{
-            all_columns, dsl::transaction_logs, finalized_block_index,
-        };
-
-        let matches: Vec<TransactionLog> = transaction_logs
-            .select(all_columns)
-            .filter(finalized_block_index.eq(block_index as i64))
-            .load::<TransactionLog>(conn)?;
-
-        Ok(matches)
-    }
-
-    fn get_all_ordered_by_block_index(conn: &Conn) -> Result<Vec<TransactionLog>, WalletDbError> {
-        use crate::db::schema::transaction_logs::{
-            all_columns, dsl::transaction_logs, finalized_block_index,
-        };
-
-        let matches = transaction_logs
-            .select(all_columns)
-            .order_by(finalized_block_index.asc())
-            .load(conn)?;
-
-        Ok(matches)
     }
 
     fn get_associated_txos(&self, conn: &Conn) -> Result<AssociatedTxos, WalletDbError> {

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -588,7 +588,7 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        Ok(query.load(conn)?)
+        Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }
 
     fn list_for_account(
@@ -687,7 +687,7 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        Ok(query.load(conn)?)
+        Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }
 
     fn list_for_address(
@@ -778,9 +778,7 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        let txos: Vec<Txo> = query.load(conn)?;
-
-        Ok(txos)
+        Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }
 
     fn list_unspent(
@@ -854,7 +852,11 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        Ok(query.select(txos::all_columns).distinct().load(conn)?)
+        Ok(query
+            .select(txos::all_columns)
+            .distinct()
+            .order(txos::received_block_index.desc())
+            .load(conn)?)
     }
 
     fn list_unverified(
@@ -916,7 +918,10 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        Ok(query.distinct().load(conn)?)
+        Ok(query
+            .distinct()
+            .order(txos::received_block_index.desc())
+            .load(conn)?)
     }
 
     fn list_unspent_or_pending_key_images(
@@ -938,8 +943,10 @@ impl TxoModel for Txo {
             query = query.filter(txos::token_id.eq(token_id as i64));
         }
 
-        let results: Vec<(Option<Vec<u8>>, String)> =
-            query.select((txos::key_image, txos::id)).load(conn)?;
+        let results: Vec<(Option<Vec<u8>>, String)> = query
+            .select((txos::key_image, txos::id))
+            .order(txos::received_block_index.desc())
+            .load(conn)?;
 
         Ok(results
             .into_iter()
@@ -994,7 +1001,7 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        Ok(query.load(conn)?)
+        Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }
 
     fn list_orphaned(
@@ -1034,9 +1041,7 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        let txos: Vec<Txo> = query.load(conn)?;
-
-        Ok(txos)
+        Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }
 
     fn list_pending(
@@ -1093,9 +1098,11 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        let txos: Vec<Txo> = query.select(txos::all_columns).distinct().load(conn)?;
-
-        Ok(txos)
+        Ok(query
+            .select(txos::all_columns)
+            .distinct()
+            .order(txos::received_block_index.desc())
+            .load(conn)?)
     }
 
     fn get(txo_id_hex: &str, conn: &Conn) -> Result<Txo, WalletDbError> {

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -518,25 +518,60 @@ where
         },
         JsonCommandRequest::get_all_transaction_logs_for_block { block_index } => {
             let block_index = block_index.parse::<u64>().map_err(format_error)?;
-            let transaction_logs = service
+            let transaction_logs_and_txos = service
                 .list_transaction_logs(None, None, None, Some(block_index), Some(block_index))
                 .map_err(format_error)?;
-            let transaction_log_map: Map<String, serde_json::Value> = Map::from_iter(
-                transaction_logs
-                    .iter()
-                    .map(|(t, a, _v)| {
-                        (
-                            t.id.clone(),
-                            serde_json::json!(
-                                json_rpc::v1::models::transaction_log::TransactionLog::new(t, a)
-                            ),
-                        )
-                    })
-                    .collect::<Vec<(String, serde_json::Value)>>(),
-            );
+
+            let mut transaction_log_map: Map<String, serde_json::Value> = Map::new();
+
+            let received_txos = service
+                .list_txos(
+                    None,
+                    None,
+                    None,
+                    Some(*Mob::ID),
+                    Some(block_index),
+                    Some(block_index),
+                    None,
+                    None,
+                )
+                .map_err(format_error)?;
+
+            let received_tx_logs: Vec<TransactionLog> = received_txos
+                .iter()
+                .map(|(txo, _)| {
+                    let subaddress_b58 = match (txo.subaddress_index, txo.account_id.as_ref()) {
+                        (Some(subaddress_index), Some(account_id)) => service
+                            .get_address_for_account(
+                                &AccountID(account_id.clone()),
+                                subaddress_index,
+                            )
+                            .map(|assigned_sub| assigned_sub.public_address_b58)
+                            .ok(),
+                        _ => None,
+                    };
+
+                    TransactionLog::new_from_received_txo(txo, subaddress_b58)
+                })
+                .collect::<Result<Vec<TransactionLog>, _>>()
+                .map_err(format_error)?;
+
+            for received_tx_log in received_tx_logs.iter() {
+                let tx_log_json = serde_json::to_value(received_tx_log).map_err(format_error)?;
+                transaction_log_map.insert(received_tx_log.transaction_log_id.clone(), tx_log_json);
+            }
+
+            for (tx_log, associated_txos, _status) in &transaction_logs_and_txos {
+                let tx_log_json =
+                    serde_json::json!(json_rpc::v1::models::transaction_log::TransactionLog::new(
+                        tx_log,
+                        associated_txos
+                    ));
+                transaction_log_map.insert(tx_log.id.clone(), tx_log_json);
+            }
 
             JsonCommandResponse::get_all_transaction_logs_for_block {
-                transaction_log_ids: transaction_logs
+                transaction_log_ids: transaction_logs_and_txos
                     .iter()
                     .map(|(t, _a, _v)| t.id.to_string())
                     .collect(),

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -517,13 +517,12 @@ where
                 .collect(),
         },
         JsonCommandRequest::get_all_transaction_logs_for_block { block_index } => {
-            let transaction_logs_and_txos = service
-                .get_all_transaction_logs_for_block(
-                    block_index.parse::<u64>().map_err(format_error)?,
-                )
+            let block_index = block_index.parse::<u64>().map_err(format_error)?;
+            let transaction_logs = service
+                .list_transaction_logs(None, None, None, Some(block_index), Some(block_index))
                 .map_err(format_error)?;
             let transaction_log_map: Map<String, serde_json::Value> = Map::from_iter(
-                transaction_logs_and_txos
+                transaction_logs
                     .iter()
                     .map(|(t, a, _v)| {
                         (
@@ -537,7 +536,7 @@ where
             );
 
             JsonCommandResponse::get_all_transaction_logs_for_block {
-                transaction_log_ids: transaction_logs_and_txos
+                transaction_log_ids: transaction_logs
                     .iter()
                     .map(|(t, _a, _v)| t.id.to_string())
                     .collect(),
@@ -546,7 +545,7 @@ where
         }
         JsonCommandRequest::get_all_transaction_logs_ordered_by_block => {
             let transaction_logs_and_txos = service
-                .get_all_transaction_logs_ordered_by_block()
+                .list_transaction_logs(None, None, None, None, None)
                 .map_err(format_error)?;
 
             let mut transaction_log_map: Map<String, serde_json::Value> = Map::new();

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -17,9 +17,9 @@ use crate::{
             confirmation_number::Confirmation,
             network_status::NetworkStatus,
             receiver_receipt::ReceiverReceipt,
-            transaction_log::{TransactionLog, TransactionLogMap},
+            transaction_log::TransactionLog,
             tx_proposal::{TxProposal, UnsignedTxProposal},
-            txo::{Txo, TxoMap},
+            txo::Txo,
             wallet_status::WalletStatus,
         },
     },
@@ -28,6 +28,7 @@ use crate::{
 };
 use mc_mobilecoind_json::data_types::{JsonTx, JsonTxOut, JsonTxOutMembershipProof};
 use serde::{Deserialize, Serialize};
+use serde_json::Map;
 use std::collections::HashMap;
 
 /// Responses from the Full Service Wallet.
@@ -134,7 +135,7 @@ pub enum JsonCommandResponse {
     },
     get_transaction_logs {
         transaction_log_ids: Vec<String>,
-        transaction_log_map: TransactionLogMap,
+        transaction_log_map: Map<String, serde_json::Value>,
     },
     get_txo {
         txo: Txo,
@@ -144,7 +145,7 @@ pub enum JsonCommandResponse {
     },
     get_txos {
         txo_ids: Vec<String>,
-        txo_map: TxoMap,
+        txo_map: Map<String, serde_json::Value>,
     },
     get_txo_membership_proofs {
         outputs: Vec<JsonTxOut>,

--- a/full-service/src/json_rpc/v2/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v2/models/transaction_log.rs
@@ -2,8 +2,6 @@
 
 //! API definition for the TransactionLog object.
 
-use std::collections::BTreeMap;
-
 use mc_common::HashMap;
 use serde::{Deserialize, Serialize};
 
@@ -13,9 +11,6 @@ use crate::{
 };
 
 use super::amount::Amount;
-
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct TransactionLogMap(pub BTreeMap<String, TransactionLog>);
 
 /// A log of a transaction that occurred on the MobileCoin network, constructed
 /// and/or submitted from an account in this wallet.

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -2,13 +2,8 @@
 
 //! API definition for the Txo object.
 
-use std::collections::BTreeMap;
-
 use crate::{db, db::txo::TxoStatus};
 use serde_derive::{Deserialize, Serialize};
-
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct TxoMap(pub BTreeMap<String, Txo>);
 
 /// An Txo in the wallet.
 ///

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -56,17 +56,6 @@ pub trait TransactionLogService {
         &self,
         transaction_id_hex: &str,
     ) -> Result<(TransactionLog, AssociatedTxos, ValueMap), TransactionLogServiceError>;
-
-    /// Get all transaction logs for a given block.
-    fn get_all_transaction_logs_for_block(
-        &self,
-        block_index: u64,
-    ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError>;
-
-    /// Get all transaction logs ordered& by finalized_block_index.
-    fn get_all_transaction_logs_ordered_by_block(
-        &self,
-    ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError>;
 }
 
 impl<T, FPR> TransactionLogService for WalletService<T, FPR>
@@ -104,39 +93,6 @@ where
         let value_map = transaction_log.value_map(&conn)?;
 
         Ok((transaction_log, associated, value_map))
-    }
-
-    fn get_all_transaction_logs_for_block(
-        &self,
-        block_index: u64,
-    ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError> {
-        let conn = self.get_conn()?;
-        let transaction_logs = TransactionLog::get_all_for_block_index(block_index, &conn)?;
-        let mut res: Vec<(TransactionLog, AssociatedTxos, ValueMap)> = Vec::new();
-        for transaction_log in transaction_logs {
-            res.push((
-                transaction_log.clone(),
-                transaction_log.get_associated_txos(&conn)?,
-                transaction_log.value_map(&conn)?,
-            ));
-        }
-        Ok(res)
-    }
-
-    fn get_all_transaction_logs_ordered_by_block(
-        &self,
-    ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError> {
-        let conn = self.get_conn()?;
-        let transaction_logs = TransactionLog::get_all_ordered_by_block_index(&conn)?;
-        let mut res: Vec<(TransactionLog, AssociatedTxos, ValueMap)> = Vec::new();
-        for transaction_log in transaction_logs {
-            res.push((
-                transaction_log.clone(),
-                transaction_log.get_associated_txos(&conn)?,
-                transaction_log.value_map(&conn)?,
-            ));
-        }
-        Ok(res)
     }
 }
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -4,13 +4,7 @@
 
 # RUSTFLAGS="-C instrument-coverage" \
 
-set -e
-
-if [[ ! -z "$1" ]]; then
-    cd "$1"
-fi
-
 echo "Testing in $PWD"
 SGX_MODE=SW IAS_MODE=DEV CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css \
-cargo test
+cargo test $1
 echo "Testing in $PWD complete."


### PR DESCRIPTION
### In this PR
* This enables txos and transaction logs to be returned ordered by their received/submitted block indices, descending
* Cleans up some unnecessary functions leftover from before refactor
* updates test script to allow specified test

