### PR TITLE
Specify Subaddress for Sender Memo Credential

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -599,7 +599,7 @@ mod tests {
             .unwrap();
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         // Log submitted transaction from tx_proposal
@@ -769,7 +769,7 @@ mod tests {
 
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         let tx_log = TransactionLog::log_submitted(
@@ -848,7 +848,7 @@ mod tests {
             .unwrap();
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         // Log submitted transaction from tx_proposal
@@ -946,7 +946,7 @@ mod tests {
             .unwrap();
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         assert_eq!(
@@ -1013,7 +1013,7 @@ mod tests {
             .unwrap();
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         // Log submitted transaction from tx_proposal

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2186,7 +2186,7 @@ mod tests {
             .unwrap();
         builder.select_txos(&conn, None).unwrap();
         builder.set_tombstone(0).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&sender_account_key).unwrap();
 
         // Sleep to make sure that the foreign keys exist

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -168,7 +168,7 @@ where
                     tombstone_block,
                     max_spendable_value,
                     comment,
-                    TransactionMemo::RTH,
+                    TransactionMemo::RTH(None),
                     None,
                 )
                 .map_err(format_error)?;
@@ -279,7 +279,7 @@ where
                     Some(Mob::ID.to_string()),
                     tombstone_block,
                     max_spendable_value,
-                    TransactionMemo::RTH,
+                    TransactionMemo::RTH(None),
                     None,
                 )
                 .map_err(format_error)?;

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -54,6 +54,7 @@ pub enum JsonCommandRequest {
         max_spendable_value: Option<String>,
         comment: Option<String>,
         block_version: Option<String>,
+        sender_memo_credential_subaddress_index: Option<String>,
     },
     build_burn_transaction {
         account_id: String,
@@ -77,6 +78,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
+        sender_memo_credential_subaddress_index: Option<String>,
     },
     build_unsigned_burn_transaction {
         account_id: String,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -145,6 +145,7 @@ where
             max_spendable_value,
             comment,
             block_version,
+            sender_memo_credential_subaddress_index,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -161,6 +162,10 @@ where
                 None => None,
             };
 
+            let sender_memo_credential_subaddress_index = sender_memo_credential_subaddress_index
+                .map(|i| i.parse::<u64>().map_err(format_error))
+                .transpose()?;
+
             let (transaction_log, associated_txos, value_map, tx_proposal) = service
                 .build_sign_and_submit_transaction(
                     &account_id,
@@ -171,7 +176,7 @@ where
                     tombstone_block,
                     max_spendable_value,
                     comment,
-                    TransactionMemo::RTH,
+                    TransactionMemo::RTH(sender_memo_credential_subaddress_index),
                     block_version,
                 )
                 .map_err(format_error)?;
@@ -249,6 +254,7 @@ where
             tombstone_block,
             max_spendable_value,
             block_version,
+            sender_memo_credential_subaddress_index,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -265,6 +271,10 @@ where
                 None => None,
             };
 
+            let sender_memo_credential_subaddress_index = sender_memo_credential_subaddress_index
+                .map(|i| i.parse::<u64>().map_err(format_error))
+                .transpose()?;
+
             let tx_proposal = service
                 .build_and_sign_transaction(
                     &account_id,
@@ -274,7 +284,7 @@ where
                     fee_token_id,
                     tombstone_block,
                     max_spendable_value,
-                    TransactionMemo::RTH,
+                    TransactionMemo::RTH(sender_memo_credential_subaddress_index),
                     block_version,
                 )
                 .map_err(format_error)?;

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -472,7 +472,7 @@ where
             None,
             tombstone_block.map(|t| t.to_string()),
             max_spendable_value.map(|f| f.to_string()),
-            TransactionMemo::RTH,
+            TransactionMemo::RTH(None),
             None,
         )?;
 

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -418,7 +418,7 @@ mod tests {
                 None,
                 None,
                 None,
-                TransactionMemo::RTH,
+                TransactionMemo::RTH(None),
                 None,
             )
             .expect("Could not build transaction");
@@ -549,7 +549,7 @@ mod tests {
                 None,
                 None,
                 None,
-                TransactionMemo::RTH,
+                TransactionMemo::RTH(None),
                 None,
             )
             .expect("Could not build transaction");
@@ -673,7 +673,7 @@ mod tests {
                 None,
                 None,
                 None,
-                TransactionMemo::RTH,
+                TransactionMemo::RTH(None),
                 None,
             )
             .expect("Could not build transaction");
@@ -814,7 +814,7 @@ mod tests {
                 None,
                 None,
                 None,
-                TransactionMemo::RTH,
+                TransactionMemo::RTH(None),
                 None,
             )
             .expect("Could not build transaction");

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -592,9 +592,14 @@ mod tests {
     };
     use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{test_with_logger, Logger};
+    use mc_crypto_keys::RistrettoPublic;
     use mc_crypto_rand::rand_core::RngCore;
-    use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Token};
+    use mc_transaction_core::{
+        get_tx_out_shared_secret, ring_signature::KeyImage, tokens::Mob, Token,
+    };
+    use mc_transaction_extra::AuthenticatedSenderMemo;
     use rand::{rngs::StdRng, SeedableRng};
+    use std::convert::TryFrom;
 
     #[test_with_logger]
     fn test_build_transaction_and_log(logger: Logger) {
@@ -1146,6 +1151,194 @@ mod tests {
             )) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
         };
+    }
+
+    // Test sending a transaction from Alice -> Bob, and then from Bob -> Alice
+    #[test_with_logger]
+    fn test_send_transaction_with_sender_memo_cred_subaddress_index(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), logger.clone());
+
+        // Create our main account for the wallet
+        let alice = service
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
+            .unwrap();
+
+        // Add a block with a transaction for Alice
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_account_id = AccountID::from(&alice_account_key);
+        let alice_public_address = alice_account_key.default_subaddress();
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100 * MOB,
+            &vec![KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
+
+        // Verify balance for Alice
+        let balance = service
+            .get_balance_for_account(&AccountID(alice.id.clone()))
+            .unwrap();
+        let balance_pmob = balance.get(&Mob::ID).unwrap();
+        assert_eq!(balance_pmob.unspent, 100 * MOB as u128);
+
+        // Add an account for Bob
+        let bob = service
+            .create_account(
+                Some("Bob's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                "".to_string(),
+            )
+            .unwrap();
+        let bob_account_key: AccountKey =
+            mc_util_serial::decode(&bob.account_key).expect("Could not decode account key");
+        let bob_account_id = AccountID::from(&bob_account_key);
+
+        // Create an assigned subaddress for Bob to receive funds from Alice
+        let bob_address_from_alice = service
+            .assign_address_for_account(&AccountID(bob.id.clone()), Some("From Alice"))
+            .unwrap();
+
+        // Create an assigned subaddress for Alice to receive from Bob, which will be
+        // used to authenticate the sender (Alice)
+        let alice_address_from_bob = service
+            .assign_address_for_account(&alice_account_id, Some("From Bob"))
+            .unwrap();
+
+        // Send a transaction from Alice to Bob
+        let (transaction_log, _associated_txos, _value_map, tx_proposal) = service
+            .build_sign_and_submit_transaction(
+                &alice.id,
+                &[(
+                    bob_address_from_alice.public_address_b58,
+                    AmountJSON::new(42 * MOB, Mob::ID),
+                )],
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                TransactionMemo::RTH(Some(alice_address_from_bob.subaddress_index as u64)),
+                None,
+            )
+            .unwrap();
+        log::info!(logger, "Built and submitted transaction from Alice");
+
+        // NOTE: Submitting to the test ledger via propose_tx doesn't actually add the
+        // block to the ledger, because no consensus is occurring, so this is the
+        // workaround.
+        {
+            log::info!(logger, "Adding block from transaction log");
+            let key_images: Vec<KeyImage> = tx_proposal
+                .input_txos
+                .iter()
+                .map(|txo| txo.key_image.clone())
+                .collect();
+
+            // Note: This block doesn't contain the fee output.
+            add_block_with_tx_outs(
+                &mut ledger_db,
+                &[
+                    tx_proposal.change_txos[0].tx_out.clone(),
+                    tx_proposal.payload_txos[0].tx_out.clone(),
+                ],
+                &key_images,
+                &mut rng,
+            );
+        }
+
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
+        manually_sync_account(
+            &ledger_db,
+            &service.wallet_db.as_ref().unwrap(),
+            &bob_account_id,
+            &logger,
+        );
+
+        // Get the Txos from the transaction log
+        let transaction_txos = transaction_log
+            .get_associated_txos(&service.get_conn().unwrap())
+            .unwrap();
+        let secreted = transaction_txos
+            .outputs
+            .iter()
+            .map(|(t, _)| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
+            .collect::<Vec<Txo>>();
+        assert_eq!(secreted.len(), 1);
+        assert_eq!(secreted[0].value as u64, 42 * MOB);
+
+        let change = transaction_txos
+            .change
+            .iter()
+            .map(|(t, _)| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
+            .collect::<Vec<Txo>>();
+        assert_eq!(change.len(), 1);
+        assert_eq!(change[0].value as u64, 58 * MOB - Mob::MINIMUM_FEE);
+
+        let inputs = transaction_txos
+            .inputs
+            .iter()
+            .map(|t| Txo::get(&t.id, &service.get_conn().unwrap()).unwrap())
+            .collect::<Vec<Txo>>();
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].value as u64, 100 * MOB);
+
+        // Verify balance for Alice = original balance - fee - txo_value
+        let balance = service
+            .get_balance_for_account(&AccountID(alice.id.clone()))
+            .unwrap();
+        let balance_pmob = balance.get(&Mob::ID).unwrap();
+        assert_eq!(balance_pmob.unspent, (58 * MOB - Mob::MINIMUM_FEE) as u128);
+
+        // Bob's balance should be = output_txo_value
+        let bob_balance = service
+            .get_balance_for_account(&AccountID(bob.id.clone()))
+            .unwrap();
+        let bob_balance_pmob = bob_balance.get(&Mob::ID).unwrap();
+        assert_eq!(bob_balance_pmob.unspent, 42000000000000);
+
+        // Decrypt the memo from the transaction txo and verify.
+        let txo = &tx_proposal.payload_txos[0].tx_out;
+
+        let shared_secret = get_tx_out_shared_secret(
+            bob_account_key.view_private_key(),
+            &RistrettoPublic::try_from(&txo.public_key).unwrap(),
+        );
+
+        let memo = txo.decrypt_memo(&shared_secret);
+        let authenticated_sender_memo = AuthenticatedSenderMemo::from(memo.get_memo_data());
+        let validation = authenticated_sender_memo.validate(
+            &alice_account_key.subaddress(alice_address_from_bob.subaddress_index as u64),
+            &bob_account_key
+                .subaddress_view_private(bob_address_from_alice.subaddress_index as u64),
+            &txo.public_key,
+        );
+
+        assert!(bool::from(validation));
     }
 
     // FIXME: Test with 0 change transactions

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -582,7 +582,7 @@ mod tests {
         builder.select_txos(&conn, None).unwrap();
         builder.set_tombstone(0).unwrap();
 
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.payload_txos.len(), 1);
         assert_eq!(proposal.payload_txos[0].recipient_public_address, recipient);
@@ -692,7 +692,7 @@ mod tests {
 
         builder.set_txos(&conn, &vec![txos[0].id.clone()]).unwrap();
         builder.set_tombstone(0).unwrap();
-        match builder.build(TransactionMemo::RTH, &conn) {
+        match builder.build(TransactionMemo::RTH(None), &conn) {
             Ok(_) => {
                 panic!("Should not be able to construct Tx with > inputs value as output value")
             }
@@ -713,7 +713,7 @@ mod tests {
             .set_txos(&conn, &vec![txos[0].id.clone(), txos[1].id.clone()])
             .unwrap();
         builder.set_tombstone(0).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.payload_txos.len(), 1);
         assert_eq!(proposal.payload_txos[0].recipient_public_address, recipient);
@@ -777,7 +777,7 @@ mod tests {
         // pick up both 70 and 80
         builder.select_txos(&conn, Some(80 * MOB)).unwrap();
         builder.set_tombstone(0).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.payload_txos.len(), 1);
         assert_eq!(proposal.payload_txos[0].recipient_public_address, recipient);
@@ -821,7 +821,7 @@ mod tests {
         assert_eq!(ledger_db.num_blocks().unwrap(), 13);
 
         // We must set tombstone block before building
-        match builder.build(TransactionMemo::RTH, &conn) {
+        match builder.build(TransactionMemo::RTH(None), &conn) {
             Ok(_) => panic!("Expected TombstoneNotSet error"),
             Err(WalletTransactionBuilderError::TombstoneNotSet) => {}
             Err(e) => panic!("Unexpected error {:?}", e),
@@ -840,7 +840,7 @@ mod tests {
 
         // Not setting the tombstone results in tombstone = 0. This is an acceptable
         // value,
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.tx.prefix.tombstone_block, 23);
 
@@ -858,7 +858,7 @@ mod tests {
 
         // Not setting the tombstone results in tombstone = 0. This is an acceptable
         // value,
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.tx.prefix.tombstone_block, 20);
     }
@@ -895,7 +895,7 @@ mod tests {
         builder.set_tombstone(0).unwrap();
 
         // Verify that not setting fee results in default fee
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
 
@@ -915,7 +915,7 @@ mod tests {
         }
 
         // Verify that not setting fee results in default fee
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
 
@@ -944,7 +944,7 @@ mod tests {
         builder.select_txos(&conn, None).unwrap();
         builder.set_tombstone(0).unwrap();
         builder.set_fee(Mob::MINIMUM_FEE * 10, Mob::ID).unwrap();
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE * 10);
     }
@@ -983,7 +983,7 @@ mod tests {
         builder.set_tombstone(0).unwrap();
 
         // Verify that not setting fee results in default fee
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
@@ -1037,7 +1037,7 @@ mod tests {
         builder.select_txos(&conn, None).unwrap();
         builder.set_tombstone(0).unwrap();
 
-        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
         let proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
 
         assert_eq!(proposal.tx.prefix.fee, Mob::MINIMUM_FEE);

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -183,7 +183,7 @@ mod tests {
                     None,
                     None,
                     None,
-                    TransactionMemo::RTH,
+                    TransactionMemo::RTH(None),
                     None,
                 )
                 .unwrap();

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -269,7 +269,7 @@ where
             fee_token_id,
             tombstone_block,
             None,
-            TransactionMemo::RTH,
+            TransactionMemo::RTH(None),
             None,
         )?;
 
@@ -381,7 +381,7 @@ mod tests {
                 None,
                 None,
                 None,
-                TransactionMemo::RTH,
+                TransactionMemo::RTH(None),
                 None,
             )
             .unwrap();

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -474,7 +474,7 @@ pub fn create_test_minted_and_change_txos(
     builder.add_recipient(recipient, value, Mob::ID).unwrap();
     builder.select_txos(&conn, None).unwrap();
     builder.set_tombstone(0).unwrap();
-    let unsigned_tx_proposal = builder.build(TransactionMemo::RTH, &conn).unwrap();
+    let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
     let tx_proposal = unsigned_tx_proposal.sign(&src_account_key).unwrap();
 
     // There should be 2 outputs, one to dest and one change


### PR DESCRIPTION
This adds the ability for a user to specify which subaddress to generate their Sender Memo Credential from for RTH memos (full reasoning in the linked issue).

The main change is adding an optional parameter to the build_transaction and build_and_submit_transaction endpoints.