### PR TITLE
Make CI enforce Rust formatting/conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,18 @@ jobs:
           INGEST_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | grep ingest-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
           (cd /var/tmp && curl -O https://enclave-distribution.test.mobilecoin.com/${INGEST_SIGSTRUCT_URI})
 
+      - name: Cargo sort
+        run: |
+          cargo install cargo-sort
+          cargo sort --workspace --grouped --check
+
+      - name: Cargo fmt
+        run: |
+          cargo fmt -- --unstable-features --check
+
       - name: Cargo Clippy
         run: |
-          cargo clippy
+          cargo clippy --all --all-features
 
   test:
     runs-on: [self-hosted, Linux, large]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -51,10 +51,10 @@ crossbeam-channel = "0.5"
 diesel = { version = "1.4.8", features = ["sqlcipher-bundled", "chrono"] }
 diesel-derive-enum = { version = "1", features = ["sqlite"] }
 diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
-displaydoc = {version = "0.2", default-features = false }
+displaydoc = { version = "0.2", default-features = false }
 dotenv = "0.15.0"
 grpcio = "0.11"
-hex = {version = "0.4", default-features = false }
+hex = { version = "0.4", default-features = false }
 num_cpus = "1.14"
 protobuf = "2.28.0"
 rand = { version = "0.8", default-features = false }
@@ -74,16 +74,16 @@ tiny-bip39 = "1.0"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
+bs58 = "0.4.0"
 mc-blockchain-test-utils = { path = "../mobilecoin/blockchain/test-utils" }
 mc-connection-test-utils = { path = "../mobilecoin/connection/test-utils" }
 mc-consensus-enclave-api = { path = "../mobilecoin/consensus/enclave/api" }
 mc-fog-report-validation = { path = "../mobilecoin/fog/report/validation", features = ["automock"] }
-mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils"}
+mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils" }
 tempdir = "0.3"
-bs58 = "0.4.0"
 
 [build-dependencies]
+anyhow = "1.0"
 # clippy fails to run without this.
 diesel = { version = "1.4.8", features = ["sqlcipher-bundled"] }
 vergen = "7.4.2"
-anyhow = "1.0"

--- a/mirror/Cargo.toml
+++ b/mirror/Cargo.toml
@@ -38,11 +38,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
 
-
 [dev-dependencies]
-rand_hc = "0.3"
 rand_core = { version = "0.6", default-features = false }
-
+rand_hc = "0.3"
 
 [build-dependencies]
 # Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.

--- a/transaction-signer/Cargo.toml
+++ b/transaction-signer/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [[bin]]
 name = "transaction-signer"
 path = "src/bin/main.rs"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,15 +15,15 @@ mc-common = { path = "../mobilecoin/common", default-features = false, features 
 mc-core = { path = "../mobilecoin/core" }
 mc-crypto-keys = { path = "../mobilecoin/crypto/keys", default-features = false }
 mc-crypto-ring-signature-signer = { path = "../mobilecoin/crypto/ring-signature/signer" }
-mc-transaction-core = { path = "../mobilecoin/transaction/core" }
 mc-transaction-builder = { path = "../mobilecoin/transaction/builder" }
+mc-transaction-core = { path = "../mobilecoin/transaction/core" }
 mc-transaction-extra = { path = "../mobilecoin/transaction/extra" }
 mc-util-serial = { path = "../mobilecoin/util/serial", default-features = false }
 
 mc-full-service = { path = "../full-service" }
 
 base64 = "0.13.1"
-hex = {version = "0.4", default-features = false }
+hex = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -16,7 +16,7 @@ mc-transaction-core = { path = "../../mobilecoin/transaction/core" }
 mc-util-grpc = { path = "../../mobilecoin/util/grpc" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }
 
-displaydoc = {version = "0.2", default-features = false }
+displaydoc = { version = "0.2", default-features = false }
 futures = "0.3"
 grpcio = "0.11.0"
 protobuf = "2.28.0"

--- a/validator/service/Cargo.toml
+++ b/validator/service/Cargo.toml
@@ -10,7 +10,7 @@ name = "validator-service"
 path = "src/bin/main.rs"
 
 [dependencies]
-mc-full-service = { path = "../../full-service"}
+mc-full-service = { path = "../../full-service" }
 mc-validator-api = { path = "../api" }
 
 mc-attest-verifier = { path = "../../mobilecoin/attest/verifier" }
@@ -26,5 +26,5 @@ mc-util-parse = { path = "../../mobilecoin/util/parse" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }
 
 grpcio = "0.11.0"
-structopt = "0.3"
 rayon = "1.5"
+structopt = "0.3"


### PR DESCRIPTION
Rust has opinions about formatting of `.rs` and `Cargo.toml` files and CI should enforce that.
