### PR TITLE
Add public_key to OutputTxo

### DIFF
--- a/full-service/src/json_rpc/v2/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v2/models/transaction_log.rs
@@ -126,6 +126,8 @@ impl InputTxo {
 pub struct OutputTxo {
     pub txo_id_hex: String,
 
+    pub public_key: CompressedRistrettoPublic,
+
     pub amount: Amount,
 
     pub recipient_public_address_b58: String,
@@ -135,6 +137,7 @@ impl OutputTxo {
     pub fn new(txo: &db::models::Txo, recipient_public_address_b58: String) -> Self {
         Self {
             txo_id_hex: txo.id.clone(),
+            public_key: txo.public_key.clone(),
             amount: Amount::from(&txo.amount()),
             recipient_public_address_b58,
         }


### PR DESCRIPTION
### Motivation

http://www.pivotaltracker.com/slack_links/story/183842633

Public key is often used to identify TXOs by ramps and it simplifies ramp code to include the output public key from `build_and_submit_transaction`.

### In this PR
* Add `public_key` to `OutputTxo` json 

