### PR TITLE
adding retry logic for attestation errors

### DIFF
--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -14,6 +14,7 @@ use mc_blockchain_types::{Block, BlockContents, BlockVersion, BlockVersionError}
 use mc_common::HashSet;
 use mc_connection::{
     BlockInfo, BlockchainConnection, RetryableBlockchainConnection, UserTxConnection,
+    _retry::delay::Fibonacci,
 };
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
@@ -202,7 +203,10 @@ where
             .peer_manager
             .conns()
             .par_iter()
-            .filter_map(|conn| conn.fetch_block_info(std::iter::empty()).ok())
+            .filter_map(|conn| {
+                conn.fetch_block_info(Fibonacci::from_millis(10).take(5))
+                    .ok()
+            })
             .collect::<Vec<_>>();
 
         // Ensure that all nodes agree on the latest block version and network fees.

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -23,7 +23,9 @@ use crate::{
 use mc_account_keys::AccountKey;
 use mc_blockchain_types::BlockVersion;
 use mc_common::logger::log;
-use mc_connection::{BlockchainConnection, RetryableUserTxConnection, UserTxConnection};
+use mc_connection::{
+    BlockchainConnection, RetryableUserTxConnection, UserTxConnection, _retry::delay::Fibonacci,
+};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_builder::{
     BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder,
@@ -39,7 +41,7 @@ use crate::service::address::{AddressService, AddressServiceError};
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
-use std::{convert::TryFrom, iter::empty, sync::atomic::Ordering};
+use std::{convert::TryFrom, sync::atomic::Ordering};
 
 use super::models::tx_proposal::UnsignedTxProposal;
 
@@ -475,7 +477,7 @@ where
             .peer_manager
             .conn(responder_id)
             .ok_or(TransactionServiceError::NodeNotFound)?
-            .propose_tx(&tx_proposal.tx, empty())
+            .propose_tx(&tx_proposal.tx, Fibonacci::from_millis(10).take(5))
             .map_err(TransactionServiceError::from)?;
 
         log::trace!(

--- a/validator/service/src/validator_api.rs
+++ b/validator/service/src/validator_api.rs
@@ -6,7 +6,7 @@ use grpcio::{EnvBuilder, RpcContext, RpcStatus, Service, UnarySink};
 use mc_common::logger::{log, Logger};
 use mc_connection::{
     ConnectionManager, Error as ConnectionError, RetryError, RetryableUserTxConnection,
-    UserTxConnection,
+    UserTxConnection, _retry::delay::Fibonacci,
 };
 use mc_fog_report_connection::{Error as FogConnectionError, GrpcFogReportConnection};
 use mc_ledger_db::{Ledger, LedgerDB};
@@ -155,7 +155,7 @@ impl<UTC: UserTxConnection + 'static> ValidatorApi<UTC> {
             .conn_manager
             .conn(responder_id)
             .ok_or_else(|| rpc_internal_error("propose_tx", "conn not found", logger))?
-            .propose_tx(&tx, std::iter::empty());
+            .propose_tx(&tx, Fibonacci::from_millis(10).take(5));
 
         // Convert to GRPC response.
         let mut result = ProposeTxResponse::new();


### PR DESCRIPTION
### Motivation

Currently if the attestation connection has been invalidated by consensus it will simply fail the transaction. This will alleviate that error by adding retry logic (up to 5 times of increasing intervals of time based on the Fibonacci sequence starting at 10ms)

