### PR TITLE
Fixing intermittent OSX test failure issue due to low default filehandle limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
 
    MacOS:
     ```sh
+   echo 'ulimit -n 4096' >> ~/.bash_profile
    echo 'export PATH="/opt/homebrew/opt/openssl@3/bin:$PATH"' >> ~/.bash_profile
    export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
    export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
     CPPFLAGS="-I/usr/local/opt/openssl@3/include"
     PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
     ```
-
+The ```ulimit``` command fixes an issue related to shell resource usage. 
    MacOS:
     ```sh
    echo 'ulimit -n 4096' >> ~/.bash_profile

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
     ```sh
    echo 'ulimit -n 4096' >> ~/.bash_profile
    echo 'export PATH="/opt/homebrew/opt/openssl@3/bin:$PATH"' >> ~/.bash_profile
+   source ~/.bash_profile
    export LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
    export CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include"
    export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3/lib/pkgconfig"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
     CPPFLAGS="-I/usr/local/opt/openssl@3/include"
     PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"
     ```
-The ```ulimit``` command fixes an issue related to shell resource usage. 
+    
+    The `ulimit` command fixes an issue related to shell resource usage. 
+
    MacOS:
     ```sh
    echo 'ulimit -n 4096' >> ~/.bash_profile


### PR DESCRIPTION
### Motivation

On OSX, tests sometimes fail with an error like "panicked at 'Could not create ledger_db: LMDB: Too many open files'"

### In this PR
* fixes #183929476

### Test Plan

* follow README instructions
* run as usual via `./tools/test.sh`

### Future Work

