### PR TITLE
Feature/track build signed submitted for tx log

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -25,7 +25,7 @@ use crate::{
     service::models::tx_proposal::{TxProposal, UnsignedTxProposal},
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TransactionId(pub String);
 
 impl From<&TransactionLog> for TransactionId {
@@ -73,8 +73,10 @@ impl fmt::Display for TransactionId {
 
 #[derive(Debug, PartialEq)]
 pub enum TxStatus {
-    // The transaction log has been built but not yet submitted to consensus
+    // The transaction log has been built but not yet signed
     Built,
+    // The transaction log has been signed but not yet submitted to consensus
+    Signed,
     // The transaction log has been submitted to consensus
     Pending,
     // The txos associated with this transaction log have appeared on the ledger, indicating that
@@ -89,6 +91,7 @@ impl fmt::Display for TxStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TxStatus::Built => write!(f, "built"),
+            TxStatus::Signed => write!(f, "signed"),
             TxStatus::Pending => write!(f, "pending"),
             TxStatus::Succeeded => write!(f, "succeeded"),
             TxStatus::Failed => write!(f, "failed"),
@@ -165,6 +168,20 @@ pub trait TransactionLogModel {
         conn: &Conn,
     ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletDbError>;
 
+    /// Log a transaction that has been built but not yet signed.
+    ///
+    /// Returns:
+    /// * TransactionLog
+    fn log_built(
+        unsigned_tx_proposal: &UnsignedTxProposal,
+        account_id: &AccountID,
+        conn: &Conn,
+    ) -> Result<TransactionLog, WalletDbError>;
+
+    /// Log a transaction that has been signed
+    ///
+    /// Returns:
+    /// * TransactionLog
     fn log_signed(
         tx_proposal: TxProposal,
         comment: String,
@@ -336,54 +353,137 @@ impl TransactionLogModel for TransactionLog {
         Ok(results)
     }
 
+    fn log_built(
+        unsigned_tx_proposal: &UnsignedTxProposal,
+        account_id: &AccountID,
+        conn: &Conn,
+    ) -> Result<TransactionLog, WalletDbError> {
+        use crate::db::schema::{transaction_input_txos, transaction_logs};
+        // Verify that the account exists.
+        Account::get(account_id, conn)?;
+
+        let unsigned_tx = &unsigned_tx_proposal.unsigned_tx;
+        let transaction_log_id = TransactionId::from(unsigned_tx);
+
+        let new_transaction_log = NewTransactionLog {
+            id: &transaction_log_id.to_string(),
+            account_id: &account_id.to_string(),
+            fee_value: unsigned_tx.tx_prefix.fee as i64,
+            fee_token_id: unsigned_tx.tx_prefix.fee_token_id as i64,
+            submitted_block_index: None,
+            tombstone_block_index: None,
+            finalized_block_index: None,
+            comment: "",
+            tx: &[],
+            failed: false,
+        };
+
+        diesel::insert_into(transaction_logs::table)
+            .values(&new_transaction_log)
+            .execute(conn)?;
+
+        // Get each input txo and add it to the transaction_input_txos
+        // table for this transaction.
+        for input_txo in unsigned_tx_proposal.unsigned_input_txos.iter() {
+            let txo_id = TxoID::from(&input_txo.tx_out);
+            let new_transaction_input_txo = NewTransactionInputTxo {
+                transaction_log_id: &transaction_log_id.to_string(),
+                txo_id: &txo_id.to_string(),
+            };
+
+            diesel::insert_into(transaction_input_txos::table)
+                .values(&new_transaction_input_txo)
+                .execute(conn)?;
+        }
+
+        // TODO - Get each payload txo and add it to the transaction_output_txos
+        // table for this transactions.
+        for payload_txo in unsigned_tx_proposal.payload_txos.iter() {
+            Txo::create_new_output(payload_txo, false, &transaction_log_id, conn)?;
+        }
+
+        // TODO - Get each change txo and add it to the transaction_output_txos
+        // table for this transaction as change.
+        for change_txo in unsigned_tx_proposal.change_txos.iter() {
+            Txo::create_new_output(change_txo, true, &transaction_log_id, conn)?;
+        }
+
+        TransactionLog::get(&transaction_log_id, conn)
+    }
+
     fn log_signed(
         tx_proposal: TxProposal,
         comment: String,
         account_id_hex: &str,
         conn: &Conn,
     ) -> Result<TransactionLog, WalletDbError> {
+        use crate::db::schema::transaction_logs;
+
         // Verify that the account exists.
         Account::get(&AccountID(account_id_hex.to_string()), conn)?;
 
         let transaction_log_id = TransactionId::from(&tx_proposal);
         let tx = mc_util_serial::encode(&tx_proposal.tx);
 
-        let new_transaction_log = NewTransactionLog {
-            id: &transaction_log_id.to_string(),
-            account_id: account_id_hex,
-            fee_value: tx_proposal.tx.prefix.fee as i64,
-            fee_token_id: tx_proposal.tx.prefix.fee_token_id as i64,
-            submitted_block_index: None,
-            tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
-            finalized_block_index: None,
-            comment: &comment,
-            tx: &tx,
-            failed: false,
-        };
+        match TransactionLog::get(&transaction_log_id, conn) {
+            Ok(transaction_log) => {
+                // If the transaction log already exists, we just need to update
+                // the input txos with their key images that
+                // were generated during signing and the tx bytes with the
+                // signed tx and the tombstone block index.
+                for input_txo in tx_proposal.input_txos.iter() {
+                    let txo_id = TxoID::from(&input_txo.tx_out);
+                    Txo::update_key_image(&txo_id.to_string(), &input_txo.key_image, None, conn)?;
+                }
 
-        diesel::insert_into(crate::db::schema::transaction_logs::table)
-            .values(&new_transaction_log)
-            .execute(conn)?;
+                diesel::update(&transaction_log)
+                    .set((
+                        transaction_logs::tx.eq(&tx),
+                        transaction_logs::tombstone_block_index
+                            .eq(Some(tx_proposal.tx.prefix.tombstone_block as i64)),
+                    ))
+                    .execute(conn)?;
+            }
+            Err(WalletDbError::TransactionLogNotFound(_)) => {
+                let new_transaction_log = NewTransactionLog {
+                    id: &transaction_log_id.to_string(),
+                    account_id: account_id_hex,
+                    fee_value: tx_proposal.tx.prefix.fee as i64,
+                    fee_token_id: tx_proposal.tx.prefix.fee_token_id as i64,
+                    submitted_block_index: None,
+                    tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
+                    finalized_block_index: None,
+                    comment: &comment,
+                    tx: &tx,
+                    failed: false,
+                };
 
-        for txo in tx_proposal.input_txos.iter() {
-            let txo_id = TxoID::from(&txo.tx_out);
-            Txo::update_key_image(&txo_id.to_string(), &txo.key_image, None, conn)?;
-            let transaction_input_txo = NewTransactionInputTxo {
-                transaction_log_id: &transaction_log_id.to_string(),
-                txo_id: &txo_id.to_string(),
-            };
+                diesel::insert_into(crate::db::schema::transaction_logs::table)
+                    .values(&new_transaction_log)
+                    .execute(conn)?;
 
-            diesel::insert_into(crate::db::schema::transaction_input_txos::table)
-                .values(&transaction_input_txo)
-                .execute(conn)?;
-        }
+                for txo in tx_proposal.input_txos.iter() {
+                    let txo_id = TxoID::from(&txo.tx_out);
+                    Txo::update_key_image(&txo_id.to_string(), &txo.key_image, None, conn)?;
+                    let transaction_input_txo = NewTransactionInputTxo {
+                        transaction_log_id: &transaction_log_id.to_string(),
+                        txo_id: &txo_id.to_string(),
+                    };
 
-        for output_txo in tx_proposal.payload_txos.iter() {
-            Txo::create_new_output(output_txo, false, &transaction_log_id, conn)?;
-        }
+                    diesel::insert_into(crate::db::schema::transaction_input_txos::table)
+                        .values(&transaction_input_txo)
+                        .execute(conn)?;
+                }
 
-        for change_txo in tx_proposal.change_txos.iter() {
-            Txo::create_new_output(change_txo, true, &transaction_log_id, conn)?;
+                for output_txo in tx_proposal.payload_txos.iter() {
+                    Txo::create_new_output(output_txo, false, &transaction_log_id, conn)?;
+                }
+
+                for change_txo in tx_proposal.change_txos.iter() {
+                    Txo::create_new_output(change_txo, true, &transaction_log_id, conn)?;
+                }
+            }
+            Err(e) => return Err(e),
         }
 
         TransactionLog::get(&transaction_log_id, conn)
@@ -621,7 +721,12 @@ mod tests {
         builder.set_tombstone(0).unwrap();
         builder.select_txos(&conn, None).unwrap();
         let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
-        let tx_proposal = unsigned_tx_proposal.sign(&account_key).unwrap();
+        let tx_proposal = unsigned_tx_proposal.clone().sign(&account_key).unwrap();
+
+        assert_eq!(
+            TransactionId::from(&tx_proposal),
+            TransactionId::from(&unsigned_tx_proposal)
+        );
 
         // Log submitted transaction from tx_proposal
         let tx_log = TransactionLog::log_submitted(
@@ -1217,6 +1322,221 @@ mod tests {
             TxoStatus::Unspent
         );
         assert_eq!(updated_change_details.account_id, Some(tx_log.account_id));
+        assert_eq!(
+            updated_change_details.subaddress_index,
+            Some(CHANGE_SUBADDRESS_INDEX as i64)
+        );
+    }
+
+    #[test_with_logger]
+    fn test_log_built_signed_and_submitted(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger.clone());
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        // Start sync thread
+        let _sync_thread = SyncThread::start(ledger_db.clone(), wallet_db.clone(), logger.clone());
+
+        let account_key = random_account_with_seed_values(
+            &wallet_db,
+            &mut ledger_db,
+            &vec![70 * MOB],
+            &mut rng,
+            &logger,
+        );
+
+        // Build a transaction
+        let conn = wallet_db.get_conn().unwrap();
+        let (recipient, mut builder) =
+            builder_for_random_recipient(&account_key, &ledger_db, &mut rng);
+        builder
+            .add_recipient(recipient.clone(), 50 * MOB, Mob::ID)
+            .unwrap();
+        builder.set_tombstone(0).unwrap();
+        builder.select_txos(&conn, None).unwrap();
+        let unsigned_tx_proposal = builder.build(TransactionMemo::RTH(None), &conn).unwrap();
+
+        let tx_log =
+            TransactionLog::log_built(&unsigned_tx_proposal, &AccountID::from(&account_key), &conn)
+                .unwrap();
+
+        let expected_tx_log = TransactionLog {
+            id: TransactionId::from(&unsigned_tx_proposal).to_string(),
+            account_id: AccountID::from(&account_key).to_string(),
+            fee_value: unsigned_tx_proposal.unsigned_tx.tx_prefix.fee as i64,
+            fee_token_id: unsigned_tx_proposal.unsigned_tx.tx_prefix.fee_token_id as i64,
+            submitted_block_index: None,
+            tombstone_block_index: None,
+            finalized_block_index: None,
+            comment: "".to_string(),
+            tx: vec![],
+            failed: false,
+        };
+
+        assert_eq!(tx_log, expected_tx_log);
+
+        let tx_proposal = unsigned_tx_proposal.clone().sign(&account_key).unwrap();
+        let tx_bytes = mc_util_serial::encode(&tx_proposal.tx);
+
+        assert_eq!(
+            TransactionId::from(&tx_proposal),
+            TransactionId::from(&unsigned_tx_proposal)
+        );
+
+        let tx_log = TransactionLog::log_signed(
+            tx_proposal.clone(),
+            "".to_string(),
+            &AccountID::from(&account_key).to_string(),
+            &conn,
+        )
+        .unwrap();
+
+        let expected_tx_log = TransactionLog {
+            id: TransactionId::from(&unsigned_tx_proposal).to_string(),
+            account_id: AccountID::from(&account_key).to_string(),
+            fee_value: tx_proposal.tx.prefix.fee as i64,
+            fee_token_id: tx_proposal.tx.prefix.fee_token_id as i64,
+            submitted_block_index: None,
+            tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
+            finalized_block_index: None,
+            comment: "".to_string(),
+            tx: tx_bytes.clone(),
+            failed: false,
+        };
+
+        assert_eq!(tx_log, expected_tx_log);
+
+        // Log submitted transaction from tx_proposal
+        let tx_log = TransactionLog::log_submitted(
+            &tx_proposal,
+            ledger_db.num_blocks().unwrap(),
+            "".to_string(),
+            &AccountID::from(&account_key).to_string(),
+            &conn,
+        )
+        .unwrap();
+
+        let expected_tx_log = TransactionLog {
+            id: TransactionId::from(&unsigned_tx_proposal).to_string(),
+            account_id: AccountID::from(&account_key).to_string(),
+            fee_value: tx_proposal.tx.prefix.fee as i64,
+            fee_token_id: tx_proposal.tx.prefix.fee_token_id as i64,
+            submitted_block_index: Some(ledger_db.num_blocks().unwrap() as i64),
+            tombstone_block_index: Some(tx_proposal.tx.prefix.tombstone_block as i64),
+            finalized_block_index: None,
+            comment: "".to_string(),
+            tx: tx_bytes,
+            failed: false,
+        };
+        assert_eq!(tx_log, expected_tx_log);
+        assert_eq!(tx_log.value_for_token_id(Mob::ID, &conn).unwrap(), 50 * MOB);
+        assert_eq!(tx_log.status(), TxStatus::Pending);
+
+        // Check the associated_txos for this transaction_log are as expected
+        let associated_txos = tx_log
+            .get_associated_txos(&wallet_db.get_conn().unwrap())
+            .unwrap();
+
+        // There is one associated input TXO to this transaction, and it is now pending.
+        assert_eq!(associated_txos.inputs.len(), 1);
+        let input_details = Txo::get(
+            &associated_txos.inputs[0].id,
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(input_details.value as u64, 70 * MOB);
+        assert_eq!(
+            input_details
+                .status(&wallet_db.get_conn().unwrap())
+                .unwrap(),
+            TxoStatus::Pending
+        );
+        assert_eq!(input_details.subaddress_index.unwrap(), 0);
+
+        // There is one associated output TXO to this transaction, and its recipient
+        // is the destination addr
+        assert_eq!(associated_txos.outputs.len(), 1);
+        assert_eq!(
+            associated_txos.outputs[0].1,
+            b58_encode_public_address(&recipient).unwrap()
+        );
+        let output_details = Txo::get(
+            &associated_txos.outputs[0].0.id,
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(output_details.value as u64, 50 * MOB);
+
+        // We cannot know any details about the received_to_account for this TXO, as it
+        // was sent out of the wallet
+        assert!(output_details.subaddress_index.is_none());
+
+        // Assert change is as expected
+        assert_eq!(associated_txos.change.len(), 1);
+        let change_details = Txo::get(
+            &associated_txos.change[0].0.id,
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(change_details.value as u64, 20 * MOB - Mob::MINIMUM_FEE);
+
+        // Note, this will still be marked as not change until the txo
+        // appears on the ledger and the account syncs.
+        // change becomes unspent once scanned.
+        // The subaddress will also be set once received.
+        assert_eq!(change_details.subaddress_index, None,);
+
+        let key_images: Vec<KeyImage> = tx_proposal
+            .input_txos
+            .iter()
+            .map(|txo| txo.key_image.clone())
+            .collect();
+
+        // Note: This block doesn't contain the fee output.
+        add_block_with_tx_outs(
+            &mut ledger_db,
+            &[
+                tx_proposal.change_txos[0].tx_out.clone(),
+                tx_proposal.payload_txos[0].tx_out.clone(),
+            ],
+            &key_images,
+            &mut rng,
+        );
+
+        assert_eq!(ledger_db.num_blocks().unwrap(), 14);
+        let _sync = manually_sync_account(
+            &ledger_db,
+            &wallet_db,
+            &AccountID(tx_log.account_id.to_string()),
+            &logger,
+        );
+
+        let updated_tx_log = TransactionLog::get(
+            &TransactionId::from(&tx_log),
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(updated_tx_log.status(), TxStatus::Succeeded);
+
+        // Get the change txo again
+        let updated_change_details = Txo::get(
+            &associated_txos.change[0].0.id,
+            &wallet_db.get_conn().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            updated_change_details.status(&conn).unwrap(),
+            TxoStatus::Unspent
+        );
+        assert_eq!(
+            updated_change_details.account_id.unwrap(),
+            tx_log.account_id
+        );
         assert_eq!(
             updated_change_details.subaddress_index,
             Some(CHANGE_SUBADDRESS_INDEX as i64)

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -25,7 +25,7 @@ use crate::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
         models::{Account, AssignedSubaddress, NewTransactionOutputTxo, NewTxo, Txo},
-        transaction_log::TransactionID,
+        transaction_log::TransactionId,
         Conn, WalletDbError,
     },
     service::models::tx_proposal::OutputTxo,
@@ -142,7 +142,7 @@ pub trait TxoModel {
     fn create_new_output(
         output_txo: &OutputTxo,
         is_change: bool,
-        transaction_id: &TransactionID,
+        transaction_id: &TransactionId,
         conn: &Conn,
     ) -> Result<(), WalletDbError>;
 
@@ -395,7 +395,7 @@ impl TxoModel for Txo {
     fn create_new_output(
         output_txo: &OutputTxo,
         is_change: bool,
-        transaction_id: &TransactionID,
+        transaction_id: &TransactionId,
         conn: &Conn,
     ) -> Result<(), WalletDbError> {
         use crate::db::schema::txos;

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -1,7 +1,7 @@
 use crate::{
     db::{
         account::AccountID,
-        transaction_log::TransactionID,
+        transaction_log::TransactionId,
         txo::{TxoID, TxoStatus},
     },
     json_rpc::{
@@ -236,7 +236,7 @@ where
                 .map_err(format_error)?;
             JsonCommandResponse::build_split_txo_transaction {
                 tx_proposal: TxProposal::try_from(&tx_proposal).map_err(format_error)?,
-                transaction_log_id: TransactionID::from(&tx_proposal.tx).to_string(),
+                transaction_log_id: TransactionId::from(&tx_proposal.tx).to_string(),
             }
         }
         JsonCommandRequest::build_transaction {
@@ -286,7 +286,7 @@ where
 
             JsonCommandResponse::build_transaction {
                 tx_proposal: TxProposal::try_from(&tx_proposal).map_err(format_error)?,
-                transaction_log_id: TransactionID::from(&tx_proposal.tx).to_string(),
+                transaction_log_id: TransactionId::from(&tx_proposal.tx).to_string(),
             }
         }
         JsonCommandRequest::check_b58_type { b58_code } => {

--- a/full-service/src/json_rpc/v1/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v1/models/transaction_log.rs
@@ -32,6 +32,7 @@ impl From<&db::transaction_log::TxStatus> for TxStatus {
     fn from(tx_status: &db::transaction_log::TxStatus) -> Self {
         match tx_status {
             db::transaction_log::TxStatus::Built => TxStatus::Built,
+            db::transaction_log::TxStatus::Signed => TxStatus::Built,
             db::transaction_log::TxStatus::Pending => TxStatus::Pending,
             db::transaction_log::TxStatus::Succeeded => TxStatus::Succeeded,
             db::transaction_log::TxStatus::Failed => TxStatus::Failed,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1,7 +1,7 @@
 use crate::{
     db::{
         account::AccountID,
-        transaction_log::TransactionID,
+        transaction_log::TransactionId,
         txo::{TxoID, TxoStatus},
     },
     json_rpc::{
@@ -242,7 +242,7 @@ where
 
             JsonCommandResponse::build_burn_transaction {
                 tx_proposal: TxProposalJSON::try_from(&tx_proposal).map_err(format_error)?,
-                transaction_log_id: TransactionID::from(&tx_proposal.tx).to_string(),
+                transaction_log_id: TransactionId::from(&tx_proposal.tx).to_string(),
             }
         }
         JsonCommandRequest::build_transaction {
@@ -293,7 +293,7 @@ where
 
             JsonCommandResponse::build_transaction {
                 tx_proposal: TxProposalJSON::try_from(&tx_proposal).map_err(format_error)?,
-                transaction_log_id: TransactionID::from(&tx_proposal.tx).to_string(),
+                transaction_log_id: TransactionId::from(&tx_proposal.tx).to_string(),
             }
         }
         JsonCommandRequest::build_unsigned_burn_transaction {

--- a/full-service/src/json_rpc/v2/models/public_address.rs
+++ b/full-service/src/json_rpc/v2/models/public_address.rs
@@ -30,7 +30,7 @@ impl From<&mc_account_keys::PublicAddress> for PublicAddress {
             spend_public_key: hex::encode(src.spend_public_key().to_bytes()),
             fog_report_url: src.fog_report_url().map(|url| url.to_string()),
             fog_report_id: src.fog_report_id().map(|id| id.to_string()),
-            fog_authority_sig: src.fog_authority_sig().map(|sig| hex::encode(sig)),
+            fog_authority_sig: src.fog_authority_sig().map(hex::encode),
         }
     }
 }

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -5,7 +5,7 @@
 use crate::{
     db::{
         models::{TransactionLog, Txo},
-        transaction_log::{TransactionID, TransactionLogModel},
+        transaction_log::{TransactionId, TransactionLogModel},
         txo::TxoModel,
     },
     WalletService,
@@ -169,7 +169,7 @@ where
     fn get_transaction_object(&self, transaction_id_hex: &str) -> Result<Tx, LedgerServiceError> {
         let conn = self.get_conn()?;
         let transaction_log =
-            TransactionLog::get(&TransactionID(transaction_id_hex.to_string()), &conn)?;
+            TransactionLog::get(&TransactionId(transaction_id_hex.to_string()), &conn)?;
         let tx: Tx = mc_util_serial::decode(&transaction_log.tx)?;
         Ok(tx)
     }

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -365,7 +365,7 @@ where
             let mut default_fee_token_id = Mob::ID;
 
             for (recipient_public_address, amount) in addresses_and_amounts {
-                if !self.verify_address(recipient_public_address).is_ok() {
+                if self.verify_address(recipient_public_address).is_err() {
                     return Err(TransactionServiceError::InvalidPublicAddress(
                         recipient_public_address.to_string(),
                     ));

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -448,7 +448,7 @@ where
             let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
             let tx_proposal = unsigned_tx_proposal.sign(&account_key)?;
 
-            TransactionLog::log_built(tx_proposal.clone(), "".to_string(), account_id_hex, &conn)?;
+            TransactionLog::log_signed(tx_proposal.clone(), "".to_string(), account_id_hex, &conn)?;
 
             Ok(tx_proposal)
         })

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -5,7 +5,7 @@
 use crate::{
     db::{
         models::TransactionLog,
-        transaction_log::{AssociatedTxos, TransactionID, TransactionLogModel, ValueMap},
+        transaction_log::{AssociatedTxos, TransactionId, TransactionLogModel, ValueMap},
         WalletDbError,
     },
     error::WalletServiceError,
@@ -88,7 +88,7 @@ where
     ) -> Result<(TransactionLog, AssociatedTxos, ValueMap), TransactionLogServiceError> {
         let conn = self.get_conn()?;
         let transaction_log =
-            TransactionLog::get(&TransactionID(transaction_id_hex.to_string()), &conn)?;
+            TransactionLog::get(&TransactionId(transaction_id_hex.to_string()), &conn)?;
         let associated = transaction_log.get_associated_txos(&conn)?;
         let value_map = transaction_log.value_map(&conn)?;
 


### PR DESCRIPTION
### Motivation

Previously, we haven't been tracking transactions that were built but not signed. In order to support view only accounts with the offline signer and hardware wallet better, this adds that so we can track which inputs and outputs are for the built, but unsigned, transaction.

### In this PR
* Adding logging for built but unsigned transactions
* fixing bug where ```tombstone_block_index``` wasn't updated correctly if transaction log exists when submitting
* Changing how TransactionId is derived to allow it to be the same from UnsignedTx -> Tx (Using TxPrefix now)

### Future Work
Continued changes to support hardware wallet and offline transaction signing

Moving TransactionId, TxoId, and AccountId to the mobilecoin library to provide a central source of truth for these

