### PR TITLE
removing account syncing requiring regenerating subaddress keys

### DIFF
--- a/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/down.sql
+++ b/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/down.sql
+++ b/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/down.sql
@@ -1,1 +1,1 @@
--- This file should undo anything in `up.sql`
+DROP INDEX idx_assigned_subaddresses__spend_public_key;

--- a/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/up.sql
+++ b/full-service/migrations/2023-01-20-231044_add_index_to_subaddress_spend_key/up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_assigned_subaddresses__spend_public_key ON assigned_subaddresses (spend_public_key);

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2079,7 +2079,7 @@ mod tests {
         // Process the txos in the ledger into the DB
         sync_account(
             &ledger_db,
-            &wallet_db,
+            &wallet_db.get_conn().unwrap(),
             &AccountID::from(&src_account).to_string(),
             &logger,
         )

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -418,13 +418,9 @@ pub fn decode_subaddress_index(
     let subaddress_spend_public_key: RistrettoPublic =
         recover_public_subaddress_spend_key(view_private_key, &tx_out_target_key, &tx_public_key);
 
-    match AssignedSubaddress::find_by_subaddress_spend_public_key(
-        &subaddress_spend_public_key,
-        conn,
-    ) {
-        Ok(a) => Some(a.0 as u64),
-        Err(_) => None,
-    }
+    AssignedSubaddress::find_by_subaddress_spend_public_key(&subaddress_spend_public_key, conn)
+        .ok()
+        .map(|(idx, _b58)| idx as u64)
 }
 
 /// Attempt to match the target address with one of our subaddresses. This

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -142,8 +142,6 @@ pub fn sync_account(
     account_id_hex: &str,
     logger: &Logger,
 ) -> Result<(), SyncError> {
-    // let conn = wallet_db.get_conn()?;
-
     while let SyncStatus::ChunkFinished =
         sync_account_next_chunk(ledger_db, wallet_db, logger, account_id_hex)?
     {}

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -207,14 +207,11 @@ fn sync_account_next_chunk(
         let received_txos: Vec<_> = tx_outs
             .into_par_iter()
             .filter_map(|(block_index, tx_out)| {
-                let amount = match decode_amount(&tx_out, view_account_key.view_private_key()) {
-                    None => return None,
-                    Some(a) => a,
-                };
+                let amount = decode_amount(&tx_out, view_account_key.view_private_key())?;
                 let subaddress_index = decode_subaddress_index(
                     &tx_out,
                     view_account_key.view_private_key(),
-                    &wallet_db.get_conn().unwrap(),
+                    &wallet_db.get_conn().ok()?,
                 );
                 Some((block_index, tx_out, amount, subaddress_index))
             })
@@ -292,14 +289,11 @@ fn sync_account_next_chunk(
         let received_txos: Vec<_> = tx_outs
             .into_par_iter()
             .filter_map(|(block_index, tx_out)| {
-                let amount = match decode_amount(&tx_out, account_key.view_private_key()) {
-                    None => return None,
-                    Some(a) => a,
-                };
+                let amount = decode_amount(&tx_out, account_key.view_private_key())?;
                 let (subaddress_index, key_image) = decode_subaddress_and_key_image(
                     &tx_out,
                     &account_key,
-                    &wallet_db.get_conn().unwrap(),
+                    &wallet_db.get_conn().ok()?,
                 );
                 Some((block_index, tx_out, amount, subaddress_index, key_image))
             })

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -328,7 +328,12 @@ pub fn manually_sync_account(
 ) -> Account {
     let mut account: Account;
     loop {
-        match sync_account(&ledger_db, &wallet_db, &account_id.to_string(), &logger) {
+        match sync_account(
+            &ledger_db,
+            &wallet_db.get_conn().unwrap(),
+            &account_id.to_string(),
+            &logger,
+        ) {
             Ok(_) => {}
             Err(SyncError::Database(WalletDbError::Diesel(
                 diesel::result::Error::DatabaseError(_kind, info),


### PR DESCRIPTION
This update was necessary to increase account sync speed for accounts with large amounts of subaddresses, as well as not causing the API to lock when syncing any account. The main fix is that we are no longer using a transaction nor pre-generating all of the subaddress keys for each iteration, since the subaddress keys already exist in the database and we can simply perform a SQL query to match against them.