### PR TITLE
Using openssl-vendored with grpcio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "cmake",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "walkdir",
 ]
@@ -4022,6 +4023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.0.11+3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181e2429088818099075f6ccf30e6d096a513c46e7e0b946a4dde055c35cb17a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4040,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -54,7 +54,7 @@ diesel-derive-enum = { version = "1", features = ["sqlite"] }
 diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
 displaydoc = { version = "0.2", default-features = false }
 dotenv = "0.15.0"
-grpcio = "0.11"
+grpcio = { version = "0.11.0", features = ["openssl-vendored"] }
 hex = { version = "0.4", default-features = false }
 num_cpus = "1.14"
 protobuf = "2.28.0"

--- a/mirror/Cargo.toml
+++ b/mirror/Cargo.toml
@@ -26,7 +26,7 @@ mc-util-uri = { path = "../mobilecoin/util/uri" }
 boring = "2.1"
 futures = "0.3"
 generic-array = "0.14"
-grpcio = "0.11.0"
+grpcio = { version = "0.11.0", features = ["openssl-vendored"] }
 hex = "0.4"
 protobuf = "2.28"
 rand = "0.8"

--- a/validator/api/Cargo.toml
+++ b/validator/api/Cargo.toml
@@ -13,7 +13,7 @@ mc-fog-report-api = { path = "../../mobilecoin/fog/report/api" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }
 
 futures = "0.3"
-grpcio = "0.11.0"
+grpcio = { version = "0.11.0", features = ["openssl-vendored"] }
 protobuf = "2.28.0"
 
 [build-dependencies]

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -18,5 +18,5 @@ mc-util-uri = { path = "../../mobilecoin/util/uri" }
 
 displaydoc = { version = "0.2", default-features = false }
 futures = "0.3"
-grpcio = "0.11.0"
+grpcio = { version = "0.11.0", features = ["openssl-vendored"] }
 protobuf = "2.28.0"

--- a/validator/service/Cargo.toml
+++ b/validator/service/Cargo.toml
@@ -26,5 +26,5 @@ mc-util-parse = { path = "../../mobilecoin/util/parse" }
 mc-util-uri = { path = "../../mobilecoin/util/uri" }
 
 clap = { version = "4.0", features = ["derive", "env"] }
-grpcio = "0.11.0"
+grpcio = { version = "0.11.0", features = ["openssl-vendored"] }
 rayon = "1.6"


### PR DESCRIPTION
This resolves an issue where a user doesn't have the correct version of openssl installed on their machine by using a bundled version of openssl instead of the system version (if available)