### PR TITLE
Adding back txo_id_hex to undo breaking change

### DIFF
--- a/full-service/src/json_rpc/v2/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v2/models/transaction_log.rs
@@ -108,7 +108,7 @@ impl TransactionLog {
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct InputTxo {
     pub txo_id: String,
-
+    pub txo_id_hex: String,
     /// Amount of this Txo
     pub amount: Amount,
 }
@@ -117,6 +117,7 @@ impl InputTxo {
     pub fn new(txo: &db::models::Txo) -> Self {
         Self {
             txo_id: txo.id.clone(),
+            txo_id_hex: txo.id.clone(),
             amount: Amount::from(&txo.amount()),
         }
     }
@@ -125,6 +126,8 @@ impl InputTxo {
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct OutputTxo {
     pub txo_id: String,
+
+    pub txo_id_hex: String,
 
     pub public_key: String,
 
@@ -137,6 +140,7 @@ impl OutputTxo {
     pub fn new(txo: &db::models::Txo, recipient_public_address_b58: String) -> Self {
         Self {
             txo_id: txo.id.clone(),
+            txo_id_hex: txo.id.clone(),
             public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
             amount: Amount::from(&txo.amount()),
             recipient_public_address_b58,


### PR DESCRIPTION
Keeping txo_id also to prevent a second breaking change for anyone who has already implemented to breaking change fix