### PR TITLE
Update mbedTLS to solve for Xcode 13 & 14 compatability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,36 +27,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
+ "ctr",
  "opaque-debug",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher 0.4.3",
- "cpufeatures",
 ]
 
 [[package]]
@@ -65,25 +45,11 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead 0.4.1",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.8.0",
- "ghash 0.4.4",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead 0.5.1",
- "aes 0.8.2",
- "cipher 0.4.3",
- "ctr 0.9.2",
- "ghash 0.5.0",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
  "subtle",
 ]
 
@@ -210,15 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -599,16 +556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +661,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "base64 0.13.1",
  "hkdf",
  "hmac",
@@ -764,12 +711,6 @@ checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if 0.1.10",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -828,7 +769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -838,16 +778,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
@@ -1588,17 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
- "polyval 0.5.3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.0",
+ "polyval",
 ]
 
 [[package]]
@@ -1640,25 +1561,10 @@ checksum = "1132252c65fd51bd7d1dc7920e2931201fc3a2c9e3fbce6c27f8762e7a2ff3ed"
 dependencies = [
  "futures-executor",
  "futures-util",
- "grpcio-sys 0.10.3+1.44.0-patched",
+ "grpcio-sys",
  "libc",
  "log 0.4.11",
  "parking_lot 0.11.2",
- "protobuf",
-]
-
-[[package]]
-name = "grpcio"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edb2eaa4b13b9a8a07f1a1bbaadc8a5bf4132c2b1fa6358d2be14afd18a2c3"
-dependencies = [
- "futures-executor",
- "futures-util",
- "grpcio-sys 0.12.0+1.46.5-patched",
- "libc",
- "log 0.4.11",
- "parking_lot 0.12.1",
  "protobuf",
 ]
 
@@ -1676,22 +1582,6 @@ name = "grpcio-sys"
 version = "0.10.3+1.44.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23adc509a3c4dea990e0ab8d2add4a65389ee69c288b7851d75dd1df7a6d6c6"
-dependencies = [
- "bindgen 0.59.2",
- "boringssl-src",
- "cc",
- "cmake",
- "libc",
- "libz-sys",
- "pkg-config",
- "walkdir",
-]
-
-[[package]]
-name = "grpcio-sys"
-version = "0.12.0+1.46.5-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e37f6f61ce8fab679051f2cb157f1de3a0c821827441e7f9a561765d98c7d50"
 dependencies = [
  "bindgen 0.59.2",
  "boringssl-src",
@@ -1729,15 +1619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36b5f248235f45773d4944f555f83ea61fe07b18b561ccf99d7483d7381e54d"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,23 +1626,11 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "git+https://github.com/mobilecoinofficial/heapless?rev=2726f63bdc767d025f370d88341b1eb785178f2b#2726f63bdc767d025f370d88341b1eb785178f2b"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "spin 0.9.4",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2035,15 +1904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -2362,11 +2222,10 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
  "hkdf",
  "mc-account-keys-types",
  "mc-core",
@@ -2379,21 +2238,20 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core 0.6.4",
- "serde",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2404,7 +2262,6 @@ dependencies = [
  "mc-attest-verifier-types",
  "mc-blockchain-types",
  "mc-common",
- "mc-crypto-dalek",
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-ring-signature-signer",
@@ -2420,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aead 0.5.1",
+ "aead",
  "cargo-emit",
  "digest",
  "displaydoc",
@@ -2439,13 +2296,13 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aead 0.5.1",
+ "aead",
  "cargo-emit",
  "digest",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-attest-ake",
  "mc-attest-enclave-api",
  "mc-crypto-keys",
@@ -2457,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
@@ -2486,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2499,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2524,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -2538,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2552,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2575,18 +2432,17 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
  "chrono",
  "displaydoc",
- "hashbrown 0.13.1",
+ "hashbrown 0.12.3",
  "hex",
  "hex_fmt",
  "hostname",
  "lazy_static",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-rand",
@@ -2612,12 +2468,12 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.10.1",
+ "aes-gcm",
  "cookie 0.16.0",
  "displaydoc",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-attest-ake",
  "mc-attest-api",
  "mc-attest-core",
@@ -2640,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2652,11 +2508,11 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-api",
  "mc-attest-api",
  "mc-ledger-db",
@@ -2668,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2690,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2703,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "maplit",
  "mc-common",
@@ -2722,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2745,7 +2601,6 @@ dependencies = [
  "glob 0.3.0",
  "hkdf",
  "mc-core-types",
- "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -2765,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aead 0.5.1",
+ "aead",
  "digest",
  "displaydoc",
  "hkdf",
@@ -2779,38 +2634,21 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
- "mc-crypto-dalek-backend-simd",
- "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
 ]
 
 [[package]]
-name = "mc-crypto-dalek-backend-simd"
-version = "2.0.0"
-dependencies = [
- "curve25519-dalek",
-]
-
-[[package]]
-name = "mc-crypto-dalek-backend-u64"
-version = "2.0.0"
-dependencies = [
- "curve25519-dalek",
-]
-
-[[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
- "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -2818,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",
@@ -2827,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2836,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -2845,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2874,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.10.1",
+ "aes-gcm",
  "displaydoc",
  "generic-array",
  "mc-util-serial",
@@ -2887,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -2897,10 +2735,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aead 0.5.1",
- "aes-gcm 0.10.1",
+ "aead",
+ "aes-gcm",
  "digest",
  "displaydoc",
  "generic-array",
@@ -2917,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -2926,13 +2764,13 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "ed25519-dalek",
+ "hex_fmt",
+ "mc-account-keys",
  "mc-account-keys-types",
- "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
@@ -2950,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2971,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -2981,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2993,11 +2831,11 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-api",
  "mc-attest-api",
  "mc-consensus-api",
@@ -3009,10 +2847,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-account-keys",
  "mc-attest-core",
  "mc-common",
@@ -3026,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -3040,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3050,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3063,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3071,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3087,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -3095,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3120,7 +2958,7 @@ dependencies = [
  "diesel_migrations",
  "displaydoc",
  "dotenv",
- "grpcio 0.11.0",
+ "grpcio",
  "hex",
  "mc-account-keys",
  "mc-api",
@@ -3187,7 +3025,7 @@ dependencies = [
  "cargo-emit",
  "futures",
  "generic-array",
- "grpcio 0.11.0",
+ "grpcio",
  "hex",
  "mc-api",
  "mc-common",
@@ -3210,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -3237,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 4.0.26",
  "lmdb-rkv",
@@ -3250,11 +3088,11 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-account-keys",
  "mc-api",
  "mc-attest-verifier",
@@ -3281,13 +3119,13 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.10.1",
+ "aes-gcm",
  "clap 4.0.26",
  "crossbeam-channel",
  "displaydoc",
- "grpcio 0.12.0",
+ "grpcio",
  "hex_fmt",
  "libz-sys",
  "lmdb-rkv",
@@ -3341,11 +3179,11 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "mc-api",
  "mc-consensus-api",
  "mc-util-build-grpc",
@@ -3356,10 +3194,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 4.0.26",
- "grpcio 0.12.0",
+ "grpcio",
  "hex",
  "mc-api",
  "mc-common",
@@ -3374,22 +3212,22 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.10.1"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be589d425ac3950edf94eb4185e625b4ca509d8caeab7ab461e107a73c3ebfb"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
- "aead 0.5.1",
- "aes 0.8.2",
- "cipher 0.4.3",
- "ctr 0.9.2",
- "ghash 0.5.0",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -3397,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3405,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3416,18 +3254,17 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-builder"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",
  "hmac",
  "mc-account-keys",
- "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-crypto-ring-signature-signer",
@@ -3448,12 +3285,11 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "aes 0.8.2",
+ "aes",
  "bulletproofs-og",
  "crc",
- "ctr 0.9.2",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
@@ -3463,7 +3299,6 @@ dependencies = [
  "mc-account-keys",
  "mc-common",
  "mc-crypto-box",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -3486,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3501,14 +3336,13 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",
  "hmac",
  "mc-account-keys",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -3519,8 +3353,6 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
- "mc-util-vec-map",
- "mc-util-zip-exact",
  "prost",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -3555,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -3566,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.0",
@@ -3582,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3590,14 +3422,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3608,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3619,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -3630,21 +3462,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-grpc"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "clap 4.0.26",
  "cookie 0.16.0",
  "displaydoc",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "hex",
  "hex_fmt",
  "hmac",
@@ -3668,11 +3500,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "4.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-util-lmdb"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3682,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",
@@ -3691,10 +3523,10 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "grpcio 0.12.0",
+ "grpcio",
  "lazy_static",
  "mc-common",
  "prometheus",
@@ -3704,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "itertools",
@@ -3713,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -3723,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "protobuf",
@@ -3734,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -3745,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 4.0.26",
  "lazy_static",
@@ -3756,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -3770,16 +3602,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-util-vec-map"
-version = "4.0.0"
-dependencies = [
- "displaydoc",
- "heapless",
-]
-
-[[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
@@ -3790,7 +3614,7 @@ version = "2.1.2"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio 0.11.0",
+ "grpcio",
  "mc-api",
  "mc-consensus-api",
  "mc-fog-report-api",
@@ -3806,7 +3630,7 @@ version = "2.1.2"
 dependencies = [
  "displaydoc",
  "futures",
- "grpcio 0.11.0",
+ "grpcio",
  "mc-api",
  "mc-blockchain-types",
  "mc-common",
@@ -3824,7 +3648,7 @@ name = "mc-validator-service"
 version = "2.1.2"
 dependencies = [
  "clap 4.0.26",
- "grpcio 0.11.0",
+ "grpcio",
  "mc-attest-verifier",
  "mc-common",
  "mc-connection",
@@ -3843,12 +3667,12 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 4.0.26",
  "displaydoc",
  "futures",
- "grpcio 0.12.0",
+ "grpcio",
  "hex",
  "lazy_static",
  "lmdb-rkv",
@@ -3880,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -4283,17 +4107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_info"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
-dependencies = [
- "log 0.4.11",
- "serde",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,19 +4343,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.4.0",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "opaque-debug",
- "universal-hash 0.5.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5431,13 +5232,12 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ad137b9df78294b98cab1a650bef237cc6c950e82e5ce164655e674d07c5cc"
+checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
 dependencies = [
  "httpdate",
  "reqwest",
- "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -5446,15 +5246,13 @@ dependencies = [
  "sentry-slog",
  "serde_json",
  "tokio",
- "ureq",
- "webpki-roots",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe4800806552aab314129761d5d3b3d422284eca3de2ab59e9fd133636cbd3d"
+checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5464,13 +5262,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42938426670f6e7974989cd1417837a96dd8bbb01567094f567d6acb360bf88"
+checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
 dependencies = [
  "hostname",
  "libc",
- "os_info",
  "rustc_version",
  "sentry-core",
  "uname",
@@ -5478,9 +5275,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df9b9d8de2658a1ecd4e45f7b06c80c5dd97b891bfbc7c501186189b7e9bbdf"
+checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -5491,9 +5288,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7518096b31fa4075d1bbab79ad62da3258f6c67bafeb4a8b2b3f803695b9205e"
+checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
 dependencies = [
  "log 0.4.11",
  "sentry-core",
@@ -5501,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af37b8500f273e511ebd6eb0d342ff7937d64ce3f134764b2b4653112d48cb4"
+checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5511,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5911f195e34ee4723529ca67c4f00dba3e8acbccb9e5dfe90e1cd1ec1ff3e25"
+checksum = "f855446c5f08db26a73b0c532b4354d33143982eadf84071d2a0102f9885a31e"
 dependencies = [
  "sentry-core",
  "serde_json",
@@ -5522,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.29.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc95faa4078768a6bf8df45e2b894bbf372b3dbbfb364e9429c1c58ab7545c6"
+checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
  "debugid",
  "getrandom 0.2.3",
@@ -5877,9 +5674,6 @@ name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable-pattern"
@@ -5889,12 +5683,6 @@ checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"
@@ -6531,35 +6319,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "ureq"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
-dependencies = [
- "base64 0.13.1",
- "log 0.4.11",
- "once_cell",
- "rustls",
- "url 2.3.1",
- "webpki",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"
@@ -6981,8 +6744,3 @@ dependencies = [
  "syn 1.0.96",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "cmake"
-version = "0.1.45"
-source = "git+https://github.com/alexcrichton/cmake-rs?rev=5f89f90ee5d7789832963bffdb2dcb5939e6199c#5f89f90ee5d7789832963bffdb2dcb5939e6199c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,16 +27,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
- "ctr",
  "opaque-debug",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -45,11 +65,25 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.4.1",
+ "aes 0.7.5",
+ "cipher 0.3.0",
+ "ctr 0.8.0",
+ "ghash 0.4.4",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead 0.5.1",
+ "aes 0.8.2",
+ "cipher 0.4.3",
+ "ctr 0.9.2",
+ "ghash 0.5.0",
  "subtle",
 ]
 
@@ -91,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arc-swap"
@@ -176,6 +210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -533,9 +576,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -553,6 +596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -629,8 +682,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.45"
-source = "git+https://github.com/alexcrichton/cmake-rs?rev=5f89f90ee5d7789832963bffdb2dcb5939e6199c#5f89f90ee5d7789832963bffdb2dcb5939e6199c"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
 ]
@@ -660,7 +714,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "base64 0.13.1",
  "hkdf",
  "hmac",
@@ -710,6 +764,12 @@ checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -763,11 +823,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -777,7 +838,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -1518,7 +1588,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.5.3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.0",
 ]
 
 [[package]]
@@ -1560,10 +1640,25 @@ checksum = "1132252c65fd51bd7d1dc7920e2931201fc3a2c9e3fbce6c27f8762e7a2ff3ed"
 dependencies = [
  "futures-executor",
  "futures-util",
- "grpcio-sys",
+ "grpcio-sys 0.10.3+1.44.0-patched",
  "libc",
  "log 0.4.11",
  "parking_lot 0.11.2",
+ "protobuf",
+]
+
+[[package]]
+name = "grpcio"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55edb2eaa4b13b9a8a07f1a1bbaadc8a5bf4132c2b1fa6358d2be14afd18a2c3"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "grpcio-sys 0.12.0+1.46.5-patched",
+ "libc",
+ "log 0.4.11",
+ "parking_lot 0.12.1",
  "protobuf",
 ]
 
@@ -1581,6 +1676,22 @@ name = "grpcio-sys"
 version = "0.10.3+1.44.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23adc509a3c4dea990e0ab8d2add4a65389ee69c288b7851d75dd1df7a6d6c6"
+dependencies = [
+ "bindgen 0.59.2",
+ "boringssl-src",
+ "cc",
+ "cmake",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+ "walkdir",
+]
+
+[[package]]
+name = "grpcio-sys"
+version = "0.12.0+1.46.5-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e37f6f61ce8fab679051f2cb157f1de3a0c821827441e7f9a561765d98c7d50"
 dependencies = [
  "bindgen 0.59.2",
  "boringssl-src",
@@ -1618,6 +1729,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36b5f248235f45773d4944f555f83ea61fe07b18b561ccf99d7483d7381e54d"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,11 +1745,23 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "git+https://github.com/mobilecoinofficial/heapless?rev=2726f63bdc767d025f370d88341b1eb785178f2b#2726f63bdc767d025f370d88341b1eb785178f2b"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin 0.9.4",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1903,6 +2035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2187,7 +2328,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=6f5bd68166a2c12fa3922867a6a6bd68904243d3#6f5bd68166a2c12fa3922867a6a6bd68904243d3"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2199,14 +2340,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.4",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=6f5bd68166a2c12fa3922867a6a6bd68904243d3#6f5bd68166a2c12fa3922867a6a6bd68904243d3"
 dependencies = [
  "bindgen 0.58.1",
  "cc",
@@ -2221,10 +2362,11 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
+ "hex_fmt",
  "hkdf",
  "mc-account-keys-types",
  "mc-core",
@@ -2237,20 +2379,21 @@ dependencies = [
  "mc-util-serial",
  "prost",
  "rand_core 0.6.4",
+ "serde",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2261,6 +2404,7 @@ dependencies = [
  "mc-attest-verifier-types",
  "mc-blockchain-types",
  "mc-common",
+ "mc-crypto-dalek",
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-ring-signature-signer",
@@ -2276,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aead",
+ "aead 0.5.1",
  "cargo-emit",
  "digest",
  "displaydoc",
@@ -2295,13 +2439,13 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aead",
+ "aead 0.5.1",
  "cargo-emit",
  "digest",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-attest-ake",
  "mc-attest-enclave-api",
  "mc-crypto-keys",
@@ -2313,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
@@ -2342,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2355,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2380,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -2394,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2408,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2431,17 +2575,18 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
  "chrono",
  "displaydoc",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.1",
  "hex",
  "hex_fmt",
  "hostname",
  "lazy_static",
+ "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-rand",
@@ -2467,12 +2612,12 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.1",
  "cookie 0.16.0",
  "displaydoc",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-attest-ake",
  "mc-attest-api",
  "mc-attest-core",
@@ -2495,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2507,11 +2652,11 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-api",
  "mc-attest-api",
  "mc-ledger-db",
@@ -2523,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2545,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2558,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "maplit",
  "mc-common",
@@ -2577,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2600,6 +2745,7 @@ dependencies = [
  "glob 0.3.0",
  "hkdf",
  "mc-core-types",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -2619,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aead",
+ "aead 0.5.1",
  "digest",
  "displaydoc",
  "hkdf",
@@ -2633,21 +2779,38 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "mc-crypto-dalek-backend-simd",
+ "mc-crypto-dalek-backend-u64",
  "x25519-dalek",
 ]
 
 [[package]]
+name = "mc-crypto-dalek-backend-simd"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
+name = "mc-crypto-dalek-backend-u64"
+version = "2.0.0"
+dependencies = [
+ "curve25519-dalek",
+]
+
+[[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
+ "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -2655,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",
@@ -2664,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2673,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -2682,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2711,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.1",
  "displaydoc",
  "generic-array",
  "mc-util-serial",
@@ -2724,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -2734,10 +2897,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.5.1",
+ "aes-gcm 0.10.1",
  "digest",
  "displaydoc",
  "generic-array",
@@ -2754,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -2763,13 +2926,13 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
- "hex_fmt",
- "mc-account-keys",
+ "ed25519-dalek",
  "mc-account-keys-types",
+ "mc-core-types",
  "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
@@ -2787,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2808,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -2818,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2830,11 +2993,11 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-api",
  "mc-attest-api",
  "mc-consensus-api",
@@ -2846,10 +3009,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-account-keys",
  "mc-attest-core",
  "mc-common",
@@ -2863,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -2877,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -2887,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2900,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -2908,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2924,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -2932,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2957,7 +3120,7 @@ dependencies = [
  "diesel_migrations",
  "displaydoc",
  "dotenv",
- "grpcio",
+ "grpcio 0.11.0",
  "hex",
  "mc-account-keys",
  "mc-api",
@@ -3024,7 +3187,7 @@ dependencies = [
  "cargo-emit",
  "futures",
  "generic-array",
- "grpcio",
+ "grpcio 0.11.0",
  "hex",
  "mc-api",
  "mc-common",
@@ -3047,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -3074,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.26",
  "lmdb-rkv",
@@ -3087,11 +3250,11 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-account-keys",
  "mc-api",
  "mc-attest-verifier",
@@ -3118,13 +3281,13 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.1",
  "clap 4.0.26",
  "crossbeam-channel",
  "displaydoc",
- "grpcio",
+ "grpcio 0.12.0",
  "hex_fmt",
  "libz-sys",
  "lmdb-rkv",
@@ -3178,11 +3341,11 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "mc-api",
  "mc-consensus-api",
  "mc-util-build-grpc",
@@ -3193,10 +3356,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.26",
- "grpcio",
+ "grpcio 0.12.0",
  "hex",
  "mc-api",
  "mc-common",
@@ -3211,22 +3374,22 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.5-pre1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
+checksum = "7be589d425ac3950edf94eb4185e625b4ca509d8caeab7ab461e107a73c3ebfb"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.1",
+ "aes 0.8.2",
+ "cipher 0.4.3",
+ "ctr 0.9.2",
+ "ghash 0.5.0",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -3234,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -3242,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3253,17 +3416,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-transaction-builder"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",
  "hmac",
  "mc-account-keys",
+ "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-crypto-ring-signature-signer",
@@ -3284,11 +3448,12 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
- "aes",
+ "aes 0.8.2",
  "bulletproofs-og",
  "crc",
+ "ctr 0.9.2",
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
@@ -3298,6 +3463,7 @@ dependencies = [
  "mc-account-keys",
  "mc-common",
  "mc-crypto-box",
+ "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -3320,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3335,13 +3501,14 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",
  "hmac",
  "mc-account-keys",
+ "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -3352,6 +3519,8 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-vec-map",
+ "mc-util-zip-exact",
  "prost",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -3386,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -3397,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.0",
@@ -3413,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3421,14 +3590,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3439,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3450,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -3461,21 +3630,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "clap 4.0.26",
  "cookie 0.16.0",
  "displaydoc",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "hex",
  "hex_fmt",
  "hmac",
@@ -3499,11 +3668,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "2.1.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-util-lmdb"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3513,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",
@@ -3522,10 +3691,10 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
- "grpcio",
+ "grpcio 0.12.0",
  "lazy_static",
  "mc-common",
  "prometheus",
@@ -3535,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "itertools",
@@ -3544,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -3554,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "protobuf",
@@ -3565,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -3576,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.26",
  "lazy_static",
@@ -3587,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64 0.13.1",
  "displaydoc",
@@ -3601,8 +3770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-vec-map"
+version = "4.0.0"
+dependencies = [
+ "displaydoc",
+ "heapless",
+]
+
+[[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
@@ -3613,7 +3790,7 @@ version = "2.1.2"
 dependencies = [
  "cargo-emit",
  "futures",
- "grpcio",
+ "grpcio 0.11.0",
  "mc-api",
  "mc-consensus-api",
  "mc-fog-report-api",
@@ -3629,7 +3806,7 @@ version = "2.1.2"
 dependencies = [
  "displaydoc",
  "futures",
- "grpcio",
+ "grpcio 0.11.0",
  "mc-api",
  "mc-blockchain-types",
  "mc-common",
@@ -3647,7 +3824,7 @@ name = "mc-validator-service"
 version = "2.1.2"
 dependencies = [
  "clap 4.0.26",
- "grpcio",
+ "grpcio 0.11.0",
  "mc-attest-verifier",
  "mc-common",
  "mc-connection",
@@ -3666,12 +3843,12 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.26",
  "displaydoc",
  "futures",
- "grpcio",
+ "grpcio 0.12.0",
  "hex",
  "lazy_static",
  "lmdb-rkv",
@@ -3703,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3884,7 +4061,7 @@ dependencies = [
  "log 0.4.11",
  "memchr",
  "mime 0.3.16",
- "spin 0.9.3",
+ "spin 0.9.4",
  "tokio",
  "tokio-util 0.6.10",
  "version_check 0.9.3",
@@ -4103,6 +4280,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_info"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
+dependencies = [
+ "log 0.4.11",
+ "serde",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4342,7 +4530,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -5231,12 +5431,13 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
+checksum = "17ad137b9df78294b98cab1a650bef237cc6c950e82e5ce164655e674d07c5cc"
 dependencies = [
  "httpdate",
  "reqwest",
+ "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -5245,13 +5446,15 @@ dependencies = [
  "sentry-slog",
  "serde_json",
  "tokio",
+ "ureq",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
+checksum = "afe4800806552aab314129761d5d3b3d422284eca3de2ab59e9fd133636cbd3d"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -5261,12 +5464,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
+checksum = "a42938426670f6e7974989cd1417837a96dd8bbb01567094f567d6acb360bf88"
 dependencies = [
  "hostname",
  "libc",
+ "os_info",
  "rustc_version",
  "sentry-core",
  "uname",
@@ -5274,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
+checksum = "4df9b9d8de2658a1ecd4e45f7b06c80c5dd97b891bfbc7c501186189b7e9bbdf"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -5287,9 +5491,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
+checksum = "7518096b31fa4075d1bbab79ad62da3258f6c67bafeb4a8b2b3f803695b9205e"
 dependencies = [
  "log 0.4.11",
  "sentry-core",
@@ -5297,9 +5501,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
+checksum = "0af37b8500f273e511ebd6eb0d342ff7937d64ce3f134764b2b4653112d48cb4"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5307,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f855446c5f08db26a73b0c532b4354d33143982eadf84071d2a0102f9885a31e"
+checksum = "c5911f195e34ee4723529ca67c4f00dba3e8acbccb9e5dfe90e1cd1ec1ff3e25"
 dependencies = [
  "sentry-core",
  "serde_json",
@@ -5318,9 +5522,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
+checksum = "ccc95faa4078768a6bf8df45e2b894bbf372b3dbbfb364e9429c1c58ab7545c6"
 dependencies = [
  "debugid",
  "getrandom 0.2.3",
@@ -5664,21 +5868,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-
-[[package]]
-name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable-pattern"
@@ -5688,6 +5889,12 @@ checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"
@@ -6324,10 +6531,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
+dependencies = [
+ "base64 0.13.1",
+ "log 0.4.11",
+ "once_cell",
+ "rustls",
+ "url 2.3.1",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -6543,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -6749,3 +6981,8 @@ dependencies = [
  "syn 1.0.96",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "cmake"
+version = "0.1.45"
+source = "git+https://github.com/alexcrichton/cmake-rs?rev=5f89f90ee5d7789832963bffdb2dcb5939e6199c#5f89f90ee5d7789832963bffdb2dcb5939e6199c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ diesel = { git = "https://github.com/mobilecoinofficial/diesel", rev = "026f6379
 
 # latest mbedtls needs spin `^0.9.4`, but `mc-util-vec-map` resolves spin to `^0.9.2` through `heapless` `^0.7`,
 # This specifies we use the latest version of heapless ~`0.9.4` to solve the dependency constraints. 
-heapless = { git = "https://github.com/mobilecoinofficial/heapless", rev = "2726f63bdc767d025f370d88341b1eb785178f2b", default-features = false }
+heapless = { git = "https://github.com/mobilecoinofficial/heapless", rev = "2726f63bdc767d025f370d88341b1eb785178f2b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ overflow-checks = false
 # Fork and rename to use "OG" dalek-cryptography.
 bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e" }
 
-# This version contains iOS build fixes
-cmake = { git = "https://github.com/alexcrichton/cmake-rs", rev = "5f89f90ee5d7789832963bffdb2dcb5939e6199c" }
-
 # Fix issues with recent nightlies, bump curve25519-dalek version
 curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-dalek.git", rev = "8791722e0273762552c9a056eaccb7df6baf44d7" }
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
@@ -59,7 +56,3 @@ x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git
 # statically link SQLite.
 # If updating here, also update in README
 diesel = { git = "https://github.com/mobilecoinofficial/diesel", rev = "026f6379715d27c8be48396e5ca9059f4a263198" }
-
-# latest mbedtls needs spin `^0.9.4`, but `mc-util-vec-map` resolves spin to `^0.9.2` through `heapless` `^0.7`,
-# This specifies we use the latest version of heapless ~`0.9.4` to solve the dependency constraints. 
-heapless = { git = "https://github.com/mobilecoinofficial/heapless", rev = "2726f63bdc767d025f370d88341b1eb785178f2b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # mbedtls patched to allow certificate verification with a profile
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "6f5bd68166a2c12fa3922867a6a6bd68904243d3" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "6f5bd68166a2c12fa3922867a6a6bd68904243d3" }
 
 # Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
 lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
@@ -59,3 +59,7 @@ x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git
 # statically link SQLite.
 # If updating here, also update in README
 diesel = { git = "https://github.com/mobilecoinofficial/diesel", rev = "026f6379715d27c8be48396e5ca9059f4a263198" }
+
+# latest mbedtls needs spin `^0.9.4`, but `mc-util-vec-map` resolves spin to `^0.9.2` through `heapless` `^0.7`,
+# This specifies we use the latest version of heapless ~`0.9.4` to solve the dependency constraints. 
+heapless = { git = "https://github.com/mobilecoinofficial/heapless", rev = "2726f63bdc767d025f370d88341b1eb785178f2b", default-features = false }

--- a/README.md
+++ b/README.md
@@ -41,28 +41,6 @@ For database encryption features, see [DATABASE.md](DATABASE.md).
 
 ### Build and Run
 
-Note: Full-Service and mobilecoin are not currently compatible with Xcode 13 or higher (the Xcode that ships with OSX Monterey and later). Make sure you are using Xcode 12 before building and running Full-service. You can [download Xcode 12 from apple's developer downloads page](https://developer.apple.com/download/all/?q=xcode%2012).
-
-Download the latest Xcode 12 and add it to your applications folder.
-
-If you are on OSX Monterey or higher, you will need to fake the version to get OSX to allow you to open it.  Follow these steps (for Xcode 12.5.1):
-
-```sh
-# Change build version to Xcode 13.1
-/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion 19466' /Applications/Xcode_12.5.1.app/Contents/Info.plist
-
-# Open Xcode (system will check build version and cache it)
-open /Applications/Xcode_12.5.1.app/
-
-# Revert Xcode's build version
-/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion 18212' /Applications/Xcode_12.5.1.app/Contents/Info.plist
-```
-
-Then set your system to use it with:
-```sh
-sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
-```
-
 1. Install Rust from https://www.rust-lang.org/tools/install
 
 2. Install dependencies (from this top-level full-service directory).


### PR DESCRIPTION
### Motivation

`mobilecoin` core would have runtime issues when compiled on macOS w/ Xcode versions 13+. The reason for this is best explained in the [patch in mbedTLS](https://github.com/mobilecoinfoundation/rust-mbedtls/pull/66) which was the root cause area of the problem.

This PR brings that patch full-service.

### In this PR
* Patch rust-mbedtls to latest for xcode fix patch
* Remove Xcode version disclaimers in README.md
* Update submodule commit for `mobilecoin` repo

### Future Work

Update the submodule commit to point to a commit in `master` on the mobilecoin repo, right now it points to a commit in a branch. I will update this PR after that branch merges to master.
