### PR TITLE
Add endpoints for getting recent blocks and range of blocks

### DIFF
--- a/docs/v2/api-endpoints/get_blocks.md
+++ b/docs/v2/api-endpoints/get_blocks.md
@@ -1,0 +1,147 @@
+---
+description: Get the JSON representation of multiple "Block" objects in the ledger.
+---
+
+# Get Blocks
+
+## [Request](../../../full-service/src/json_rpc/v2/api/request.rs#L40)
+
+| Required Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `first_block_index` | The first block index to return. | Block must exist in the ledger. |
+
+| Optional Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `limit` | The number of blocks to return | |
+
+
+
+## [Response](../../../full-service/src/json_rpc/v2/api/response.rs#L41)
+
+## Example
+
+{% tabs %}
+{% tab title="Body Request" %}
+```text
+{
+  "method": "get_blocks",
+  "params": {
+    "block_index": "10",
+    "limit": 2
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```text
+{
+  "method": "get_blocks",
+  "result": {
+    "blocks": [
+      {
+        "id": "1caf5f40b3af987b7180e37fda27b22afaf1fe021c51759702a86c70ac73fb2b",
+        "version": "0",
+        "parent_id": "2ad80a8339a7fa4345fafcb32a4b4cf31fde19f1dbd245638b2305755f56664a",
+        "index": "10",
+        "cumulative_txo_count": "36",
+        "root_element": {
+          "range": {
+            "from": "0",
+            "to": "63"
+          },
+          "hash": "7c6ee94966a25058053a736ecf93410056f7a61e6826492b236a1d74960349ba"
+        },
+        "contents_hash": "364a7666e143aa0e6967124ba21bfa478c8354b5139ea654b816612bf3c32c41"
+      },
+      {
+        "id": "c9098ce66ad40495d3347cb5f50ee8109c4a5c881f24cfb8085af24f1517af7c",
+        "version": "0",
+        "parent_id": "1caf5f40b3af987b7180e37fda27b22afaf1fe021c51759702a86c70ac73fb2b",
+        "index": "11",
+        "cumulative_txo_count": "38",
+        "root_element": {
+          "range": {
+            "from": "0",
+            "to": "63"
+          },
+          "hash": "29214009f53ea67d07902ba8f45fa5256609bb53b8431538b3294458979eb67a"
+        },
+        "contents_hash": "8637dad481d11ac504cf38554d53229b18e099dd61e4927e9754d1941dbf990b"
+      }
+    ],
+    "block_contents": [
+      {
+        "key_images": [
+          "0a209695c4a088e2d177b5f87976096f5deafe12e22b14b65e3cefbcf3338f4ef603"
+        ],
+        "outputs": [
+          {
+            "masked_amount": {
+              "commitment": "ead9a4df10433156bf25cfc3a7b071a2ee20376a53a87a22f0893d872b1be40c",
+              "masked_value": "6817199765353746279",
+              "masked_token_id": "",
+              "version": 1
+            },
+            "target_key": "d848939f37624bc3159cde523787fc7f5c30135ee16abba6126c5dc6eec63a1f",
+            "public_key": "1a70e3383373c31a73c01b0987f657cd9250a2bf95a28174fb304890b0168a7c",
+            "e_fog_hint": "54610778c3f6558f6f6c52e3168cc13e2e08ab520eb46c2839020e20c8f059ece37e9cfa28c4328aa0351920849d5c2d565172270e9c20e339582b53bc2a6d7c1373d536ec1a9258110f689145870cadd6ae0100",
+            "e_memo": ""
+          },
+          {
+            "masked_amount": {
+              "commitment": "64654ec80d7a43cdd0f2752833d70b4e4e949af44884e219115cecd28304c916",
+              "masked_value": "16842093316104514354",
+              "masked_token_id": "",
+              "version": 1
+            },
+            "target_key": "fac9dc71a33bfabb64049f9faabed6302a46e4f095edde8405d87124a4679320",
+            "public_key": "7a01a348a0a9c6da070bfa70b467802e0a7ee49c7c828a814ac4a474442a0a18",
+            "e_fog_hint": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "e_memo": ""
+          }
+        ]
+      },
+      {
+        "key_images": [
+          "0a20a82fd520e5a9245776bed4e002d63939bbc97256bc76064f7950268eab938c69"
+        ],
+        "outputs": [
+          {
+            "masked_amount": {
+              "commitment": "4ebeed141d87c99d51ff09013a7aac35aca0de6455d9b7a774d31af9a425a67b",
+              "masked_value": "4128812440862043022",
+              "masked_token_id": "",
+              "version": 1
+            },
+            "target_key": "96e8772a54928b4e45d158917986733034768c56871458258dc1c21afb468f11",
+            "public_key": "82199be50fa18b3268ca2fd486533b4de75d687be21975b2ae661d9816be2316",
+            "e_fog_hint": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "e_memo": ""
+          },
+          {
+            "masked_amount": {
+              "commitment": "d49e2ed4639211bed5d87b0572ac5cf55dbadedc0f64408024277fe5bc75cf64",
+              "masked_value": "18400396735931331034",
+              "masked_token_id": "",
+              "version": 1
+            },
+            "target_key": "806efd05a0b3ac2579fe0fb3ee39cee85f4132ff0a60d40ee415d01bb765a502",
+            "public_key": "fa2945ebc19d504921096830603df708f61161e55b5cf925e62bd3ce24522d4c",
+            "e_fog_hint": "0c291818ff5c6d4a0d316e54c51ced28ab4828e6f461dc2c23a8eac4a15b9362d5383656c1384da40245cd51eb74244bec61cfb4ee4b53bc4da99a4987b618d970784f9009a516fc539e26a966c8768ebab80100",
+            "e_memo": ""
+          }
+        ]
+      }
+    ]
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+{% endtabs %}
+

--- a/docs/v2/api-endpoints/get_recent_blocks.md
+++ b/docs/v2/api-endpoints/get_recent_blocks.md
@@ -1,0 +1,177 @@
+---
+description: Get the JSON representation of the last recent "Block" objects in the ledger.
+---
+
+# Get Recent Blocks
+
+## [Request](../../../full-service/src/json_rpc/v2/api/request.rs#L40)
+
+| Optional Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `limit` | The number of blocks to return | |
+
+## [Response](../../../full-service/src/json_rpc/v2/api/response.rs#L41)
+
+## Example
+
+{% tabs %}
+{% tab title="Body Request" %}
+```text
+{
+  "method": "get_recent_blocks",
+  "params": {
+    "limit": 2,
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```text
+{
+  "method": "get_recent_blocks",
+  "result": {
+    "blocks": [
+      {
+        "id": "257ff2b9eaffac94af49aad3752133b3005b0eb1fb12f0c3beb4cf031da8f108",
+        "version": "2",
+        "parent_id": "bbcd793fbf98bc82468c518c8cc754d9eed8cf48702987a33ad982fb03c15508",
+        "index": "1378218",
+        "cumulative_txo_count": "4137864",
+        "root_element": {
+          "range": {
+            "from": "0",
+            "to": "4194303"
+          },
+          "hash": "9546556dad370fbb5afb21970213551e0e10330c28d2e1fc39be252c211188ad"
+        },
+        "contents_hash": "d91cf3225ed252e4a134429a96dc384a2505d0d3bb773c0d55677117af4462a1"
+      },
+      {
+        "id": "bbcd793fbf98bc82468c518c8cc754d9eed8cf48702987a33ad982fb03c15508",
+        "version": "2",
+        "parent_id": "f0b701f1eb070e2c0ec652ecf8b32fc858df20cf5c40ced855f315cebc7a60ca",
+        "index": "1378217",
+        "cumulative_txo_count": "4137861",
+        "root_element": {
+          "range": {
+            "from": "0",
+            "to": "4194303"
+          },
+          "hash": "2d1d266cd6659561cba07188758c920f5da8b4d192004e96270732f259cbc591"
+        },
+        "contents_hash": "8064cff29b04735e2f78767f687696cc4926d5ab5ecdfcb34ca2de7aca2bc2c7"
+      }
+    ],
+    "block_contents": [
+      {
+        "key_images": [
+          "0a202625b073d304a2d0915cb3f7efe59928f9e4e9d37d7348566e8c76308a6d3574",
+          "0a205a70001e6740a68ae8dde3fe04eac289bb103bef61e0ce56897e4881a79e6b7d"
+        ],
+        "outputs": [
+          {
+            "masked_amount": {
+              "commitment": "a2ce1ce0be4a0ceabca33eb29db8bcfc19b923207f85980d2f8bb03d0036f23a",
+              "masked_value": "2833140401228471876",
+              "masked_token_id": "df22df15382a452f",
+              "version": 1
+            },
+            "target_key": "3670cfd20f3a375e844b29eec0cf32d94c55b2694c50f2353778f0412a5bf02e",
+            "public_key": "3e2ddbdcee5b80bc5522f505f85d98cedc1f007e6de696c8cc3687b9ed68ff10",
+            "e_fog_hint": "730c9e46bfa5960ca9d8619b11a6b6399c0c34ed2c42122992dd7746d0869b3434970a08d0f4c014652678b6abdb7a8d1a37925f2334c1d7e0742997ecb600a5552d66b1434529e37460ca7efc77a78573d40100",
+            "e_memo": "8a1ff5f33944dc8e3f8e71d2989a2c70b218cb0338339fe264621dc374654722a92abe670d4462259f6a6a8b638ac89354fe1ae60c4f3ce7c32e77278c6695842dfa"
+          },
+          {
+            "masked_amount": {
+              "commitment": "be1c82662b09996ce08ca794e10b426698c8792a8eac336a3c8199dc765aa65c",
+              "masked_value": "13849038797285909200",
+              "masked_token_id": "ec4c6d6e0af1dd00",
+              "version": 1
+            },
+            "target_key": "8acdd2efc9970abb6b78fde479305ef896a62f904149d9f0129d2b2656bee132",
+            "public_key": "56a361f432dc8dc515859bd3236044586f73ae5f3a90792afaec44b2f7a36455",
+            "e_fog_hint": "9d3d05cfdffd35b74c1082f97af2666a0cd0ada7094306e3d510c9048b0ef365d5daa40afc65ee6daee6a3f640d1767c79aa54666ea4cb177bcf153e34361b52f63ea524e23d0769ed9f779c58245c2a27400100",
+            "e_memo": "e8624cabaa4581c5f9f612a092f02409341018c8648d6fc8455e4e49985629ae8dbef20fa6c35a0da25774cc09ef9d19673c9010e5a532a8e4902f7dc91097cd3858"
+          },
+          {
+            "masked_amount": {
+              "commitment": "4e591230d1839539abc53c92b5e9d1af5992143cf7794a4a1ca963679f690048",
+              "masked_value": "8969994541795584088",
+              "masked_token_id": "2904992a11ee40dd",
+              "version": 1
+            },
+            "target_key": "2e7c5052422ebee60f278c5cc30c54517e6394bc6d23e462cb550cc2ebdd3140",
+            "public_key": "c4e12b8b87448e4b5491b64941dfa5508fa2081e07e168dee9d60c0039f33c40",
+            "e_fog_hint": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "e_memo": "91243098a3babe81323c90ccb6578a4fa6164fe3c13a485594dc9f1eb9bad4b6ef8d40e029b40c32821195bf79f5a2865bedf18c287a8197f9dd8bf0d16ac67202f0"
+          }
+        ]
+      },
+      {
+        "key_images": [
+          "0a204050f5486f5979ae946e03026bd5bb0ceff5cb8defeff047b9a9d9220610746c",
+          "0a2088c2323687804d55ed683332feda3eda5ff7c8a66f1a75b0eb31cbc28fb7406f"
+        ],
+        "outputs": [
+          {
+            "masked_amount": {
+              "commitment": "e0971bd281bb0cedfa336eb837e80b019df6a1d072603bb67f06d7c18cfc9a06",
+              "masked_value": "15708444948380422301",
+              "masked_token_id": "6c4c414a634b2f82",
+              "version": 1
+            },
+            "target_key": "00837df1548b8a69a51251368cd5c94704db6032883cc84d3d7b02dd869ead62",
+            "public_key": "4e4d5bdb0f74c1b6a780ad12a505a33e7c49c6c51367d5d79b999d6eb51fdf30",
+            "e_fog_hint": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "e_memo": "bbe2a8e4f5a0e8ffc1a17dc2dcd27b44ab3dd7907ab600acc64f517dbe726461f8728652174c5af79a31a96d2fff6b754e878ce592ea8aa07a79c795ab35f39a8d9f"
+          },
+          {
+            "masked_amount": {
+              "commitment": "5049bd497cdbbec13ab38ad548c77d2e18c24adccd3a7d9fa608acc0bf916c66",
+              "masked_value": "6750428392038692076",
+              "masked_token_id": "dedd08ff94d39f08",
+              "version": 1
+            },
+            "target_key": "b4a3e8d91746a23af085a1abf44f14c93b0b719ad7192a324fa12790fe86a502",
+            "public_key": "6473e0f18679edcc20fdbccf2876b2ea2ce4cf6e047404be72f66ed438482e50",
+            "e_fog_hint": "54e3caff452051384aa26bc73c500d26e314ccb95b546326d483fb297a86246eb5c8d89c05afa039d38aae7e3831f7e11753d37b043f2255715cc21853391ba9f64cc3407e2ee637f1d6af396c8da6df61490100",
+            "e_memo": "70f5cc0c70aea608a216782412e8a9c236a5b36d3cf12f0bd5163f86789a5d0b47e6acea96d588819d43bb853240c36c385cb4d866c954311592b5c2fd23a82f5240"
+          },
+          {
+            "masked_amount": {
+              "commitment": "ac530133865b10be86927880168b504fdfd170cb0f34c1fb1747e27f4003135d",
+              "masked_value": "10314885951227847898",
+              "masked_token_id": "c72f6f8025f7788b",
+              "version": 1
+            },
+            "target_key": "dcc52f2425101366563d2ce6910c30849a6ce817adb27667bfab6bab66d7143b",
+            "public_key": "ec7761d4f32c99a8c65fefe06897c960afeec4351012869e6999801dbe4de401",
+            "e_fog_hint": "d483539b71f6b65d54a24a697ce8931cdb12296419bcffd097c2f5e2ee2a426ce876069c9a8132b87b74acfb71c27421ccde6818d18418d3acfa773f8fc2e486d96b779392ae4460fdbd5ccd7e02b982fa570100",
+            "e_memo": "7a5379bb34492e6858cbdd3166d0649ee1af5e3b29ca99b7d15326b88802a69cc713370911e82d2594dd96bf474320c97b87804449a38db919c74236b3294141f9d9"
+          }
+        ]
+      }
+    ],
+    "network_status": {
+      "network_block_height": "1378219",
+      "local_block_height": "1378219",
+      "local_num_txos": "4137864",
+      "fees": {
+        "0": "400000000",
+        "1": "2560",
+        "8192": "2560"
+      },
+      "block_version": "2"
+    }
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+{% endtabs %}
+

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -158,6 +158,10 @@ pub enum JsonCommandRequest {
         block_index: Option<String>,
         txo_public_key: Option<String>,
     },
+    get_blocks {
+        first_block_index: String,
+        limit: usize,
+    },
     get_recent_blocks {
         limit: Option<usize>,
     },

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -158,6 +158,9 @@ pub enum JsonCommandRequest {
         block_index: Option<String>,
         txo_public_key: Option<String>,
     },
+    get_recent_blocks {
+        limit: Option<usize>,
+    },
     get_confirmations {
         transaction_log_id: String,
     },

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -119,6 +119,10 @@ pub enum JsonCommandResponse {
         block: Block,
         block_contents: BlockContents,
     },
+    get_blocks {
+        blocks: Vec<Block>,
+        block_contents: Vec<BlockContents>,
+    },
     get_recent_blocks {
         blocks: Vec<Block>,
         block_contents: Vec<BlockContents>,

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -119,6 +119,11 @@ pub enum JsonCommandResponse {
         block: Block,
         block_contents: BlockContents,
     },
+    get_recent_blocks {
+        blocks: Vec<Block>,
+        block_contents: Vec<BlockContents>,
+        network_status: NetworkStatus,
+    },
     get_confirmations {
         confirmations: Vec<Confirmation>,
     },

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -74,7 +74,6 @@ pub const RECENT_BLOCKS_DEFAULT_LIMIT: usize = 10;
 /// Maximal amount of blocks we can return in a single request
 pub const MAX_BLOCKS_PER_REQUEST: usize = 100;
 
-
 pub async fn generic_wallet_api<T, FPR>(
     _api_key_guard: ApiKeyGuard,
     state: &rocket::State<WalletState<T, FPR>>,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -700,6 +700,35 @@ where
                 block_contents: BlockContents::new(&block_contents),
             }
         }
+        JsonCommandRequest::get_blocks {
+            first_block_index,
+            limit,
+        } => {
+            if limit > MAX_BLOCKS_PER_REQUEST {
+                return Err(format_error(format!(
+                    "Limit must be less than or equal to {}",
+                    MAX_BLOCKS_PER_REQUEST
+                )));
+            }
+
+            let first_block_index = first_block_index.parse::<u64>().map_err(format_error)?;
+
+            let blocks_and_contents = service
+                .get_block_objects(first_block_index, limit)
+                .map_err(format_error)?;
+
+            let (blocks, block_contents): (Vec<_>, Vec<_>) = blocks_and_contents
+                .iter()
+                .map(|(block, block_contents)| {
+                    (Block::new(block), BlockContents::new(block_contents))
+                })
+                .unzip();
+
+            JsonCommandResponse::get_blocks {
+                blocks,
+                block_contents,
+            }
+        }
         JsonCommandRequest::get_recent_blocks { limit } => {
             let limit = limit.unwrap_or(RECENT_BLOCKS_DEFAULT_LIMIT);
             if limit > MAX_BLOCKS_PER_REQUEST {

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -69,10 +69,10 @@ use std::{
 };
 
 /// Default amount of recent blocks to return
-const RECENT_BLOCKS_DEFAULT_LIMIT: usize = 10;
+pub const RECENT_BLOCKS_DEFAULT_LIMIT: usize = 10;
 
 /// Maximal amount of blocks we can return in a single request
-const MAX_BLOCKS_PER_REQUEST: usize = 100;
+pub const MAX_BLOCKS_PER_REQUEST: usize = 100;
 
 
 pub async fn generic_wallet_api<T, FPR>(

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -5,9 +5,18 @@
 #[cfg(test)]
 mod e2e_misc {
     use crate::{
-        json_rpc::v2::api::test_utils::{
-            dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
-            setup_no_wallet_db, setup_with_api_key, wait_for_sync,
+        json_rpc::v2::{
+            api::{
+                test_utils::{
+                    dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
+                    setup_no_wallet_db, setup_with_api_key, wait_for_sync,
+                },
+                wallet::RECENT_BLOCKS_DEFAULT_LIMIT,
+            },
+            models::{
+                block::{Block, BlockContents},
+                network_status::NetworkStatus,
+            },
         },
         test_utils::{
             add_block_with_tx_outs, create_test_received_txo, random_account_with_seed_values, MOB,
@@ -114,6 +123,7 @@ mod e2e_misc {
         let status = result.get("network_status").unwrap();
         assert_eq!(status.get("network_block_height").unwrap(), "12");
         assert_eq!(status.get("local_block_height").unwrap(), "12");
+        assert_eq!(status.get("local_num_txos").unwrap(), "60");
         assert_eq!(
             status.get("block_version").unwrap(),
             &BlockVersion::MAX.to_string()
@@ -292,6 +302,107 @@ mod e2e_misc {
             error.get("data").unwrap().get("server_error").unwrap(),
             "LedgerDB(Record not found)"
         );
+    }
+
+    #[test_with_logger]
+    fn test_get_recent_blocks(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, _, _, _) = setup(&mut rng, logger.clone());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_recent_blocks",
+            "params": {
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let blocks: Vec<Block> =
+            serde_json::from_value(result.get("blocks").unwrap().clone()).unwrap();
+        let block_contents: Vec<BlockContents> =
+            serde_json::from_value(result.get("block_contents").unwrap().clone()).unwrap();
+        let network_status: NetworkStatus =
+            serde_json::from_value(result.get("network_status").unwrap().clone()).unwrap();
+
+        assert_eq!(network_status.network_block_height, "12");
+        assert_eq!(network_status.local_block_height, "12");
+
+        assert_eq!(blocks.len(), block_contents.len());
+        assert_eq!(blocks.len(), RECENT_BLOCKS_DEFAULT_LIMIT);
+
+        // The most recent block should be the last one
+        assert_eq!(blocks[0].index, "11");
+
+        // Blocks should be in decending order
+        assert!(blocks
+            .windows(2)
+            .all(|w| w[0].index.parse::<u64>().unwrap() == w[1].index.parse::<u64>().unwrap() + 1));
+
+        // Limit should work
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_recent_blocks",
+            "params": {
+                "limit": 3,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let blocks: Vec<Block> =
+            serde_json::from_value(result.get("blocks").unwrap().clone()).unwrap();
+        let block_contents: Vec<BlockContents> =
+            serde_json::from_value(result.get("block_contents").unwrap().clone()).unwrap();
+        let network_status: NetworkStatus =
+            serde_json::from_value(result.get("network_status").unwrap().clone()).unwrap();
+
+        assert_eq!(network_status.network_block_height, "12");
+        assert_eq!(network_status.local_block_height, "12");
+
+        assert_eq!(blocks.len(), block_contents.len());
+        assert_eq!(blocks.len(), 3);
+
+        // The most recent block should be the last one
+        assert_eq!(blocks[0].index, "11");
+
+        // Blocks should be in decending order
+        assert!(blocks
+            .windows(2)
+            .all(|w| w[0].index.parse::<u64>().unwrap() == w[1].index.parse::<u64>().unwrap() + 1));
+    }
+
+    #[test_with_logger]
+    fn test_get_blocks(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, _, _, _) = setup(&mut rng, logger.clone());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_blocks",
+            "params": {
+                "first_block_index": "5",
+                "limit": 3,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let blocks: Vec<Block> =
+            serde_json::from_value(result.get("blocks").unwrap().clone()).unwrap();
+        let block_contents: Vec<BlockContents> =
+            serde_json::from_value(result.get("block_contents").unwrap().clone()).unwrap();
+
+        assert_eq!(blocks.len(), block_contents.len());
+        assert_eq!(blocks.len(), 3);
+
+        // The first block should be the one we requested
+        assert_eq!(blocks[0].index, "5");
+
+        // Blocks should be in ascending order
+        assert!(blocks
+            .windows(2)
+            .all(|w| w[0].index.parse::<u64>().unwrap() == w[1].index.parse::<u64>().unwrap() - 1));
     }
 
     #[test_with_logger]

--- a/full-service/src/json_rpc/v2/models/network_status.rs
+++ b/full-service/src/json_rpc/v2/models/network_status.rs
@@ -16,6 +16,9 @@ pub struct NetworkStatus {
     /// is synced when the local_block_height reaches the network_block_height.
     pub local_block_height: String,
 
+    /// The number of TxOuts in the local ledger.
+    pub local_num_txos: String,
+
     /// The current network fee per token_id.
     pub fees: BTreeMap<String, String>,
 
@@ -30,6 +33,7 @@ impl TryFrom<&service::balance::NetworkStatus> for NetworkStatus {
         Ok(NetworkStatus {
             network_block_height: src.network_block_height.to_string(),
             local_block_height: src.local_block_height.to_string(),
+            local_num_txos: src.local_num_txos.to_string(),
             fees: src
                 .fees
                 .iter()

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -112,6 +112,7 @@ impl Default for &Balance {
 pub struct NetworkStatus {
     pub network_block_height: u64,
     pub local_block_height: u64,
+    pub local_num_txos: u64,
     pub fees: BTreeMap<TokenId, u64>,
     pub block_version: u32,
 }
@@ -233,6 +234,7 @@ where
         Ok(NetworkStatus {
             network_block_height,
             local_block_height: self.ledger_db.num_blocks()?,
+            local_num_txos: self.ledger_db.num_txos()?,
             fees,
             block_version,
         })

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -123,6 +123,11 @@ pub trait LedgerService {
         block_index: u64,
     ) -> Result<(Block, BlockContents), LedgerServiceError>;
 
+    fn get_recent_block_objects(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(Block, BlockContents)>, LedgerServiceError>;
+
     fn contains_key_image(&self, key_image: &KeyImage) -> Result<bool, LedgerServiceError>;
 
     fn get_latest_block_info(&self) -> Result<BlockInfo, LedgerServiceError>;
@@ -191,6 +196,35 @@ where
         let block = self.ledger_db.get_block(block_index)?;
         let block_contents = self.ledger_db.get_block_contents(block_index)?;
         Ok((block, block_contents))
+    }
+
+    fn get_recent_block_objects(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<(Block, BlockContents)>, LedgerServiceError> {
+        let latest_block_index = self.ledger_db.num_blocks()?.checked_sub(1).ok_or_else(|| {
+            LedgerServiceError::InvalidArgument("No blocks in ledger".to_string())
+        })?;
+        let mut block_index = latest_block_index;
+        let mut results = vec![];
+
+        loop {
+            if results.len() >= limit {
+                break;
+            }
+
+            let block = self.ledger_db.get_block(block_index)?;
+            let block_contents = self.ledger_db.get_block_contents(block_index)?;
+            results.push((block, block_contents));
+
+            if block_index == 0 {
+                break;
+            }
+
+            block_index -= 1;
+        }
+
+        Ok(results)
     }
 
     fn contains_key_image(&self, key_image: &KeyImage) -> Result<bool, LedgerServiceError> {


### PR DESCRIPTION
### Motivation

These endpoints are needed for implementing a block explorer. In theory the `get_recent_blocks` endpoint can be implemented by using a combination of `get_blocks` and `get_network_status`, but it is simple enough that I figured it's nice to just have it.

### In this PR
Two new endpoints: `get_blocks` and `get_recent_blocks` in the V2 API.

### Test Plan
Unit tests were added.
