### PR TITLE
A basic search endpoint

### DIFF
--- a/docs/v2/api-endpoints/search_ledger.md
+++ b/docs/v2/api-endpoints/search_ledger.md
@@ -1,0 +1,112 @@
+---
+description: Search the ledger for blocks based on a query string (that can be either a tx out public key or a key image)
+---
+
+# Search Ledger
+
+## [Request](../../../full-service/src/json_rpc/v2/api/request.rs#L40)
+
+| Param | Purpose | Requirements |
+| :--- | :--- | :--- |
+| `query` | Query string to search for. | Currently the supported queries are hex representations of a tx out public key or a key image. |
+
+## [Response](../../../full-service/src/json_rpc/v2/api/response.rs#L41)
+
+## Example
+
+{% tabs %}
+{% tab title="Body Request" %}
+```text
+{
+  "method": "search_ledger",
+  "params": {
+    "query": "0a209458f8e0aa9eff40475c64bcb90407adb0da56e6889665ea23176ae28314ca4f"
+  },
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```text
+{
+  "method": "search_ledger",
+  "result": {
+    "results": [
+      {
+        "result_type": "KeyImage",
+        "block": {
+          "id": "e0140f99e60299842b953cd5caa8d2c8977861eba66c8987deb8d628a98cabef",
+          "version": "2",
+          "parent_id": "c49b11e3cc8da6ac030a5ca15e969a2a9eb6c4f466af71eb04baaf5c21b56401",
+          "index": "1369672",
+          "cumulative_txo_count": "4112217",
+          "root_element": {
+            "range": {
+              "from": "0",
+              "to": "4194303"
+            },
+            "hash": "25485b5701617714fe66fb59fe01b296ff627252eb8b9a95fe7445ee8e889263"
+          },
+          "contents_hash": "840c5a4e462ec19a89195f71a6731503dcaf91a3f19655c1dd89194fa367beb7"
+        },
+        "block_contents": {
+          "key_images": [
+            "0a209458f8e0aa9eff40475c64bcb90407adb0da56e6889665ea23176ae28314ca4f",
+            "0a209cd92e6c177ee88bf5f0ec74ee0c689cdd86452681a97befeab2a5c66f6a4c4b"
+          ],
+          "outputs": [
+            {
+              "masked_amount": {
+                "commitment": "908013979a7921c58bebe18ea52e6a0d0549357de0f91162c27918a0c1aca36a",
+                "masked_value": "5021023487447205630",
+                "masked_token_id": "4b91842f66e11f78",
+                "version": 1
+              },
+              "target_key": "42ba9c95315143febafa00c491ae9c2b612b2b311f4514c11c21a692bc960716",
+              "public_key": "545eb308f009216f9b2768879e70ec7db505e6d1e22d1ef9629a89a0934cf875",
+              "e_fog_hint": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+              "e_memo": "2602de077ca7fa4c0199aeb6297f8db4f52e1fc73be0e358271c4ef12cd3452e952a6649b6e130bfaaf310eebf4a76afa4c9f94724c73e28c5da209668582b27ed30"
+            },
+            {
+              "masked_amount": {
+                "commitment": "aac44ae256a5ad368d34436ab0c07669743d0033020bff45fca01586ca3c4519",
+                "masked_value": "9134733508405425051",
+                "masked_token_id": "4c088b69b7a477de",
+                "version": 1
+              },
+              "target_key": "7a521900c99388e6bc6d40e17cb42f95fffcb3605c881d04323157eb92ed2404",
+              "public_key": "7a21df10a5af5cb0f8ece7d2d9ec92fe71ca86a4956f47930e92eb0924037e76",
+              "e_fog_hint": "c58f3d8c2f06d8446d7847c30892a2a085cbe76aef4de2a01e8911a98a9c02a023d2aee25ae5756708b36ece79bcb6ffad7c121fa861a4ced11df207b64fac64581d672caa4f4fe35d46e342b2afd9b4d6950100",
+              "e_memo": "4473d4483f0504a9a2866995b2d8e560b41c3c3eae7d3ee2e48357bf5771e886db93fcdbc613523bdbf693e8c894120d16285d88b65815ba434103399cc5740a9f7b"
+            },
+            {
+              "masked_amount": {
+                "commitment": "d621fc3837f94ec5efe3f391f67f8e3aa1e5ca6fa142e40554ee7401cc52e069",
+                "masked_value": "7675168110278462933",
+                "masked_token_id": "d2a91db0f96813de",
+                "version": 1
+              },
+              "target_key": "2cfa011ec4c8ee576cc7dc56ae7ef5928b65f50e77fc2a9bf92822f8d66c0259",
+              "public_key": "98ff4f715080417cb65165c606ab39169caa969f23643e6b4f3e5569385fed1b",
+              "e_fog_hint": "c7fd6f47978f68eeeb087fa5e94ad535beb4d1a0a0255ee9af1407bda136d9e2f9b7425a001bef4c58967b1283c22e0583d034fde2db01f4cf6b0cfaaaaf9fbdd37d959a5effd6545cdea201bda4adcb21a40100",
+              "e_memo": "4c692f00fdc26bea03012d7eb1e10ecde3ad3f07ef4cfab9f9490458e3668dca805c14e69fd3818ffd14fa9a1898811a5610837d818c5cabd4be397e62665b62b07c"
+            }
+          ]
+        },
+        "tx_out": null,
+        "key_image": {
+          "block_contents_key_image_index": "0"
+        }
+      }
+    ]
+  },
+  "error": null,
+  "jsonrpc": "2.0",
+  "id": 1
+}
+```
+{% endtab %}
+{% endtabs %}
+

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -250,4 +250,7 @@ pub enum JsonCommandRequest {
         address: String,
     },
     version,
+    search_ledger {
+        query: String,
+    },
 }

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -227,6 +227,9 @@ pub enum JsonCommandRequest {
         num_mixins: u64,
         excluded_outputs: Vec<JsonTxOut>,
     },
+    search_ledger {
+        query: String,
+    },
     submit_transaction {
         tx_proposal: TxProposal,
         comment: Option<String>,
@@ -250,7 +253,4 @@ pub enum JsonCommandRequest {
         address: String,
     },
     version,
-    search_ledger {
-        query: String,
-    },
 }

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -15,6 +15,7 @@ use crate::{
             balance::BalanceMap,
             block::{Block, BlockContents},
             confirmation_number::Confirmation,
+            ledger::LedgerSearchResult,
             network_status::NetworkStatus,
             public_address::PublicAddress,
             receiver_receipt::ReceiverReceipt,
@@ -188,6 +189,9 @@ pub enum JsonCommandResponse {
         string: String,
         number: (String, String, String, String),
         commit: String,
+    },
+    search_ledger {
+        results: Vec<LedgerSearchResult>,
     },
 }
 

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -172,6 +172,9 @@ pub enum JsonCommandResponse {
         mixins: Vec<JsonTxOut>,
         membership_proofs: Vec<JsonTxOutMembershipProof>,
     },
+    search_ledger {
+        results: Vec<LedgerSearchResult>,
+    },
     submit_transaction {
         transaction_log: Option<TransactionLog>,
     },
@@ -189,9 +192,6 @@ pub enum JsonCommandResponse {
         string: String,
         number: (String, String, String, String),
         commit: String,
-    },
-    search_ledger {
-        results: Vec<LedgerSearchResult>,
     },
 }
 

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1127,6 +1127,12 @@ where
             ),
             commit: env!("VERGEN_GIT_SHA").to_string(),
         },
+        JsonCommandRequest::search_ledger { query } => {
+            let results = service.search_ledger(&query).map_err(format_error)?;
+            JsonCommandResponse::search_ledger {
+                results: results.iter().map(Into::into).collect(),
+            }
+        }
     };
 
     Ok(response)

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1058,6 +1058,12 @@ where
                 membership_proofs,
             }
         }
+        JsonCommandRequest::search_ledger { query } => {
+            let results = service.search_ledger(&query).map_err(format_error)?;
+            JsonCommandResponse::search_ledger {
+                results: results.iter().map(Into::into).collect(),
+            }
+        }
         JsonCommandRequest::submit_transaction {
             tx_proposal,
             comment,
@@ -1127,12 +1133,6 @@ where
             ),
             commit: env!("VERGEN_GIT_SHA").to_string(),
         },
-        JsonCommandRequest::search_ledger { query } => {
-            let results = service.search_ledger(&query).map_err(format_error)?;
-            JsonCommandResponse::search_ledger {
-                results: results.iter().map(Into::into).collect(),
-            }
-        }
     };
 
     Ok(response)

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -15,8 +15,8 @@ mod e2e_misc {
             },
             models::{
                 block::{Block, BlockContents},
+                ledger::LedgerSearchResult,
                 network_status::NetworkStatus,
-            ledger::LedgerSearchResult,
             },
         },
         test_utils::{

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -5,9 +5,12 @@
 #[cfg(test)]
 mod e2e_misc {
     use crate::{
-        json_rpc::v2::api::test_utils::{
-            dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
-            setup_no_wallet_db, setup_with_api_key, wait_for_sync,
+        json_rpc::v2::{
+            api::test_utils::{
+                dispatch, dispatch_with_header, dispatch_with_header_expect_error, setup,
+                setup_no_wallet_db, setup_with_api_key, wait_for_sync,
+            },
+            models::ledger::LedgerSearchResult,
         },
         test_utils::{
             add_block_with_tx_outs, create_test_received_txo, random_account_with_seed_values, MOB,
@@ -16,6 +19,7 @@ mod e2e_misc {
 
     use mc_common::logger::{test_with_logger, Logger};
     use mc_crypto_rand::RngCore;
+    use mc_ledger_db::Ledger;
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Amount, BlockVersion, Token};
 
     use rand::{rngs::StdRng, SeedableRng};
@@ -326,5 +330,76 @@ mod e2e_misc {
         // Check that we got a result! (We don't really care what it is, just that it's
         // working)
         let _ = res.get("result").unwrap();
+    }
+
+    #[test_with_logger]
+    fn test_ledger_search(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, ledger_db, _, _) = setup(&mut rng, logger.clone());
+
+        // Search a non-existent hash
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "search_ledger",
+            "params": {
+                "query": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let results: Vec<LedgerSearchResult> =
+            serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
+        assert_eq!(results.len(), 0);
+
+        // Search by txo public key
+        let txo = ledger_db.get_tx_out_by_index(5).unwrap();
+        let pub_key_hex = hex::encode(txo.public_key.as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "search_ledger",
+            "params": {
+                "query": pub_key_hex
+            },
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let results: Vec<LedgerSearchResult> =
+            serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
+        assert_eq!(results.len(), 1);
+
+        assert_eq!(results[0].result_type, "TxOut".to_string());
+        assert_eq!(results[0].tx_out.as_ref().unwrap().global_tx_out_index, "5");
+
+        // Search by key image
+        let block_contents = ledger_db.get_block_contents(3).unwrap();
+        let key_image_hex = hex::encode(block_contents.key_images[0].as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "search_ledger",
+            "params": {
+                "query": key_image_hex
+            },
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let results: Vec<LedgerSearchResult> =
+            serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
+        assert_eq!(results.len(), 1);
+
+        assert_eq!(results[0].result_type, "KeyImage".to_string());
+        assert_eq!(results[0].block.index, "3");
+        assert_eq!(
+            results[0]
+                .key_image
+                .as_ref()
+                .unwrap()
+                .block_contents_key_image_index,
+            "0"
+        );
     }
 }

--- a/full-service/src/json_rpc/v2/models/block.rs
+++ b/full-service/src/json_rpc/v2/models/block.rs
@@ -5,7 +5,7 @@
 use mc_mobilecoind_json::data_types::{JsonTxOut, JsonTxOutMembershipElement};
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
 pub struct Block {
     pub id: String,
     pub version: String,
@@ -32,7 +32,13 @@ impl Block {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+impl From<&mc_blockchain_types::Block> for Block {
+    fn from(src: &mc_blockchain_types::Block) -> Self {
+        Self::new(src)
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
 pub struct BlockContents {
     pub key_images: Vec<String>,
     pub outputs: Vec<JsonTxOut>,
@@ -55,5 +61,10 @@ impl BlockContents {
                 })
                 .collect::<Vec<JsonTxOut>>(),
         }
+    }
+}
+impl From<&mc_blockchain_types::BlockContents> for BlockContents {
+    fn from(src: &mc_blockchain_types::BlockContents) -> Self {
+        Self::new(src)
     }
 }

--- a/full-service/src/json_rpc/v2/models/ledger.rs
+++ b/full-service/src/json_rpc/v2/models/ledger.rs
@@ -2,13 +2,15 @@
 
 //! API definition for ledger-related objects.
 
-use crate::service::models::ledger::LedgerSearchResult as ServiceLedgerSearchResult;
+use crate::{
+    json_rpc::v2::models::block::{Block, BlockContents},
+    service::models::ledger::LedgerSearchResult as ServiceLedgerSearchResult,
+};
 use serde_derive::{Deserialize, Serialize};
 
 // TxOut search result
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct LedgerTxOutSearchResult {
-    pub block_index: String,
     pub block_contents_tx_out_index: String,
     pub global_tx_out_index: String,
 }
@@ -16,7 +18,6 @@ pub struct LedgerTxOutSearchResult {
 // KeyImage search result
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct LedgerKeyImageSearchResult {
-    pub block_index: String,
     pub block_contents_key_image_index: String,
 }
 
@@ -24,6 +25,8 @@ pub struct LedgerKeyImageSearchResult {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct LedgerSearchResult {
     pub result_type: String,
+    pub block: Block,
+    pub block_contents: BlockContents,
     pub tx_out: Option<LedgerTxOutSearchResult>,
     pub key_image: Option<LedgerKeyImageSearchResult>,
 }
@@ -32,28 +35,32 @@ impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
     fn from(src: &ServiceLedgerSearchResult) -> Self {
         match src {
             ServiceLedgerSearchResult::TxOut {
-                block_index,
+                block,
+                block_contents,
                 block_contents_tx_out_index,
-                global_tx_out_index,
+                tx_out_global_index,
             } => Self {
                 result_type: "TxOut".to_string(),
+                block: block.into(),
+                block_contents: block_contents.into(),
                 tx_out: Some(LedgerTxOutSearchResult {
-                    block_index: block_index.to_string(),
                     block_contents_tx_out_index: block_contents_tx_out_index.to_string(),
-                    global_tx_out_index: global_tx_out_index.to_string(),
+                    global_tx_out_index: tx_out_global_index.to_string(),
                 }),
-                key_image: None,
+                ..Default::default()
             },
             ServiceLedgerSearchResult::KeyImage {
-                block_index,
+                block,
+                block_contents,
                 block_contents_key_image_index,
             } => Self {
                 result_type: "KeyImage".to_string(),
-                tx_out: None,
+                block: block.into(),
+                block_contents: block_contents.into(),
                 key_image: Some(LedgerKeyImageSearchResult {
-                    block_index: block_index.to_string(),
                     block_contents_key_image_index: block_contents_key_image_index.to_string(),
                 }),
+                ..Default::default()
             },
         }
     }

--- a/full-service/src/json_rpc/v2/models/ledger.rs
+++ b/full-service/src/json_rpc/v2/models/ledger.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for ledger-related objects.
+
+use crate::service::models::ledger::LedgerSearchResult as ServiceLedgerSearchResult;
+use serde_derive::{Deserialize, Serialize};
+
+// TxOut search result
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LedgerTxOutSearchResult {
+    pub block_index: String,
+    pub block_contents_tx_out_index: String,
+    pub global_tx_out_index: String,
+}
+
+// KeyImage search result
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LedgerKeyImageSearchResult {
+    pub block_index: String,
+    pub block_contents_key_image_index: String,
+}
+
+/// Information about a single search result
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LedgerSearchResult {
+    pub result_type: String,
+    pub tx_out: Option<LedgerTxOutSearchResult>,
+    pub key_image: Option<LedgerKeyImageSearchResult>,
+}
+
+impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
+    fn from(src: &ServiceLedgerSearchResult) -> Self {
+        match src {
+            ServiceLedgerSearchResult::TxOut {
+                block_index,
+                block_contents_tx_out_index,
+                global_tx_out_index,
+            } => Self {
+                result_type: "TxOut".to_string(),
+                tx_out: Some(LedgerTxOutSearchResult {
+                    block_index: block_index.to_string(),
+                    block_contents_tx_out_index: block_contents_tx_out_index.to_string(),
+                    global_tx_out_index: global_tx_out_index.to_string(),
+                }),
+                key_image: None,
+            },
+            ServiceLedgerSearchResult::KeyImage {
+                block_index,
+                block_contents_key_image_index,
+            } => Self {
+                result_type: "KeyImage".to_string(),
+                tx_out: None,
+                key_image: Some(LedgerKeyImageSearchResult {
+                    block_index: block_index.to_string(),
+                    block_contents_key_image_index: block_contents_key_image_index.to_string(),
+                }),
+            },
+        }
+    }
+}

--- a/full-service/src/json_rpc/v2/models/mod.rs
+++ b/full-service/src/json_rpc/v2/models/mod.rs
@@ -6,6 +6,7 @@ pub mod amount;
 pub mod balance;
 pub mod block;
 pub mod confirmation_number;
+pub mod ledger;
 pub mod masked_amount;
 pub mod network_status;
 pub mod public_address;

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -356,13 +356,15 @@ fn search_ledger_by_tx_out_pub_key(
         return Ok(None);
     };
 
-    let global_tx_out_index = match ledger_db.get_tx_out_index_by_public_key(&public_key) {
+    let tx_out_global_index = match ledger_db.get_tx_out_index_by_public_key(&public_key) {
         Ok(index) => index,
         Err(LedgerError::NotFound) => return Ok(None),
         Err(e) => return Err(LedgerServiceError::from(e)),
     };
 
-    let block_index = ledger_db.get_block_index_by_tx_out_index(global_tx_out_index)?;
+    let block_index = ledger_db.get_block_index_by_tx_out_index(tx_out_global_index)?;
+
+    let block = ledger_db.get_block(block_index)?;
 
     let block_contents = ledger_db.get_block_contents(block_index)?;
 
@@ -374,9 +376,10 @@ fn search_ledger_by_tx_out_pub_key(
         as u64;
 
     Ok(Some(LedgerSearchResult::TxOut {
-        block_index,
+        block,
+        block_contents,
         block_contents_tx_out_index,
-        global_tx_out_index,
+        tx_out_global_index,
     }))
 }
 
@@ -396,6 +399,8 @@ fn search_ledger_by_key_image(
         return Ok(None);
     };
 
+    let block = ledger_db.get_block(block_index)?;
+
     let block_contents = ledger_db.get_block_contents(block_index)?;
 
     let block_contents_key_image_index = block_contents
@@ -406,7 +411,8 @@ fn search_ledger_by_key_image(
         as u64;
 
     Ok(Some(LedgerSearchResult::KeyImage {
-        block_index,
+        block,
+        block_contents,
         block_contents_key_image_index,
     }))
 }

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -19,7 +19,7 @@ use mc_connection::{
 };
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
-use mc_ledger_db::{Ledger, LedgerDB};
+use mc_ledger_db::{Error as LedgerError, Ledger, LedgerDB};
 use mc_ledger_sync::NetworkState;
 use mc_transaction_core::{
     ring_signature::KeyImage,

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -8,6 +8,7 @@ use crate::{
         transaction_log::{TransactionId, TransactionLogModel},
         txo::TxoModel,
     },
+    service::models::ledger::LedgerSearchResult,
     WalletService,
 };
 use mc_blockchain_types::{Block, BlockContents, BlockVersion, BlockVersionError};
@@ -70,6 +71,9 @@ pub enum LedgerServiceError {
 
     /// Block version: {0}
     BlockVersion(BlockVersionError),
+
+    /// Ledger inconsistent
+    LedgerInconsistent,
 }
 
 impl From<mc_ledger_db::Error> for LedgerServiceError {
@@ -151,6 +155,8 @@ pub trait LedgerService {
         &self,
         public_key: &CompressedRistrettoPublic,
     ) -> Result<u64, LedgerServiceError>;
+
+    fn search_ledger(&self, query: &str) -> Result<Vec<LedgerSearchResult>, LedgerServiceError>;
 }
 
 impl<T, FPR> LedgerService for WalletService<T, FPR>
@@ -300,6 +306,35 @@ where
         let index = self.ledger_db.get_tx_out_index_by_public_key(public_key)?;
         Ok(self.ledger_db.get_block_index_by_tx_out_index(index)?)
     }
+
+    fn search_ledger(&self, query: &str) -> Result<Vec<LedgerSearchResult>, LedgerServiceError> {
+        let mut results = vec![];
+
+        // Try intepreting the query as a hex string.
+        if let Some(mut query_bytes) = hex::decode(query).ok() {
+            // Hack - strip away the protobuf header if we have one. This hack
+            // is needed because sometimes full-service returns protobuf-encoded
+            // bytes instead of just returning the raw bytes.
+            // See https://github.com/mobilecoinofficial/full-service/issues/201
+            // The protobuf encoded bytes start with 0x0a20
+            if query_bytes.len() == 34 && query_bytes[0] == 0x0a && query_bytes[1] == 0x20 {
+                query_bytes.remove(0);
+                query_bytes.remove(0);
+            }
+
+            // Try and search for a tx out by public key.
+            if let Some(result) = search_ledger_by_tx_out_pub_key(&self.ledger_db, &query_bytes)? {
+                results.push(result);
+            }
+
+            // Try and search for a key image.
+            if let Some(result) = search_ledger_by_key_image(&self.ledger_db, &query_bytes)? {
+                results.push(result);
+            }
+        }
+
+        Ok(results)
+    }
 }
 
 pub fn get_tx_out_by_public_key(
@@ -309,4 +344,69 @@ pub fn get_tx_out_by_public_key(
     let txo_index = ledger_db.get_tx_out_index_by_public_key(public_key)?;
     let txo = ledger_db.get_tx_out_by_index(txo_index)?;
     Ok(txo)
+}
+
+fn search_ledger_by_tx_out_pub_key(
+    ledger_db: &LedgerDB,
+    query_bytes: &[u8],
+) -> Result<Option<LedgerSearchResult>, LedgerServiceError> {
+    let public_key = if let Ok(pk) = CompressedRistrettoPublic::try_from(&query_bytes[..]) {
+        pk
+    } else {
+        return Ok(None);
+    };
+
+    let global_tx_out_index = match ledger_db.get_tx_out_index_by_public_key(&public_key) {
+        Ok(index) => index,
+        Err(LedgerError::NotFound) => return Ok(None),
+        Err(e) => return Err(LedgerServiceError::from(e)),
+    };
+
+    let block_index = ledger_db.get_block_index_by_tx_out_index(global_tx_out_index)?;
+
+    let block_contents = ledger_db.get_block_contents(block_index)?;
+
+    let block_contents_tx_out_index = block_contents
+        .outputs
+        .iter()
+        .position(|tx_out| tx_out.public_key == public_key)
+        .ok_or(LedgerServiceError::LedgerInconsistent)?
+        as u64;
+
+    Ok(Some(LedgerSearchResult::TxOut {
+        block_index,
+        block_contents_tx_out_index,
+        global_tx_out_index,
+    }))
+}
+
+fn search_ledger_by_key_image(
+    ledger_db: &LedgerDB,
+    query_bytes: &[u8],
+) -> Result<Option<LedgerSearchResult>, LedgerServiceError> {
+    let key_image = if let Ok(ki) = KeyImage::try_from(&query_bytes[..]) {
+        ki
+    } else {
+        return Ok(None);
+    };
+
+    let block_index = if let Some(idx) = ledger_db.check_key_image(&key_image)? {
+        idx
+    } else {
+        return Ok(None);
+    };
+
+    let block_contents = ledger_db.get_block_contents(block_index)?;
+
+    let block_contents_key_image_index = block_contents
+        .key_images
+        .iter()
+        .position(|key_image2| key_image2 == &key_image)
+        .ok_or(LedgerServiceError::LedgerInconsistent)?
+        as u64;
+
+    Ok(Some(LedgerSearchResult::KeyImage {
+        block_index,
+        block_contents_key_image_index,
+    }))
 }

--- a/full-service/src/service/models/ledger.rs
+++ b/full-service/src/service/models/ledger.rs
@@ -2,6 +2,7 @@
 
 //! API definition for LedgerService-related objects.
 
+use mc_blockchain_types::{Block, BlockContents};
 use serde_derive::{Deserialize, Serialize};
 
 /// A single search result from the ledger.
@@ -9,20 +10,26 @@ use serde_derive::{Deserialize, Serialize};
 pub enum LedgerSearchResult {
     /// Query matched a TxOut
     TxOut {
-        /// The block index that contains the TxOut
-        block_index: u64,
+        /// The block that contains the TxOut
+        block: Block,
+
+        /// The block contents that contains the TxOut
+        block_contents: BlockContents,
 
         /// The index of the output inside the block contents
         block_contents_tx_out_index: u64,
 
-        /// The global tx out index
-        global_tx_out_index: u64,
+        /// The global index of the TxOut
+        tx_out_global_index: u64,
     },
 
     /// Query matched a KeyImage
     KeyImage {
-        /// The block index that contains the KeyImage
-        block_index: u64,
+        /// The block that contains the TxOut
+        block: Block,
+
+        /// The block contents that contains the TxOut
+        block_contents: BlockContents,
 
         /// The index of the key image inside the block contents
         block_contents_key_image_index: u64,

--- a/full-service/src/service/models/ledger.rs
+++ b/full-service/src/service/models/ledger.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for LedgerService-related objects.
+
+use serde_derive::{Deserialize, Serialize};
+
+/// A single search result from the ledger.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum LedgerSearchResult {
+    /// Query matched a TxOut
+    TxOut {
+        /// The block index that contains the TxOut
+        block_index: u64,
+
+        /// The index of the output inside the block contents
+        block_contents_tx_out_index: u64,
+
+        /// The global tx out index
+        global_tx_out_index: u64,
+    },
+
+    /// Query matched a KeyImage
+    KeyImage {
+        /// The block index that contains the KeyImage
+        block_index: u64,
+
+        /// The index of the key image inside the block contents
+        block_contents_key_image_index: u64,
+    },
+}

--- a/full-service/src/service/models/mod.rs
+++ b/full-service/src/service/models/mod.rs
@@ -1,1 +1,2 @@
+pub mod ledger;
 pub mod tx_proposal;


### PR DESCRIPTION
### Motivation

We'd like to have the option to search the ledger by tx out public keys, key images, and later on TxoIDs (and maybe other things).

### In this PR
* Initial implementation of a basic `search_ledger` endpoint.

### Test Plan
Unit test was added to cover the basic functionality.

### Future Work
* Expand search to cover more queries, such as TxoIDs.
