### PR TITLE
Account sync pause every 1000 blocks

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -159,7 +159,7 @@ pub trait TransactionLogModel {
 
     fn update_tx_and_tombstone_block_index(
         &self,
-        tx: &Vec<u8>,
+        tx: &[u8],
         tombstone_block_index: Option<i64>,
         conn: &Conn,
     ) -> Result<(), WalletDbError>;
@@ -328,7 +328,7 @@ impl TransactionLogModel for TransactionLog {
 
     fn update_tx_and_tombstone_block_index(
         &self,
-        tx: &Vec<u8>,
+        tx: &[u8],
         tombstone_block_index: Option<i64>,
         conn: &Conn,
     ) -> Result<(), WalletDbError> {

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1437,10 +1437,7 @@ mod tests {
             models::{Account, TransactionLog},
             transaction_log::TransactionLogModel,
         },
-        service::{
-            transaction::TransactionMemo,
-            transaction_builder::WalletTransactionBuilder,
-        },
+        service::{transaction::TransactionMemo, transaction_builder::WalletTransactionBuilder},
         test_utils::{
             add_block_with_tx, add_block_with_tx_outs, create_test_minted_and_change_txos,
             create_test_received_txo, create_test_txo_for_recipient, get_resolver_factory,
@@ -2159,11 +2156,10 @@ mod tests {
         // Process the txos in the ledger into the DB
         manually_sync_account(
             &ledger_db,
-            &wallet_db.get_conn().unwrap(),
-            &AccountID::from(&src_account).to_string(),
+            &wallet_db,
+            &AccountID::from(&src_account),
             &logger,
-        )
-        .unwrap();
+        );
 
         let recipient =
             AccountKey::from(&RootIdentity::from_random(&mut rng)).subaddress(rng.next_u64());

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1438,7 +1438,6 @@ mod tests {
             transaction_log::TransactionLogModel,
         },
         service::{
-            sync::{sync_account, SyncThread},
             transaction::TransactionMemo,
             transaction_builder::WalletTransactionBuilder,
         },
@@ -2158,7 +2157,7 @@ mod tests {
         .unwrap();
 
         // Process the txos in the ledger into the DB
-        sync_account(
+        manually_sync_account(
             &ledger_db,
             &wallet_db.get_conn().unwrap(),
             &AccountID::from(&src_account).to_string(),
@@ -2235,7 +2234,6 @@ mod tests {
 
         // Start sync thread
         log::info!(logger, "Starting sync thread");
-        let _sync_thread = SyncThread::start(ledger_db.clone(), wallet_db.clone(), logger.clone());
 
         log::info!(logger, "Creating a random sender account");
         let sender_account_key = random_account_with_seed_values(

--- a/full-service/src/service/ledger.rs
+++ b/full-service/src/service/ledger.rs
@@ -384,7 +384,7 @@ where
         let mut results = vec![];
 
         // Try intepreting the query as a hex string.
-        if let Some(mut query_bytes) = hex::decode(query).ok() {
+        if let Ok(mut query_bytes) = hex::decode(query) {
             // Hack - strip away the protobuf header if we have one. This hack
             // is needed because sometimes full-service returns protobuf-encoded
             // bytes instead of just returning the raw bytes.
@@ -423,7 +423,7 @@ fn search_ledger_by_tx_out_pub_key(
     ledger_db: &LedgerDB,
     query_bytes: &[u8],
 ) -> Result<Option<LedgerSearchResult>, LedgerServiceError> {
-    let public_key = if let Ok(pk) = CompressedRistrettoPublic::try_from(&query_bytes[..]) {
+    let public_key = if let Ok(pk) = CompressedRistrettoPublic::try_from(query_bytes) {
         pk
     } else {
         return Ok(None);
@@ -460,7 +460,7 @@ fn search_ledger_by_key_image(
     ledger_db: &LedgerDB,
     query_bytes: &[u8],
 ) -> Result<Option<LedgerSearchResult>, LedgerServiceError> {
-    let key_image = if let Ok(ki) = KeyImage::try_from(&query_bytes[..]) {
+    let key_image = if let Ok(ki) = KeyImage::try_from(query_bytes) {
         ki
     } else {
         return Ok(None);

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -119,7 +119,7 @@ pub fn sync_all_accounts(
 
     // Go over our list of accounts and see which ones need to process more blocks.
     let accounts: Vec<Account> =
-        { Account::list_all(&conn, None, None).expect("Failed getting accounts from database") };
+        { Account::list_all(conn, None, None).expect("Failed getting accounts from database") };
 
     for account in accounts {
         // If there are no new blocks for this account, don't do anything.
@@ -133,7 +133,7 @@ pub fn sync_all_accounts(
     Ok(())
 }
 
-fn sync_account(
+pub fn sync_account(
     ledger_db: &LedgerDB,
     conn: &Conn,
     account_id_hex: &str,

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -127,13 +127,13 @@ pub fn sync_all_accounts(
             continue;
         }
 
-        let _status = sync_account(ledger_db, conn, &account.id, logger)?;
+        sync_account_next_chunk(ledger_db, conn, &account.id, logger)?;
     }
 
     Ok(())
 }
 
-pub fn sync_account(
+pub fn sync_account_next_chunk(
     ledger_db: &LedgerDB,
     conn: &Conn,
     account_id_hex: &str,

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -127,17 +127,17 @@ pub fn sync_all_accounts(
             continue;
         }
 
-        let _status = sync_account_next_chunk(ledger_db, conn, logger, &account.id)?;
+        let _status = sync_account(ledger_db, conn, &account.id, logger)?;
     }
 
     Ok(())
 }
 
-fn sync_account_next_chunk(
+fn sync_account(
     ledger_db: &LedgerDB,
     conn: &Conn,
-    logger: &Logger,
     account_id_hex: &str,
+    logger: &Logger,
 ) -> Result<(), SyncError> {
     transaction(conn, || {
         // Get the account data. If it is no longer available, the account has been
@@ -178,7 +178,7 @@ fn sync_account_next_chunk(
 
         // If no blocks were found, exit.
         if end_block_index.is_none() {
-            return Ok(SyncStatus::NoMoreBlocks);
+            return Ok(());
         }
         let end_block_index = end_block_index.unwrap();
 
@@ -357,9 +357,7 @@ fn sync_account_next_chunk(
         };
 
         Ok(())
-    });
-
-    Ok(())
+    })
 }
 
 /// Attempt to decode the transaction amount. If we can't, then this transaction

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     error::SyncError,
     service::{
-        models::tx_proposal::TxProposal, sync::sync_account_next_chunk, transaction::TransactionMemo,
-        transaction_builder::WalletTransactionBuilder,
+        models::tx_proposal::TxProposal, sync::sync_account_next_chunk,
+        transaction::TransactionMemo, transaction_builder::WalletTransactionBuilder,
     },
     WalletService,
 };

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     error::SyncError,
     service::{
-        models::tx_proposal::TxProposal, sync::sync_account, transaction::TransactionMemo,
+        models::tx_proposal::TxProposal, sync::sync_account_next_chunk, transaction::TransactionMemo,
         transaction_builder::WalletTransactionBuilder,
     },
     WalletService,
@@ -327,7 +327,7 @@ pub fn manually_sync_account(
 ) -> Account {
     let mut account: Account;
     loop {
-        match sync_account(
+        match sync_account_next_chunk(
             &ledger_db,
             &wallet_db.get_conn().unwrap(),
             &account_id.to_string(),


### PR DESCRIPTION
### Motivation

Account syncing was still locking the database when importing an account from block 0

### In this PR
* Changed account sync to sync 1000 blocks max per iteration across all accounts before taking a slight pause to allow other code to execute. This is required because account syncing write locks the wallet_db, and previously it would loop and sync until it was up to date, which was unintentional.

