### PR TITLE
Add watcher information to v2 responses that include block information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,8 @@ dependencies = [
  "mc-util-uri",
  "mc-validator-api",
  "mc-validator-connection",
+ "mc-watcher",
+ "mc-watcher-api",
  "num_cpus",
  "protobuf",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ dependencies = [
  "strum_macros",
  "tempdir",
  "tiny-bip39",
+ "url",
  "uuid",
  "vergen",
 ]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -44,6 +44,8 @@ mc-util-from-random = { path = "../mobilecoin/util/from-random" }
 mc-util-parse = { path = "../mobilecoin/util/parse" }
 mc-util-serial = { path = "../mobilecoin/util/serial", default-features = false }
 mc-util-uri = { path = "../mobilecoin/util/uri" }
+mc-watcher = { path = "../mobilecoin/watcher" }
+mc-watcher-api = { path = "../mobilecoin/watcher/api" }
 
 base64 = "0.13.1"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -82,6 +82,7 @@ mc-connection-test-utils = { path = "../mobilecoin/connection/test-utils" }
 mc-consensus-enclave-api = { path = "../mobilecoin/consensus/enclave/api" }
 mc-fog-report-validation = { path = "../mobilecoin/fog/report/validation", features = ["automock"] }
 mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils" }
+url = "2.3"
 tempdir = "0.3"
 
 [build-dependencies]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -82,8 +82,8 @@ mc-connection-test-utils = { path = "../mobilecoin/connection/test-utils" }
 mc-consensus-enclave-api = { path = "../mobilecoin/consensus/enclave/api" }
 mc-fog-report-validation = { path = "../mobilecoin/fog/report/validation", features = ["automock"] }
 mc-fog-report-validation-test-utils = { path = "../mobilecoin/fog/report/validation/test-utils" }
-url = "2.3"
 tempdir = "0.3"
+url = "2.3"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -20,6 +20,7 @@ use mc_full_service::{
 use mc_ledger_sync::{LedgerSyncServiceThread, PollingNetworkState, ReqwestTransactionsFetcher};
 use mc_validator_api::ValidatorUri;
 use mc_validator_connection::ValidatorConnection;
+use mc_watcher::{watcher::WatcherSyncThread, watcher_db::create_or_open_rw_watcher_db};
 use std::{
     env,
     net::IpAddr,
@@ -152,15 +153,50 @@ async fn consensus_backed_full_service(
             ledger_db.clone(),
             peer_manager.clone(),
             network_state.clone(),
-            transactions_fetcher,
+            transactions_fetcher.clone(),
             config.poll_interval,
             logger.clone(),
         ))
     };
 
+    // Optionally instantiate the watcher sync thread and get the watcher_db handle.
+    let (watcher_db, _watcher_sync_thread) = match &config.watcher_db {
+        Some(watcher_db_path) => {
+            log::info!(logger, "Launching watcher.");
+
+            log::info!(logger, "Opening watcher db at {:?}.", watcher_db_path);
+            let watcher_db = create_or_open_rw_watcher_db(
+                watcher_db_path,
+                &transactions_fetcher.source_urls,
+                logger.clone(),
+            )
+            .expect("Could not create or open WatcherDB");
+
+            // Start watcher db sync thread, unless running in offline mode.
+            let watcher_sync_thread = if config.offline {
+                panic!("Attempted to start watcher but we are configured in offline mode");
+            } else {
+                log::info!(logger, "Starting watcher sync thread");
+                Some(
+                    WatcherSyncThread::new(
+                        watcher_db.clone(),
+                        ledger_db.clone(),
+                        config.poll_interval,
+                        false,
+                        logger.clone(),
+                    )
+                    .expect("Failed starting watcher thread"),
+                )
+            };
+            (Some(watcher_db), watcher_sync_thread)
+        }
+        None => (None, None),
+    };
+
     let service = WalletService::new(
         wallet_db,
         ledger_db,
+        watcher_db,
         peer_manager,
         network_state,
         config.get_fog_resolver_factory(logger.clone()),
@@ -183,6 +219,10 @@ async fn validator_backed_full_service(
     rocket_config: rocket::Config,
     logger: Logger,
 ) -> Result<(), rocket::Error> {
+    if config.wallet_db.is_some() {
+        panic!("Watcher syncing is not yet supported in a validator configuration");
+    }
+
     let validator_conn = ValidatorConnection::new(
         validator_uri,
         config.peers_config.chain_id.clone(),
@@ -233,6 +273,7 @@ async fn validator_backed_full_service(
     let service = WalletService::new(
         wallet_db,
         ledger_db,
+        None,
         conn_manager,
         network_state,
         Arc::new(move |fog_uris| -> Result<FogResolver, String> {

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -70,7 +70,8 @@ pub struct APIConfig {
     #[clap(long, env = "MC_VALIDATOR")]
     pub validator: Option<ValidatorUri>,
 
-    /// Path to watcher db (lmdb).
+    /// Path to watcher db (lmdb). When provided, watcher syncing will take
+    /// place.
     #[structopt(long)]
     pub watcher_db: Option<PathBuf>,
 }

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -69,6 +69,10 @@ pub struct APIConfig {
     /// network directly.
     #[clap(long, env = "MC_VALIDATOR")]
     pub validator: Option<ValidatorUri>,
+
+    /// Path to watcher db (lmdb).
+    #[structopt(long)]
+    pub watcher_db: Option<PathBuf>,
 }
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {

--- a/full-service/src/json_rpc/v1/api/test_utils.rs
+++ b/full-service/src/json_rpc/v1/api/test_utils.rs
@@ -110,6 +110,7 @@ pub fn create_test_setup(
     let service = WalletService::new(
         Some(wallet_db),
         ledger_db.clone(),
+        None,
         peer_manager,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -23,6 +23,7 @@ use crate::{
             tx_proposal::{TxProposal, UnsignedTxProposal},
             txo::Txo,
             wallet_status::WalletStatus,
+            watcher::WatcherBlockInfo,
         },
     },
     service::receipt::ReceiptTransactionStatus,
@@ -119,14 +120,17 @@ pub enum JsonCommandResponse {
     get_block {
         block: Block,
         block_contents: BlockContents,
+        watcher_info: Option<WatcherBlockInfo>,
     },
     get_blocks {
         blocks: Vec<Block>,
         block_contents: Vec<BlockContents>,
+        watcher_infos: Vec<Option<WatcherBlockInfo>>,
     },
     get_recent_blocks {
         blocks: Vec<Block>,
         block_contents: Vec<BlockContents>,
+        watcher_infos: Vec<Option<WatcherBlockInfo>>,
         network_status: NetworkStatus,
     },
     get_confirmations {

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -116,6 +116,7 @@ pub fn create_test_setup(
     let service = WalletService::new(
         wallet_db,
         ledger_db.clone(),
+        None,
         peer_manager,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -43,6 +43,7 @@ use crate::{
         transaction::{TransactionMemo, TransactionService},
         transaction_log::TransactionLogService,
         txo::TxoService,
+        watcher::WatcherService,
         WalletService,
     },
     util::b58::{
@@ -694,9 +695,14 @@ where
                     .map_err(format_error)?,
             };
 
+            let watcher_info = service
+                .get_watcher_block_info(block.index)
+                .map_err(format_error)?;
+
             JsonCommandResponse::get_block {
                 block: Block::new(&block),
                 block_contents: BlockContents::new(&block_contents),
+                watcher_info: watcher_info.as_ref().map(Into::into),
             }
         }
         JsonCommandRequest::get_blocks {
@@ -723,9 +729,22 @@ where
                 })
                 .unzip();
 
+            let watcher_infos = blocks_and_contents
+                .iter()
+                .map(|(block, _contents)| {
+                    service
+                        .get_watcher_block_info(block.index)
+                        .map_err(format_error)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
             JsonCommandResponse::get_blocks {
                 blocks,
                 block_contents,
+                watcher_infos: watcher_infos
+                    .iter()
+                    .map(|info| info.as_ref().map(Into::into))
+                    .collect(),
             }
         }
         JsonCommandRequest::get_recent_blocks { limit } => {
@@ -748,6 +767,15 @@ where
                 })
                 .unzip();
 
+            let watcher_infos = blocks_and_contents
+                .iter()
+                .map(|(block, _contents)| {
+                    service
+                        .get_watcher_block_info(block.index)
+                        .map_err(format_error)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
             let network_status =
                 NetworkStatus::try_from(&service.get_network_status().map_err(format_error)?)
                     .map_err(format_error)?;
@@ -755,6 +783,10 @@ where
             JsonCommandResponse::get_recent_blocks {
                 blocks,
                 block_contents,
+                watcher_infos: watcher_infos
+                    .iter()
+                    .map(|info| info.as_ref().map(Into::into))
+                    .collect(),
                 network_status,
             }
         }

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -684,7 +684,7 @@ mod e2e_misc {
             serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
         assert_eq!(results.len(), 1);
 
-        assert_eq!(results[0].result_type, "TxOut".to_string());
+        assert_eq!(results[0].result_type, "KeyImage".to_string());
         assert_eq!(
             results[0]
                 .watcher_info

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -29,7 +29,6 @@ mod e2e_misc {
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Amount, BlockVersion, Token};
 
-    use mc_watcher_api::TimestampResultCode;
     use rand::{rngs::StdRng, SeedableRng};
     use rocket::http::{Header, Status};
     use serde_json::json;

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -29,6 +29,7 @@ mod e2e_misc {
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Amount, BlockVersion, Token};
 
+    use mc_watcher_api::TimestampResultCode;
     use rand::{rngs::StdRng, SeedableRng};
     use rocket::http::{Header, Status};
     use serde_json::json;
@@ -412,6 +413,45 @@ mod e2e_misc {
     }
 
     #[test_with_logger]
+    fn test_get_recent_blocks_with_watcher(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, _, _, _) = setup_with_watcher(&mut rng, logger.clone());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_recent_blocks",
+            "params": {
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let blocks: Vec<Block> =
+            serde_json::from_value(result.get("blocks").unwrap().clone()).unwrap();
+
+        assert_eq!(blocks.len(), RECENT_BLOCKS_DEFAULT_LIMIT);
+
+        let watcher_infos = result.get("watcher_infos").unwrap().as_array().unwrap();
+        assert_eq!(watcher_infos.len(), blocks.len());
+        for watcher_info in watcher_infos {
+            assert_eq!(
+                watcher_info.get("timestamp_result_code").unwrap(),
+                "TimestampFound"
+            );
+            // create_test_watcher_db generated two signatures
+            assert_eq!(
+                watcher_info
+                    .get("signatures")
+                    .unwrap()
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                2
+            );
+        }
+    }
+
+    #[test_with_logger]
     fn test_get_blocks(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
         let (client, _, _, _) = setup(&mut rng, logger.clone());
@@ -442,6 +482,46 @@ mod e2e_misc {
         assert!(blocks
             .windows(2)
             .all(|w| w[0].index.parse::<u64>().unwrap() == w[1].index.parse::<u64>().unwrap() - 1));
+    }
+
+    #[test_with_logger]
+    fn test_get_blocks_with_watcher(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, _, _, _) = setup_with_watcher(&mut rng, logger.clone());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_blocks",
+            "params": {
+                "first_block_index": "5",
+                "limit": 3,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let blocks: Vec<Block> =
+            serde_json::from_value(result.get("blocks").unwrap().clone()).unwrap();
+        assert_eq!(blocks.len(), 3);
+
+        let watcher_infos = result.get("watcher_infos").unwrap().as_array().unwrap();
+        assert_eq!(watcher_infos.len(), blocks.len());
+        for watcher_info in watcher_infos {
+            assert_eq!(
+                watcher_info.get("timestamp_result_code").unwrap(),
+                "TimestampFound"
+            );
+            // create_test_watcher_db generated two signatures
+            assert_eq!(
+                watcher_info
+                    .get("signatures")
+                    .unwrap()
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                2
+            );
+        }
     }
 
     #[test_with_logger]
@@ -546,6 +626,73 @@ mod e2e_misc {
                 .unwrap()
                 .block_contents_key_image_index,
             "0"
+        );
+    }
+
+    #[test_with_logger]
+    fn test_ledger_search_with_watcher(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+        let (client, ledger_db, _, _) = setup_with_watcher(&mut rng, logger.clone());
+
+        // Search by txo public key
+        let txo = ledger_db.get_tx_out_by_index(5).unwrap();
+        let pub_key_hex = hex::encode(txo.public_key.as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "search_ledger",
+            "params": {
+                "query": pub_key_hex
+            },
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let results: Vec<LedgerSearchResult> =
+            serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
+        assert_eq!(results.len(), 1);
+
+        assert_eq!(results[0].result_type, "TxOut".to_string());
+        assert_eq!(
+            results[0]
+                .watcher_info
+                .as_ref()
+                .unwrap()
+                .timestamp_result_code,
+            "TimestampFound"
+        );
+        // create_test_watcher_db generated two signatures
+        assert_eq!(
+            results[0].watcher_info.as_ref().unwrap().signatures.len(),
+            2
+        );
+
+        // Search by key image
+        let block_contents = ledger_db.get_block_contents(3).unwrap();
+        let key_image_hex = hex::encode(block_contents.key_images[0].as_bytes());
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "search_ledger",
+            "params": {
+                "query": key_image_hex
+            },
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let results: Vec<LedgerSearchResult> =
+            serde_json::from_value(result.get("results").unwrap().clone()).unwrap();
+        assert_eq!(results.len(), 1);
+
+        assert_eq!(results[0].result_type, "TxOut".to_string());
+        assert_eq!(
+            results[0]
+                .watcher_info
+                .as_ref()
+                .unwrap()
+                .timestamp_result_code,
+            "TimestampFound"
         );
     }
 }

--- a/full-service/src/json_rpc/v2/models/block.rs
+++ b/full-service/src/json_rpc/v2/models/block.rs
@@ -68,3 +68,19 @@ impl From<&mc_blockchain_types::BlockContents> for BlockContents {
         Self::new(src)
     }
 }
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct BlockSignature {
+    pub signature: String,
+    pub signer: String,
+    pub signed_at: String,
+}
+impl From<&mc_blockchain_types::BlockSignature> for BlockSignature {
+    fn from(src: &mc_blockchain_types::BlockSignature) -> Self {
+        Self {
+            signature: hex::encode(src.signature()),
+            signer: hex::encode(src.signer()),
+            signed_at: src.signed_at().to_string(),
+        }
+    }
+}

--- a/full-service/src/json_rpc/v2/models/ledger.rs
+++ b/full-service/src/json_rpc/v2/models/ledger.rs
@@ -3,7 +3,10 @@
 //! API definition for ledger-related objects.
 
 use crate::{
-    json_rpc::v2::models::block::{Block, BlockContents},
+    json_rpc::v2::models::{
+        block::{Block, BlockContents},
+        watcher::WatcherBlockInfo,
+    },
     service::models::ledger::LedgerSearchResult as ServiceLedgerSearchResult,
 };
 use serde_derive::{Deserialize, Serialize};
@@ -29,6 +32,7 @@ pub struct LedgerSearchResult {
     pub block_contents: BlockContents,
     pub tx_out: Option<LedgerTxOutSearchResult>,
     pub key_image: Option<LedgerKeyImageSearchResult>,
+    pub watcher_info: Option<WatcherBlockInfo>,
 }
 
 impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
@@ -39,6 +43,7 @@ impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
                 block_contents,
                 block_contents_tx_out_index,
                 tx_out_global_index,
+                watcher_info,
             } => Self {
                 result_type: "TxOut".to_string(),
                 block: block.into(),
@@ -47,12 +52,14 @@ impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
                     block_contents_tx_out_index: block_contents_tx_out_index.to_string(),
                     global_tx_out_index: tx_out_global_index.to_string(),
                 }),
+                watcher_info: watcher_info.as_ref().map(Into::into),
                 ..Default::default()
             },
             ServiceLedgerSearchResult::KeyImage {
                 block,
                 block_contents,
                 block_contents_key_image_index,
+                watcher_info,
             } => Self {
                 result_type: "KeyImage".to_string(),
                 block: block.into(),
@@ -60,6 +67,7 @@ impl From<&ServiceLedgerSearchResult> for LedgerSearchResult {
                 key_image: Some(LedgerKeyImageSearchResult {
                     block_contents_key_image_index: block_contents_key_image_index.to_string(),
                 }),
+                watcher_info: watcher_info.as_ref().map(Into::into),
                 ..Default::default()
             },
         }

--- a/full-service/src/json_rpc/v2/models/mod.rs
+++ b/full-service/src/json_rpc/v2/models/mod.rs
@@ -15,3 +15,4 @@ pub mod transaction_log;
 pub mod tx_proposal;
 pub mod txo;
 pub mod wallet_status;
+pub mod watcher;

--- a/full-service/src/json_rpc/v2/models/watcher.rs
+++ b/full-service/src/json_rpc/v2/models/watcher.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for watcher-related objects.
+
+use super::block::BlockSignature;
+use mc_watcher_api::TimestampResultCode;
+use serde_derive::{Deserialize, Serialize};
+
+/// Information about a single block signature
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct BlockSignatureData {
+    pub src_url: String,
+    pub archive_filename: String,
+    pub block_signature: BlockSignature,
+}
+
+impl From<&mc_watcher::watcher_db::BlockSignatureData> for BlockSignatureData {
+    fn from(src: &mc_watcher::watcher_db::BlockSignatureData) -> Self {
+        Self {
+            src_url: src.src_url.clone(),
+            archive_filename: src.archive_filename.clone(),
+            block_signature: (&src.block_signature).into(),
+        }
+    }
+}
+
+/// Information about a block provided by the Watcher.
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+pub struct WatcherBlockInfo {
+    pub timestamp: String,
+    pub timestamp_result_code: String,
+    pub signatures: Vec<BlockSignatureData>,
+}
+
+impl From<&crate::service::models::watcher::WatcherBlockInfo> for WatcherBlockInfo {
+    fn from(src: &crate::service::models::watcher::WatcherBlockInfo) -> Self {
+        Self {
+            timestamp: src.timestamp.to_string(),
+            timestamp_result_code: match src.timestamp_result_code {
+                TimestampResultCode::TimestampFound => "TimestampFound".to_string(),
+                TimestampResultCode::WatcherBehind => "WatcherBehind".to_string(),
+                TimestampResultCode::Unavailable => "Unavailable".to_string(),
+                TimestampResultCode::WatcherDatabaseError => "WatcherDatabaseError".to_string(),
+                TimestampResultCode::BlockIndexOutOfBounds => "BlockIndexOutOfBounds".to_string(),
+            },
+            signatures: src.signatures.iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/full-service/src/service/mod.rs
+++ b/full-service/src/service/mod.rs
@@ -17,5 +17,6 @@ pub mod transaction_builder;
 pub mod transaction_log;
 pub mod txo;
 mod wallet_service;
+pub mod watcher;
 
 pub use wallet_service::WalletService;

--- a/full-service/src/service/mod.rs
+++ b/full-service/src/service/mod.rs
@@ -16,7 +16,8 @@ pub mod transaction;
 pub mod transaction_builder;
 pub mod transaction_log;
 pub mod txo;
-mod wallet_service;
 pub mod watcher;
+
+mod wallet_service;
 
 pub use wallet_service::WalletService;

--- a/full-service/src/service/models/ledger.rs
+++ b/full-service/src/service/models/ledger.rs
@@ -2,6 +2,7 @@
 
 //! API definition for LedgerService-related objects.
 
+use crate::service::models::watcher::WatcherBlockInfo;
 use mc_blockchain_types::{Block, BlockContents};
 use serde_derive::{Deserialize, Serialize};
 
@@ -21,6 +22,9 @@ pub enum LedgerSearchResult {
 
         /// The global index of the TxOut
         tx_out_global_index: u64,
+
+        /// Watcher info, when available.
+        watcher_info: Option<WatcherBlockInfo>,
     },
 
     /// Query matched a KeyImage
@@ -33,5 +37,8 @@ pub enum LedgerSearchResult {
 
         /// The index of the key image inside the block contents
         block_contents_key_image_index: u64,
+
+        /// Watcher info, when available.
+        watcher_info: Option<WatcherBlockInfo>,
     },
 }

--- a/full-service/src/service/models/mod.rs
+++ b/full-service/src/service/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod ledger;
 pub mod tx_proposal;
+pub mod watcher;

--- a/full-service/src/service/models/watcher.rs
+++ b/full-service/src/service/models/watcher.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! API definition for watcher-related objects.
+
+use mc_watcher::watcher_db::BlockSignatureData;
+use mc_watcher_api::TimestampResultCode;
+
+use serde_derive::{Deserialize, Serialize};
+
+/// Information about a block provided by the Watcher.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WatcherBlockInfo {
+    pub timestamp: u64,
+    pub timestamp_result_code: TimestampResultCode,
+    pub signatures: Vec<BlockSignatureData>,
+}

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -15,6 +15,7 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::LedgerDB;
 use mc_ledger_sync::PollingNetworkState;
 use mc_util_uri::FogUri;
+use mc_watcher::watcher_db::WatcherDB;
 use std::sync::{atomic::AtomicUsize, Arc, RwLock};
 
 /// Service for interacting with the wallet
@@ -31,6 +32,9 @@ pub struct WalletService<
 
     /// Ledger database.
     pub ledger_db: LedgerDB,
+
+    /// Watcher database.
+    pub watcher_db: Option<WatcherDB>,
 
     /// Peer manager for consensus validators to query for network height.
     pub peer_manager: McConnectionManager<T>,
@@ -65,6 +69,7 @@ impl<
     pub fn new(
         wallet_db: Option<WalletDb>,
         ledger_db: LedgerDB,
+        watcher_db: Option<WatcherDB>,
         peer_manager: McConnectionManager<T>,
         network_state: Arc<RwLock<PollingNetworkState<T>>>,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
@@ -86,6 +91,7 @@ impl<
         WalletService {
             wallet_db,
             ledger_db,
+            watcher_db,
             peer_manager,
             network_state,
             fog_resolver_factory,

--- a/full-service/src/service/watcher.rs
+++ b/full-service/src/service/watcher.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2020-2021 MobileCoin Inc.
+
+//! Service for accessing the watcher database.
+use crate::{service::models::watcher::WatcherBlockInfo, WalletService};
+use displaydoc::Display;
+use mc_connection::{BlockchainConnection, UserTxConnection};
+use mc_fog_report_validation::FogPubkeyResolver;
+use mc_watcher::error::WatcherDBError;
+
+/// Errors for the Watcher Service.
+#[derive(Display, Debug)]
+pub enum WatcherServiceError {
+    /// Error interacting with watcher database: {0}
+    WatcherDb(WatcherDBError),
+}
+
+impl From<WatcherDBError> for WatcherServiceError {
+    fn from(src: WatcherDBError) -> Self {
+        Self::WatcherDb(src)
+    }
+}
+
+/// Trait defining the ways in which the service can interact with the watcher.
+pub trait WatcherService {
+    fn get_watcher_block_info(
+        &self,
+        block_index: u64,
+    ) -> Result<Option<WatcherBlockInfo>, WatcherServiceError>;
+}
+
+impl<T, FPR> WatcherService for WalletService<T, FPR>
+where
+    T: BlockchainConnection + UserTxConnection + 'static,
+    FPR: FogPubkeyResolver + Send + Sync + 'static,
+{
+    fn get_watcher_block_info(
+        &self,
+        block_index: u64,
+    ) -> Result<Option<WatcherBlockInfo>, WatcherServiceError> {
+        match &self.watcher_db {
+            Some(watcher_db) => {
+                let (timestamp, timestamp_result_code) =
+                    watcher_db.get_block_timestamp(block_index)?;
+                let signatures = watcher_db.get_block_signatures(block_index)?;
+
+                Ok(Some(WatcherBlockInfo {
+                    timestamp,
+                    timestamp_result_code,
+                    signatures,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -584,6 +584,7 @@ fn setup_wallet_service_impl(
     WalletService::new(
         wallet_db,
         ledger_db,
+        None,
         peer_manager,
         network_state,
         get_resolver_factory(&mut rng).unwrap(),


### PR DESCRIPTION
### Motivation

This information is needed by the new block explorer, and might also be useful for other users who want access to timestamps and block signatures.

### In this PR
Adding an optional syncing of a `WatcherDB` and exposing the data provided by it, when available, via the V2 API

### Test Plan
I tested this manually. Example response looks like this:
```
...
       "watcher_info": {
          "timestamp": "1673991888",
          "timestamp_result_code": "TimestampFound",
          "signatures": [
            {
              "src_url": "https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/",
              "archive_filename": "00/00/00/00/00/14/e6/000000000014e648.pb",
              "block_signature": {
                "signature": "31e7de448588e62dca608bde40b0e4d63f091385c420ef5734a27307c523b9a13aa9fabe78dd5f3efe9aed790351ed7a063e1e601c944ff626cb8f1e1bfca20f",
                "signer": "93fde5c0ae8941df2b58d9831afe823a8861b8d3e3974af5ba4c75b891d3ac75",
                "signed_at": "1673991888"
              }
            },
            {
              "src_url": "https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/",
              "archive_filename": "00/00/00/00/00/14/e6/000000000014e648.pb",
              "block_signature": {
                "signature": "5434a4c2ae810a11f43d7a15cfe04c94c34663c02f18597313e892bc4c01ca5f2b606ff9ba835e1b4eb34f49c4db64438ab1232e8a60dbc7048460a1f373bb00",
                "signer": "dcb477362fc975a1d0a86cb8ee9d82963d7b3a3e0abba606f15cd2aae786c288",
                "signed_at": "1673991888"
              }
            }
          ]
        }
      }
...
```
