### PR TITLE
updating logger to cancel resetting when falling out of scope

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -56,7 +56,11 @@ async fn main() -> Result<(), rocket::Error> {
         exit(EXIT_INVALID_HOST);
     }
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
+    let (logger, global_logger_guard) = create_app_logger(o!());
+
+    // This is necessary to prevent the logger from being reset when it goes out of
+    // scope so that rocket can use it in its own async context
+    global_logger_guard.cancel_reset();
 
     let wallet_db = match config.wallet_db {
         Some(ref wallet_db_path_buf) => {

--- a/mirror/src/public/main.rs
+++ b/mirror/src/public/main.rs
@@ -239,7 +239,12 @@ fn rocket() -> _ {
     //     panic!("Refusing to start with self-signed TLS certificate. Use
     // --allow-self-signed-tls to override this check."); }
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
+    let (logger, global_logger_guard) = create_app_logger(o!());
+
+    // This is necessary to prevent the logger from being reset when it goes out of
+    // scope so that rocket can use it in its own async context
+    global_logger_guard.cancel_reset();
+
     log::info!(
         logger,
         "Starting wallet service mirror public forwarder, listening for mirror requests on {} and client requests on {}",


### PR DESCRIPTION
This fixes a shutdown error that was caused by slog global logger being reset after dropping out of scope while still being used by rocket in an sync context