### PR TITLE
Brian/updating rocket setup

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -56,7 +56,11 @@ async fn main() -> Result<(), rocket::Error> {
         exit(EXIT_INVALID_HOST);
     }
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
+    let (logger, global_logger_guard) = create_app_logger(o!());
+
+    // This is necessary to prevent the logger from being reset when it goes out of
+    // scope so that rocket can use it in its own async context
+    global_logger_guard.cancel_reset();
 
     let wallet_db = match config.wallet_db {
         Some(ref wallet_db_path_buf) => {

--- a/full-service/src/json_rpc/wallet.rs
+++ b/full-service/src/json_rpc/wallet.rs
@@ -140,38 +140,28 @@ async fn validator_backed_wallet_api_v2(
 }
 
 /// Returns an instance of a Rocket server.
-pub fn consensus_backed_rocket(
-    rocket_config: rocket::Config,
-    state: WalletState<ThickClient<HardcodedCredentialsProvider>, FogResolver>,
-) -> rocket::Rocket<rocket::Build> {
-    rocket::custom(rocket_config)
-        .mount(
-            "/",
-            routes![
-                consensus_backed_wallet_api_v1,
-                consensus_backed_wallet_api_v2,
-                wallet_help_v1,
-                wallet_help_v2,
-                health
-            ],
-        )
-        .manage(state)
+pub fn consensus_backed_rocket(rocket_config: rocket::Config) -> rocket::Rocket<rocket::Build> {
+    rocket::custom(rocket_config).mount(
+        "/",
+        routes![
+            consensus_backed_wallet_api_v1,
+            consensus_backed_wallet_api_v2,
+            wallet_help_v1,
+            wallet_help_v2,
+            health
+        ],
+    )
 }
 
-pub fn validator_backed_rocket(
-    rocket_config: rocket::Config,
-    state: WalletState<ValidatorConnection, FogResolver>,
-) -> rocket::Rocket<rocket::Build> {
-    rocket::custom(rocket_config)
-        .mount(
-            "/",
-            routes![
-                validator_backed_wallet_api_v1,
-                validator_backed_wallet_api_v2,
-                wallet_help_v1,
-                wallet_help_v2,
-                health
-            ],
-        )
-        .manage(state)
+pub fn validator_backed_rocket(rocket_config: rocket::Config) -> rocket::Rocket<rocket::Build> {
+    rocket::custom(rocket_config).mount(
+        "/",
+        routes![
+            validator_backed_wallet_api_v1,
+            validator_backed_wallet_api_v2,
+            wallet_help_v1,
+            wallet_help_v2,
+            health
+        ],
+    )
 }

--- a/mirror/src/public/main.rs
+++ b/mirror/src/public/main.rs
@@ -239,7 +239,7 @@ fn rocket() -> Rocket<Build> {
 
     let query_manager = QueryManager::default();
 
-    start_grpc_server(config.clone(), query_manager.clone(), logger.clone());
+    start_grpc_server(&config, &query_manager, &logger);
 
     build_rocket(config, query_manager, logger)
 }
@@ -247,44 +247,43 @@ fn rocket() -> Rocket<Build> {
 /// Starts the GRPC server in its own thread. This is necessary because the GRPC
 /// server does not implement Sync, which is a requirement to be managed by
 /// Rocket OR pass over an async await block.
-fn start_grpc_server(config: Config, query_manager: QueryManager, logger: Logger) {
-    rocket::tokio::spawn(async move {
-        log::info!(
+fn start_grpc_server(config: &Config, query_manager: &QueryManager, logger: &Logger) {
+    log::info!(
             logger.clone(),
             "Starting wallet service mirror public forwarder, listening for mirror requests on {} and client requests on {}",
             config.mirror_listen_uri.addr(),
             config.client_listen_uri.addr(),
         );
 
-        // Start the mirror-facing GRPC server.
-        log::info!(logger.clone(), "Starting mirror GRPC server");
+    // Start the mirror-facing GRPC server.
+    log::info!(logger.clone(), "Starting mirror GRPC server");
 
-        let build_info_service = BuildInfoService::new(logger.clone()).into_service();
-        let health_service = HealthService::new(None, logger.clone()).into_service();
-        let mirror_service =
-            MirrorService::new(query_manager.clone(), logger.clone()).into_service();
+    let build_info_service = BuildInfoService::new(logger.clone()).into_service();
+    let health_service = HealthService::new(None, logger.clone()).into_service();
+    let mirror_service = MirrorService::new(query_manager.clone(), logger.clone()).into_service();
 
-        let env = Arc::new(
-            EnvBuilder::new()
-                .name_prefix("Mirror-RPC".to_string())
-                .build(),
-        );
+    let env = Arc::new(
+        EnvBuilder::new()
+            .name_prefix("Mirror-RPC".to_string())
+            .build(),
+    );
 
-        let ch_builder = ChannelBuilder::new(env.clone())
-            .max_receive_message_len(-1)
-            .max_send_message_len(-1);
+    let ch_builder = ChannelBuilder::new(env.clone())
+        .max_receive_message_len(-1)
+        .max_send_message_len(-1);
 
-        let server_builder = ServerBuilder::new(env)
-            .register_service(build_info_service)
-            .register_service(health_service)
-            .register_service(mirror_service)
-            .channel_args(ch_builder.build_args())
-            .bind_using_uri(&config.mirror_listen_uri, logger.clone());
+    let server_builder = ServerBuilder::new(env)
+        .register_service(build_info_service)
+        .register_service(health_service)
+        .register_service(mirror_service)
+        .channel_args(ch_builder.build_args())
+        .bind_using_uri(&config.mirror_listen_uri, logger.clone());
 
-        let mut server = server_builder
-            .build()
-            .expect("Failed to build mirror GRPC server");
+    let mut server = server_builder
+        .build()
+        .expect("Failed to build mirror GRPC server");
 
+    rocket::tokio::spawn(async move {
         server.start();
 
         loop {

--- a/mirror/src/public/main.rs
+++ b/mirror/src/public/main.rs
@@ -239,7 +239,12 @@ fn rocket() -> _ {
     //     panic!("Refusing to start with self-signed TLS certificate. Use
     // --allow-self-signed-tls to override this check."); }
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
+    let (logger, global_logger_guard) = create_app_logger(o!());
+
+    // This is necessary to prevent the logger from being reset when it goes out of
+    // scope so that rocket can use it in its own async context
+    global_logger_guard.cancel_reset();
+
     log::info!(
         logger,
         "Starting wallet service mirror public forwarder, listening for mirror requests on {} and client requests on {}",

--- a/mirror/src/public/main.rs
+++ b/mirror/src/public/main.rs
@@ -33,7 +33,7 @@ use rocket::{
     response::Responder,
     routes,
     tokio::io::AsyncReadExt,
-    Data, Request, Response,
+    Build, Data, Request, Response, Rocket,
 };
 use structopt::StructOpt;
 
@@ -228,7 +228,7 @@ async fn encrypted_request(
 }
 
 #[launch]
-fn rocket() -> _ {
+fn rocket() -> Rocket<Build> {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
 


### PR DESCRIPTION
Refactoring the mirror service public main function to use rocket::main instead of rocket::launch, which allows the grpcio::Server to remain in scope until the exiting of the program
