### PR TITLE
adding index to assigned subaddress on subaddress index

### DIFF
--- a/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/down.sql
+++ b/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/down.sql
@@ -1,1 +1,1 @@
-DROP INDEX idx_assigned_subaddresses__subaddress_index;
+DROP INDEX idx_assigned_subaddresses__subaddress_index_account_id;

--- a/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/down.sql
+++ b/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_assigned_subaddresses__subaddress_index;

--- a/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/up.sql
+++ b/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/up.sql
@@ -1,1 +1,1 @@
-CREATE UNIQUE INDEX idx_assigned_subaddresses__subaddress_index ON assigned_subaddresses (subaddress_index);
+CREATE UNIQUE INDEX idx_assigned_subaddresses__subaddress_index_account_id ON assigned_subaddresses (account_id, subaddress_index);

--- a/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/up.sql
+++ b/full-service/migrations/2023-02-15-225147_add_index_to_subaddress_index/up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_assigned_subaddresses__subaddress_index ON assigned_subaddresses (subaddress_index);


### PR DESCRIPTION
an alternate solution to the assign next subaddress slowdown as the number of subaddresses increases for an account. For more info, see #712 