### PR TITLE
updating branches from develop->main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,11 @@ env:
 on:
   pull_request:
     branches:
-      - develop
       - main
       - release/*
   push:
     branches:
       - main
-      - develop
       - release/*
 
 concurrency:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -13,7 +13,7 @@ env:
 on:
   pull_request:
     branches:
-      - develop
+      - main
   push:
     branches:
       - feature/*


### PR DESCRIPTION
Since the [gitbook docs](https://mobilecoin.gitbook.io/full-service-api/) are attached to the `main` branch but we had been using `develop` as our primary branch (and not really using `main`), the easiest thing to do was just to rename `develop` to `main`