### PR TITLE
removing mac builds - only for v2.3 series

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ env:
 on:
   push:
     tags:
-      - 'v*-pre.*'
-      - '*.dev-build.*'
+      - "v*-pre.*"
+      - "*.dev-build.*"
 
 jobs:
   build-and-pre-release:
@@ -20,13 +20,9 @@ jobs:
       contents: write
     strategy:
       matrix:
-        runner-tags: [[self-hosted, macOS, X64, cargo], [self-hosted, macOS, ARM64, cargo], [self-hosted, Linux, large]]
+        runner-tags: [[self-hosted, Linux, large]]
         namespace: [test, prod]
         include:
-          - runner-tags: [self-hosted, macOS, X64, cargo]
-            container: ""
-          - runner-tags: [self-hosted, macOS, ARM64, cargo]
-            container: ""
           - runner-tags: [self-hosted, Linux, large]
             container: mobilecoin/rust-sgx-base:latest
           - namespace: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
-      - '!v*-pre*'
+      - "v*"
+      - "!v*-pre*"
 
 jobs:
   release:
@@ -32,10 +32,6 @@ jobs:
           files: |
             ${{ steps.current_release.outputs.tag_name }}-Linux-X64-testnet.tar.gz
             ${{ steps.current_release.outputs.tag_name }}-Linux-X64-mainnet.tar.gz
-            ${{ steps.current_release.outputs.tag_name }}-macOS-X64-testnet.tar.gz
-            ${{ steps.current_release.outputs.tag_name }}-macOS-X64-mainnet.tar.gz
-            ${{ steps.current_release.outputs.tag_name }}-macOS-ARM64-testnet.tar.gz
-            ${{ steps.current_release.outputs.tag_name }}-macOS-ARM64-mainnet.tar.gz
           target: /var/tmp/
 
       - name: Extract Release
@@ -43,16 +39,8 @@ jobs:
           rm -rfv build_artifacts
           mkdir -pv build_artifacts/Linux-X64-testnet
           mkdir -pv build_artifacts/Linux-X64-mainnet
-          mkdir -pv build_artifacts/macOS-X64-testnet
-          mkdir -pv build_artifacts/macOS-X64-mainnet
-          mkdir -pv build_artifacts/macOS-ARM64-testnet
-          mkdir -pv build_artifacts/macOS-ARM64-mainnet
           tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-Linux-X64-testnet.tar.gz -C build_artifacts/Linux-X64-testnet
           tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-Linux-X64-mainnet.tar.gz -C build_artifacts/Linux-X64-mainnet
-          tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-macOS-X64-testnet.tar.gz -C build_artifacts/macOS-X64-testnet
-          tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-macOS-X64-mainnet.tar.gz -C build_artifacts/macOS-X64-mainnet
-          tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-macOS-ARM64-testnet.tar.gz -C build_artifacts/macOS-ARM64-testnet
-          tar xzvf /var/tmp/${{ steps.current_release.outputs.tag_name }}-macOS-ARM64-mainnet.tar.gz -C build_artifacts/macOS-ARM64-mainnet
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -61,10 +49,6 @@ jobs:
           cd release
           tar -czvf ${{ github.ref_name }}-Linux-X64-testnet.tar.gz -C ../build_artifacts/Linux-X64-testnet/ .
           tar -czvf ${{ github.ref_name }}-Linux-X64-mainnet.tar.gz -C ../build_artifacts/Linux-X64-mainnet/ .
-          tar -czvf ${{ github.ref_name }}-macOS-X64-testnet.tar.gz -C ../build_artifacts/macOS-X64-testnet/ .
-          tar -czvf ${{ github.ref_name }}-macOS-X64-mainnet.tar.gz -C ../build_artifacts/macOS-X64-mainnet/ .
-          tar -czvf ${{ github.ref_name }}-macOS-ARM64-testnet.tar.gz -C ../build_artifacts/macOS-ARM64-testnet/ .
-          tar -czvf ${{ github.ref_name }}-macOS-ARM64-mainnet.tar.gz -C ../build_artifacts/macOS-ARM64-mainnet/ .
 
       - name: Upload Release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
This is to allow CI to run smoothly for the 2.3 series, which is not working on mac at the moment. This has been resolved in 2.4, so this PR should not be merged back in.