### PR TITLE
removing inaccurate requirement

### DIFF
--- a/docs/v1/api-endpoints/verify_address.md
+++ b/docs/v1/api-endpoints/verify_address.md
@@ -8,7 +8,7 @@ description: Verify whether an address is correctly b58-encoded.
 
 | Required Param | Purpose | Requirements |
 | :--- | :--- | :--- |
-| `address` | The address on which to perform this action. | Address must be assigned for an account in the wallet. |
+| `address` | The address on which to perform this action. |  |
 
 ## Example
 

--- a/docs/v2/api-endpoints/verify_address.md
+++ b/docs/v2/api-endpoints/verify_address.md
@@ -8,7 +8,7 @@ description: Verify whether an address is correctly b58-encoded.
 
 | Required Param | Purpose | Requirements |
 | :--- | :--- | :--- |
-| `address` | The address on which to perform this action. | Address must be assigned for an account in the wallet. |
+| `address` | The address on which to perform this action. |  |
 
 ## [Response](../../../full-service/src/json_rpc/v2/api/response.rs#L41)
 


### PR DESCRIPTION
Address does not need to be part of wallet to be validated

### Motivation
The docs are inaccurate in that the address to be verified doesn't actually need to be under an account within FS - it's just a B58 verifier. 
