### PR TITLE
Feature/update dockerfiles include all binaries

### DIFF
--- a/.internal-ci/docker/Dockerfile.full-service
+++ b/.internal-ci/docker/Dockerfile.full-service
@@ -22,12 +22,12 @@ RUN  apt-get update \
   && ln -s /etc/ssl/certs/ca-certificates.crt /usr/share/grpc/roots.pem
 
 ARG RUST_BIN_PATH=target/release
-COPY ${RUST_BIN_PATH}/full-service /usr/local/bin/full-service
-COPY ${RUST_BIN_PATH}/transaction-signer /usr/local/bin/full-service
-COPY ${RUST_BIN_PATH}/validator-service /usr/local/bin/full-service
-COPY ${RUST_BIN_PATH}/wallet-service-mirror-private /usr/local/bin/full-service
-COPY ${RUST_BIN_PATH}/wallet-service-mirror-public /usr/local/bin/full-service
-COPY ${RUST_BIN_PATH}/generate-rsa-keypair /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/full-service /usr/local/bin/
+COPY ${RUST_BIN_PATH}/transaction-signer /usr/local/bin/
+COPY ${RUST_BIN_PATH}/validator-service /usr/local/bin/
+COPY ${RUST_BIN_PATH}/wallet-service-mirror-private /usr/local/bin/
+COPY ${RUST_BIN_PATH}/wallet-service-mirror-public /usr/local/bin/
+COPY ${RUST_BIN_PATH}/generate-rsa-keypair /usr/local/bin/
 COPY ${RUST_BIN_PATH}/*.css /usr/local/bin/
 COPY .internal-ci/docker/entrypoints/full-service.sh /usr/local/bin/entrypoint.sh
 

--- a/.internal-ci/docker/Dockerfile.full-service
+++ b/.internal-ci/docker/Dockerfile.full-service
@@ -23,6 +23,11 @@ RUN  apt-get update \
 
 ARG RUST_BIN_PATH=target/release
 COPY ${RUST_BIN_PATH}/full-service /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/transaction-signer /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/validator-service /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/wallet-service-mirror-private /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/wallet-service-mirror-public /usr/local/bin/full-service
+COPY ${RUST_BIN_PATH}/generate-rsa-keypair /usr/local/bin/full-service
 COPY ${RUST_BIN_PATH}/*.css /usr/local/bin/
 COPY .internal-ci/docker/entrypoints/full-service.sh /usr/local/bin/entrypoint.sh
 

--- a/.internal-ci/docker/Dockerfile.full-service-with-build
+++ b/.internal-ci/docker/Dockerfile.full-service-with-build
@@ -52,7 +52,7 @@ COPY . /app/
 ARG BUILD_OPTS
 ARG SGX_MODE=HW
 ARG IAS_MODE=PROD
-ARG RUSTFLAGS='-C target-cpu=penryn'
+ARG RUSTFLAGS
 
 # Build full-service
 RUN  --mount=type=cache,target=/opt/cargo/git \

--- a/.internal-ci/docker/Dockerfile.full-service-with-build
+++ b/.internal-ci/docker/Dockerfile.full-service-with-build
@@ -59,8 +59,14 @@ RUN  --mount=type=cache,target=/opt/cargo/git \
      --mount=type=cache,target=/opt/cargo/registry/index \
      --mount=type=cache,target=/opt/cargo/registry/cache \
      --mount=type=cache,target=/app/target \
-     cargo build --locked --release -p mc-full-service ${BUILD_OPTS} \
-  && cp /app/target/release/full-service /usr/local/bin/full-service
+     cargo build --locked --release ${BUILD_OPTS}
+
+RUN cp /app/target/release/full-service /usr/local/bin/
+RUN cp /app/target/release/transaction-signer /usr/local/bin/
+RUN cp /app/target/release/validator-service /usr/local/bin/
+RUN cp /app/target/release/wallet-service-mirror-private /usr/local/bin/
+RUN cp /app/target/release/wallet-service-mirror-public /usr/local/bin/
+RUN cp /app/target/release/generate-rsa-keypair /usr/local/bin/
 
 # This is the runtime container.
 # Adding/updating OS will not affect the ability to verify the build environment.
@@ -80,7 +86,12 @@ RUN  apt-get update \
   && mkdir -p /usr/share/grpc \
   && ln -s /etc/ssl/certs/ca-certificates.crt /usr/share/grpc/roots.pem
 
-COPY --from=builder /usr/local/bin/full-service /usr/local/bin/full-service
+COPY --from=builder /usr/local/bin/full-service /usr/local/bin/
+COPY --from=builder /usr/local/bin/transaction-signer /usr/local/bin/
+COPY --from=builder /usr/local/bin/validator-service /usr/local/bin/
+COPY --from=builder /usr/local/bin/wallet-service-mirror-private /usr/local/bin/
+COPY --from=builder /usr/local/bin/wallet-service-mirror-public /usr/local/bin/
+COPY --from=builder /usr/local/bin/generate-rsa-keypair /usr/local/bin/
 COPY --from=builder /app/*.css /usr/local/bin/
 COPY .internal-ci/docker/entrypoints/full-service.sh /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
### Motivation

* Update Dockerfiles to include all binaries (mirror, validator, etc) to make testing more cluster-based
* Remove penryn restriction in the `Dockerfile.full-service-with-build` to match `build.yaml` and thus released binaries

### In this PR

* Updates to both Dockerfiles (copying all binaries into the containers)
* Remove penryn cpu target in `Dockerfile.full-service-with-build`

### Test Plan

* Haven't run tests, other than what is run with the existing workflows

### Future Work

* Update workflows to make use of actual release binaries?
  * Instead of redoing the same work which is effectively NOT using the release binaries
* Update workflows to deploy validator system, mirror system