### PR TITLE
Implement payment requests for all token types.

### DIFF
--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -421,6 +421,7 @@ where
                             .map_err(format_error)?;
                     b58_data.insert("public_address_b58".to_string(), public_address_b58);
                     b58_data.insert("value".to_string(), payment_request.value.to_string());
+                    b58_data.insert("token_id".to_string(), payment_request.token_id.to_string());
                     b58_data.insert("memo".to_string(), payment_request.memo);
                 }
             }

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -749,7 +749,10 @@ mod e2e_misc {
         assert_eq!(b58_type, "PaymentRequest");
         assert_eq!(value, "42000000000000");
         assert_eq!(token_id, "0");
-        assert_eq!(public_address_b58, account_obj.get("main_address").unwrap().as_str().unwrap());
+        assert_eq!(
+            public_address_b58,
+            account_obj.get("main_address").unwrap().as_str().unwrap()
+        );
         assert_eq!(memo, "");
     }
 }

--- a/full-service/src/util/b58/tests.rs
+++ b/full-service/src/util/b58/tests.rs
@@ -98,6 +98,7 @@ mod tests {
 
         assert_eq!(decoded.public_address, public_address);
         assert_eq!(decoded.value, 1_000_000_000_000);
+        assert_eq!(decoded.token_id, Mob::ID);
         assert_eq!(decoded.memo, "This is a memo".to_string());
     }
 

--- a/python/mobilecoin/client.py
+++ b/python/mobilecoin/client.py
@@ -290,6 +290,12 @@ class ClientAsync:
         })
         return r['transaction_log'], r['tx_proposal']
 
+    async def check_b58_type(self, b58_code):
+        return await self._req({
+            "method": "check_b58_type",
+            "params": {"b58_code": b58_code},
+        })
+
     # Polling utility functions.
 
     @staticmethod

--- a/python/mobilecoin/client.py
+++ b/python/mobilecoin/client.py
@@ -290,6 +290,20 @@ class ClientAsync:
         })
         return r['transaction_log'], r['tx_proposal']
 
+    async def create_payment_request(self, account_id, amount, memo=None):
+        r = await self._req({
+            "method": "create_payment_request",
+            "params": {
+                "account_id": account_id,
+                "amount": {
+                    "value": str(amount.value),
+                    "token_id": str(amount.token.token_id)
+                },
+                "memo": memo,
+            }
+        })
+        return r['payment_request_b58']
+
     async def check_b58_type(self, b58_code):
         return await self._req({
             "method": "check_b58_type",


### PR DESCRIPTION
- Add token-id to payment request results from check_b58_type.
- Implement payment requests in Python API and CLI.
