### PR TITLE
2.3 - fix: Add validator-service to mirror testing setup

### DIFF
--- a/mirror/test/start.sh
+++ b/mirror/test/start.sh
@@ -52,7 +52,6 @@ check_pid_file()
     fi
 }
 
-
 test_dir=/tmp/mirror_test
 git_base=$(git rev-parse --show-toplevel)
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"${git_base}/target/docker"}
@@ -89,8 +88,8 @@ then
     then
         echo "full-service is already running"
     else
-        echo "- Starting full-service"
-        exec "${git_base}"/tools/run-fs.sh "${network}" >./full-service.log 2>&1 &
+        echo "- Starting full-service with validator-service"
+        exec "${git_base}"/tools/run-fs.sh --validator "${network}" >./full-service.log 2>&1 &
         echo $! >.full-service.pid
     fi
 else

--- a/mirror/test/stop.sh
+++ b/mirror/test/stop.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 killall full-service
+killall validator-service
 killall wallet-service-mirror-private
 killall wallet-service-mirror-public

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -2,8 +2,6 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 # Set of shared functions for full-service build, test and run tools.
 
-
-
 # debug - echo a debug message
 #  1: message
 debug()
@@ -43,4 +41,19 @@ get_css_file()
 
     debug "  css file saved ${css_file}"
     echo "${css_file}"
+}
+
+# 1: pid file to check
+check_pid_file()
+{
+    if [[ -f "${1}" ]]
+    then
+        pid=$(cat "${1}")
+        if ps -p "${pid}" > /dev/null
+        then
+            echo "running"
+        else
+            echo "not running"
+        fi
+    fi
 }


### PR DESCRIPTION
### Motivation

Run manual testing of full-service + mirror + validator-service.

### In this PR

* Add `--validator` option to `run-fs.sh` script to configure full-service and start the validator-service .

### Test Plan

```
# build full-service project binaries.
tools/build-fs test

# start fs/validator/mirror services with mirror test scripts.
cd mirror/test
./start.sh --network test

# Since full-service relies on validator-service for its view of the MC network, the 
# start script will report ready before validator-service has finished loading all of its blocks.
# Watch validator-service log (/tmp/validator-service.log) for block download status.

# Run mirror test script with funded wallet mnemonic.
./test.sh --mnemonic '<24 words>'

# Stop services when test complete
./stop.sh
```

### Future Work

* When using the validator-service, full-service only knows about the blocks validator-service has loaded. So monitoring `get_wallet_status` to wait for full-service to be ready doesn't really work. 
* The shell scripts I'm using to start and monitor the services are getting clunky.  We should consider something like `supervisord` to manage the processes for local testing.
* Watching `get_account_status`, `next_block_index` vs `local_block_height` on a new account import doesn't seem to be an accurate indicator of the background account indexing. The values match before the account is ready and we get  `Error building transaction: Wallet DB Error: No unspent Txos in the wallet` when attempting `build_and_submit_transaction`.   A retry after full-service returns the CPU to idle is successful.

