### PR TITLE
v2.3 - fix: set chain-id to main for main|prod network

### DIFF
--- a/tools/run-fs.sh
+++ b/tools/run-fs.sh
@@ -89,12 +89,10 @@ case "${net}" in
 
         ;;
     prod|main)
-        # CBB: we should replicate the "prod" css bucket to "main", then we can
-        #      get rid of this workaround.
-        if [[ "${net}" == "main" ]]
+        if [[ "${net}" == "prod" ]]
         then
-            echo "Detected \"main\" network, setting css urls to use \"prod\""
-            net="prod"
+            echo "Detected \"prod\" legacy network setting. Using \"main\" instead."
+            net=main
         fi
 
         domain_name="prod.mobilecoinww.com"

--- a/tools/run-fs.sh
+++ b/tools/run-fs.sh
@@ -59,6 +59,13 @@ fi
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${location}/.shared-functions.sh"
 
+# use main instead of legacy prod
+if [[ "${net}" == "prod" ]]
+then
+    echo "Detected \"prod\" legacy network setting. Using \"main\" instead."
+    net=main
+fi
+
 # Setup workdir
 WORK_DIR="${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}"
 mkdir -p "${WORK_DIR}"
@@ -86,15 +93,8 @@ case "${net}" in
             MC_TX_SOURCE_URL="${tx_source_base}/node1.${domain_name}/,${tx_source_base}/node2.${domain_name}/"
             MC_FOG_INGEST_ENCLAVE_CSS=$(get_css_file "test" "${WORK_DIR}/ingest-enclave.css")
         fi
-
         ;;
-    prod|main)
-        if [[ "${net}" == "prod" ]]
-        then
-            echo "Detected \"prod\" legacy network setting. Using \"main\" instead."
-            net=main
-        fi
-
+    main)
         domain_name="prod.mobilecoinww.com"
         tx_source_base="https://ledger.mobilecoinww.com"
 
@@ -106,7 +106,7 @@ case "${net}" in
             MC_TX_SOURCE_URL="${tx_source_base}/node1.${domain_name}/,${tx_source_base}/node2.${domain_name}/"
             MC_FOG_INGEST_ENCLAVE_CSS=$(get_css_file "prod" "${WORK_DIR}/ingest-enclave.css")
         fi
-    ;;
+        ;;
     alpha)
         echo "alpha network doesn't yet publish enclave css measurements, manually download or copy ${WORK_DIR}/ingest-enclave.css"
 
@@ -121,7 +121,7 @@ case "${net}" in
             MC_TX_SOURCE_URL="${tx_source_base}/node1.${domain_name}/,${tx_source_base}/node2.${domain_name}/"
         fi
         MC_FOG_INGEST_ENCLAVE_CSS="${WORK_DIR}/ingest-enclave.css"
-    ;;
+        ;;
     local)
         # Set chain id, peer and tx_sources for 2 nodes.
         MC_CHAIN_ID="${net}"
@@ -131,11 +131,11 @@ case "${net}" in
             MC_TX_SOURCE_URL="http://localhost:4566/node-0-ledger/,http://localhost:4566/node-1-ledger/"
         fi
         MC_FOG_INGEST_ENCLAVE_CSS="${WORK_DIR}/ingest-enclave.css"
-    ;;
+        ;;
     *)
         echo "Using current environment's SGX, IAS and enclave values"
         echo "Set MC_CHAIN_ID, MC_PEER, MC_TX_SOURCE_URL MC_FOG_INGEST_ENCLAVE_CSS as appropriate"
-    ;;
+        ;;
 esac
 
 echo "Setting '${net}' environment values"


### PR DESCRIPTION
### Motivation

Small change in tools/run-fs.sh helper script to fix the chain-id logic when running on `main` or the legacy `prod` networks.

### Test Plan

```
# build fs for main network
tools/build-fs.sh main

# start fs with run-fs.sh helper script with main or prod networks
tools/run-fs.sh prod

OR

tools/run-fs.sh main

# watch for blocks to start downloading
```


