### PR TITLE
Add v1 api mirror tests

### DIFF
--- a/mirror/test/test.sh
+++ b/mirror/test/test.sh
@@ -48,7 +48,7 @@ declare -a MethodList=("assign_address_for_account" "build_and_submit_transactio
 for method in "${MethodList[@]}"; do
     echo "${method}"
 
-    response=$(node mirror-client.js --public-mirror-url http://127.0.0.1:9091 --key-file /tmp/mirror_test/mirror-client.pem --request "{\"method\": \"${method}\", \"params\": {}, \"jsonrpc\": \"2.0\", \"id\": 1}" 2>/dev/null)
+    response=$(node mirror-client.js --public-mirror-url http://127.0.0.1:9092 --key-file /tmp/mirror_test/mirror-client.pem --request "{\"method\": \"${method}\", \"params\": {}, \"jsonrpc\": \"2.0\", \"id\": 1}" 2>/dev/null)
 
     if ! [[ "$response" =~ 'Http error, status: 400: Unsupported request' ]]
     then
@@ -61,15 +61,26 @@ done
 
 echo "Unsupported methods [ PASS ]"
 
-echo "Running mirror-test.sh - supported methods"
+echo "Running v2 mirror-test.js - supported methods"
 
-if node mirror-test.js --public-mirror-url http://127.0.0.1:9091 \
+if node mirror-test.js --public-mirror-url http://127.0.0.1:9092 \
     --full-service-url http://127.0.0.1:9090 \
     --key-file /tmp/mirror_test/mirror-client.pem \
     --mnemonic "${mnemonic}"
 then
-    echo "Supported methods [ PASS ]"
+    echo "v2 Supported methods [ PASS ]"
 else
-    echo "Supported methods [ FAIL ]"
+    echo "v2 Supported methods [ FAIL ]"
+    exit 1
+fi
+
+echo "Running v1 v1/test_suite/test_script.js"
+pushd ./v1/test_suite > /dev/null || exit 1
+
+if node test_script.js 127.0.0.1 9091 127.0.0.1 9090 /tmp/mirror_test/mirror-client.pem "${mnemonic}"
+then
+    echo "v1 Supported methods [ PASS ]"
+else
+    echo "v1 Supported methods [ FAIL ]"
     exit 1
 fi

--- a/mirror/test/v1/test_lib/package.json
+++ b/mirror/test/v1/test_lib/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test_lib",
+  "version": "1.0.0",
+  "description": "",
+  "main": "send-request-encrypted.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Mobile Coin",
+  "license": "MIT"
+}

--- a/mirror/test/v1/test_lib/send-request-encrypted.js
+++ b/mirror/test/v1/test_lib/send-request-encrypted.js
@@ -1,0 +1,167 @@
+// Minimum supported NodeJS version: v12.9.0
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+if (NODE_MAJOR_VERSION < 12) {
+    throw new Error('Requires Node 12 (or higher)');
+}
+
+// Imports
+const http = require('http');
+const fs = require('fs');
+const crypto = require('crypto');
+const KEY_SIZE = 512;
+
+
+function sendRequestPromise(params, postData, processSuccessfulResponse) {
+    return new Promise(function(resolve, reject) {
+        var req = http.request(params, (response) => {
+            // cumulate data
+            var buf = [];
+            var result;
+            response.on('data', function(chunk) {
+                buf.push(chunk);
+            });
+            // resolve on end
+            response.on('end', function() {
+                if (response.statusCode == 200) {
+                try {
+                    result = processSuccessfulResponse(buf);
+                } catch(error) {
+                    reject(`Failed to process a successful request: ${error}`);
+                }
+                resolve(result);
+                } else {
+                    reject (`Http error, status: ${response.statusCode}: ${buf}`);
+                }
+            });
+            //reject on response error
+            response.on('error', (error) => {
+                reject(`Error reading response: ${error}`);
+            });
+
+        });
+        // reject on request error
+        req.on('error', function(error) {
+            reject(`Error sending request: ${error}`);
+        });
+        req.write(postData);
+        req.end();
+    });
+}
+
+
+
+function sendRequest(host, port, key_file, request) {
+    return sendRequestEncrypted(host, port, "/encrypted-request", key_file, request);
+}
+
+
+function sendRequestEncrypted(host, port, path, key_file, msg) {
+    // Load key
+    let key_bytes = fs.readFileSync(key_file)
+    if (!key_bytes) {
+        throw 'Failed loading key';
+    }
+    let key = crypto.createPublicKey(key_bytes);
+    if (!key) {
+        throw 'Failed creating key';
+    }
+
+
+    // Ensure the key is 4096 bits (outputs 512-byte chunks).
+    let test_data = encrypt(key, [1, 2, 3]);
+    if (test_data.length != KEY_SIZE) {
+        throw `Key is not 4096-bit, encrypted output chunk size returned was ${test_data.length}`;
+    }
+
+    // Prepare request
+    let encrypted_msg = encrypt(key, msg);
+
+    // Send request to server
+    let params = {
+        host: host,
+        port: port,
+        timeout: 120000,
+        path: path,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': Buffer.byteLength(encrypted_msg)
+        }
+    };
+    let processSuccessfulResponse = (buf) => {
+        let result = decrypt(key, Buffer.concat(buf)).toString();
+        const resultJSON = JSON.parse(result);
+        console.log(JSON.stringify(resultJSON, null, 4));
+        return result;
+    };
+    return sendRequestPromise(params, encrypted_msg, processSuccessfulResponse);
+}
+
+function sendRequestUnencrypted(host, port, path, msg) {
+    // Send request to server
+    let params = {
+        host: host,
+        port: port,
+        timeout: 120000,
+        path: path,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(msg)
+        }
+    };
+    let processSuccessfulResponse = (buf) => {
+            let result = Buffer.concat(buf).toString();
+            const resultJSON = JSON.parse(result);
+            console.log(JSON.stringify(resultJSON, null, 4));
+            return result;
+        };
+    return sendRequestPromise(params, msg, processSuccessfulResponse);
+}
+
+
+
+// Crypto utilities
+function encrypt(key, buf) {
+    let res = [];
+
+    // Each encrypted chunk must be no longer than the length of the public modulus minus padding size.
+    // PKCS1 is 11 bytes of padding (which is also defined as PKCS1_PADDING_LEN in the rust code).
+    const MAX_CHUNK_SIZE = KEY_SIZE - 11;
+
+    while (buf.length > 0) {
+        let data = buf.slice(0, MAX_CHUNK_SIZE);
+        buf = buf.slice(data.length);
+
+        res.push(crypto.publicEncrypt({
+            key: key,
+            padding: crypto.constants.RSA_PKCS1_PADDING,
+        }, Buffer.from(data)));
+    }
+
+    return Buffer.concat(res)
+}
+
+function decrypt(key, buf) {
+    let res = [];
+
+    while (buf.length > 0) {
+        let data = buf.slice(0, KEY_SIZE);
+        buf = buf.slice(data.length);
+
+        res.push(crypto.publicDecrypt({
+            key,
+            padding: crypto.constants.RSA_PKCS1_PADDING,
+        }, Buffer.from(data)));
+    }
+
+    return Buffer.concat(res)
+}
+
+function sign(buf) {
+    return crypto.sign(null, Buffer.from(buf), { key, passphrase: '' })
+}
+
+exports.sendRequest = sendRequest;
+exports.sendRequestUnencrypted = sendRequestUnencrypted;
+exports.sendRequestEncrypted = sendRequestEncrypted;

--- a/mirror/test/v1/test_suite/package.json
+++ b/mirror/test/v1/test_suite/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test_suite",
+  "version": "1.0.0",
+  "description": "run tests for lvn",
+  "main": "test_script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "test_lib": "file:../test_lib"
+  }
+}

--- a/mirror/test/v1/test_suite/test_script.js
+++ b/mirror/test/v1/test_suite/test_script.js
@@ -1,0 +1,450 @@
+// Minimum supported NodeJS version: v12.9.0
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+if (NODE_MAJOR_VERSION < 12) {
+    throw new Error('Requires Node 12 (or higher)');
+}
+
+// Imports
+const client = require('../test_lib/send-request-encrypted');
+const full_service_path = "/wallet";
+const public_mirror_path = "/encrypted-request";
+const wait_time_ms = 10000;
+const fields = ["method", "params", "jsonrpc", "id", "block_index", "mnemonic", "key_derivation_version", "name", "account_id", "recipient_public_address", "value_pmob", "offset", "limit", "subaddress_index", "memo", "amount_pmob", "address", "transaction_log_id", "txo_id", "confirmation"];
+
+function getFuncName() {
+    return getFuncName.caller.name
+}
+const timer = (ms) => new Promise((res) => setTimeout(res, ms));
+async function runAllTests(public_mirror_host, public_mirror_port, full_service_host, full_service_port, key_file, mnemonic) {
+    try {
+        await testGetBlock(public_mirror_host, public_mirror_port, key_file);
+        // let accountJSON = await testImportAccount(full_service_host, full_service_port, mnemonic);
+        const accountJSON = await getFirstAccount(public_mirror_host, public_mirror_port, key_file);
+        let accountInfo = JSON.parse(accountJSON);
+        let accountId = accountInfo["result"]["account"]["account_id"];
+        let mainAddress = accountInfo["result"]["account"]["main_address"];
+        console.log(`account_id: ${accountId}, main_address: ${mainAddress}`);
+        let balanceJSON = await waitForBalanceToBeSynced(public_mirror_host, public_mirror_port, key_file, accountId);
+        let balanceInfo = JSON.parse(balanceJSON);
+        localBlockHeight = balanceInfo["result"]["balance"]["local_block_height"];
+        accountBlockHeight = balanceInfo["result"]["balance"]["account_block_height"];
+        console.log(balanceJSON);
+
+        let transactionJSON = await testBuildAndSubmitTransaction(full_service_host, full_service_port, accountId, mainAddress, "1");
+        let transactionInfo = JSON.parse(transactionJSON);
+        let transactionLogId = transactionInfo["result"]["transaction_log"]["transaction_log_id"];
+        let transactionBlockIndex = transactionInfo["result"]["transaction_log"]["submitted_block_index"];
+        let outputTxoHex = transactionInfo["result"]["transaction_log"]["output_txos"][0]["txo_id_hex"];
+        console.log(`transactionLogId: ${transactionLogId}`);
+        console.log(`transaction block: ${transactionBlockIndex}`);
+        console.log(`outputTxo: ${outputTxoHex}`);
+        let addresses = await testGetAddressesForAccount(public_mirror_host, public_mirror_port, key_file, accountId);
+        let accountStatus = await testGetAccountStatus(public_mirror_host, public_mirror_port, key_file, accountId);
+        let paymentRequest = await testCreatePaymentRequest(public_mirror_host, public_mirror_port, key_file, accountId, 1, 1);
+        let balance = await testGetBalanceForAddress(public_mirror_host, public_mirror_port, key_file, mainAddress);
+        let addressVerification = await testVerifyAddress(public_mirror_host, public_mirror_port, key_file, mainAddress);
+        let walletStatus = await testWalletStatus(public_mirror_host, public_mirror_port, key_file);
+        let networkStatus = await testNetworkStatus(public_mirror_host, public_mirror_port, key_file);
+        let transactionLogs = await testGetTransactionLogsForBlock(public_mirror_host, public_mirror_port, key_file, transactionBlockIndex);
+        transactionLogs = await testGetTransactionLogsForAccount(public_mirror_host, public_mirror_port, key_file, accountId, "1", "1");
+        transactionLogs = await waitForTransactionToBeSynced(public_mirror_host, public_mirror_port, key_file, transactionLogId);
+        let confirmationJSON = await testGetConfirmations(public_mirror_host, public_mirror_port, key_file, transactionLogId);
+        let confirmationInfo = JSON.parse(confirmationJSON);
+        console.log(`confirmationJson: ${confirmationJSON}`);
+        let confirmation = confirmationInfo["result"]["confirmations"][0]["confirmation"];
+        console.log(`confirmation: ${confirmation}`);
+        let validation = await testValidateConfirmations(public_mirror_host, public_mirror_port, key_file, accountId, outputTxoHex, confirmation);;
+
+    }
+    catch (error) {
+        console.error(`Test failed: ${error}`);
+        throw "Failed";
+    }
+}
+
+
+async function getAccounts (public_mirror_host, public_mirror_port, key_file) {
+    const request = {
+      method: 'get_all_accounts',
+      jsonrpc: '2.0',
+      id: 1
+    }
+    const requestString = JSON.stringify(request, null)
+    console.log(JSON.stringify({ request }, null, 4))
+    return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString)
+  }
+
+async function getFirstAccount (public_mirror_host, public_mirror_port, key_file) {
+    const accountsJSON = await getAccounts(public_mirror_host, public_mirror_port, key_file)
+    // Get first account
+    const accounts = JSON.parse(accountsJSON)
+    const first = accounts.result.account_ids[0]
+    const accountMap = accounts.result.account_map
+
+    // fake an import_account response
+    return JSON.stringify({
+      method: 'import_account',
+      result: {
+        account: accountMap[first]
+      },
+      jsonrpc: '2.0',
+      id: 1
+    })
+  }
+
+
+async function testImportAccount(full_service_host, full_service_port, mnemonic) {
+    try {
+        let request = {
+            method: "import_account",
+            params: {
+                mnemonic: mnemonic,
+                key_derivation_version: "2",
+                name: "Bob"
+            },
+            jsonrpc: "2.0",
+            id: 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequestUnencrypted(full_service_host, full_service_port, full_service_path, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testBuildAndSubmitTransaction(full_service_host, full_service_port, account_id, recipient_address, value_pmob) {
+    try {
+        let request = {
+            "method": "build_and_submit_transaction",
+            "params": {
+                "account_id": account_id,
+                "recipient_public_address": recipient_address,
+                "value_pmob": value_pmob
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequestUnencrypted(full_service_host, full_service_port, full_service_path, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+
+
+async function testGetBlock(public_mirror_host, public_mirror_port, key_file) {
+    try {
+        let request = {
+            method: "get_block",
+            params: {
+                block_index: "0"
+            },
+            jsonrpc: "2.0",
+            id: 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testGetBalanceForAccount(public_mirror_host, public_mirror_port, key_file, account_id) {
+    try {
+        let request = {
+            "method": "get_balance_for_account",
+            "params": {
+                "account_id": account_id
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function waitForBalanceToBeSynced(public_mirror_host, public_mirror_port, key_file, account_id) {
+    let balanceJSON = await testGetBalanceForAccount(public_mirror_host, public_mirror_port, key_file, account_id);
+    let balanceInfo = JSON.parse(balanceJSON);
+    let balance_synced = balanceInfo["result"]["balance"]["is_synced"];
+    while (!balance_synced) {
+        await timer(wait_time_ms);
+        balanceJSON = await testGetBalanceForAccount(public_mirror_host, public_mirror_port, key_file, account_id);
+        balanceInfo = JSON.parse(balanceJSON);
+        balance_synced = balanceInfo["result"]["balance"]["is_synced"];
+    }
+    return balanceJSON;
+}
+async function testGetAddressesForAccount(public_mirror_host, public_mirror_port, key_file, account_id) {
+    try {
+        let request = {
+            "method": "get_addresses_for_account",
+            "params": {
+                "account_id": account_id,
+                "offset": "1",
+                "limit": "1000"
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testGetAccountStatus(public_mirror_host, public_mirror_port, key_file, account_id) {
+    try {
+        let request = {
+            "method": "get_account_status",
+            "params": {
+                "account_id": account_id
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testCreatePaymentRequest(public_mirror_host, public_mirror_port, key_file, account_id, amount_pmob, subaddress_index) {
+    try {
+        let request = {
+            "method": "create_payment_request",
+            "params": {
+                "account_id": account_id,
+                "amount_pmob": amount_pmob,
+                "subaddress_index": subaddress_index,
+                "memo": "testCreatePaymentRequest"
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testGetBalanceForAddress(public_mirror_host, public_mirror_port, key_file, address) {
+    try {
+        let request = {
+            "method": "get_balance_for_address",
+            "params": {
+                "address": address
+            },
+            "jsonrpc": "2.0",
+            "api_version": "2",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testVerifyAddress(public_mirror_host, public_mirror_port, key_file, address) {
+    try {
+        let request = {
+            "method": "verify_address",
+            "params": {
+                "address": address
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+
+async function testWalletStatus(public_mirror_host, public_mirror_port, key_file) {
+    try {
+        let request = {
+            "method": "get_wallet_status",
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+
+async function testNetworkStatus(public_mirror_host, public_mirror_port, key_file) {
+    try {
+        let request = {
+            "method": "get_network_status",
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testGetTransactionLogsForBlock(public_mirror_host, public_mirror_port, key_file, block_index) {
+    try {
+        let request = {
+            "method": "get_all_transaction_logs_for_block",
+            "params": {
+                "block_index": block_index
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+
+async function testGetTransactionLogsForAccount(public_mirror_host, public_mirror_port, key_file, account_id, offset, limit) {
+    try {
+        let request = {
+            "method": "get_transaction_logs_for_account",
+            "params": {
+                "account_id": account_id,
+                "offset": offset,
+                "limit": limit
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+
+async function testGetTransactionLogsById(public_mirror_host, public_mirror_port, key_file, transaction_log_id) {
+    try {
+        let request = {
+            "method": "get_transaction_log",
+            "params": {
+                "transaction_log_id": transaction_log_id
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function waitForTransactionToBeSynced(public_mirror_host, public_mirror_port, key_file, transaction_log_id) {
+    let transactionLogsJSON = await testGetTransactionLogsById(public_mirror_host, public_mirror_port, key_file, transaction_log_id);
+    let transactionInfo = JSON.parse(transactionLogsJSON);
+    let transaction_status = transactionInfo["result"]["transaction_log"]["status"];
+    while (transaction_status === "tx_status_pending") {
+        await timer(wait_time_ms);
+        transactionLogsJSON = await testGetTransactionLogsById(public_mirror_host, public_mirror_port, key_file, transaction_log_id);
+        transactionInfo = JSON.parse(transactionLogsJSON);
+        transaction_status = transactionInfo["result"]["transaction_log"]["status"];
+    }
+    return transactionLogsJSON;
+}
+async function testGetConfirmations(public_mirror_host, public_mirror_port, key_file, transaction_log_id) {
+    try {
+        let request = {
+            "method": "get_confirmations",
+            "params": {
+                "transaction_log_id": transaction_log_id
+            },
+            "jsonrpc": "2.0",
+            "id": 1
+        };
+
+        let requestString = JSON.stringify(request, fields, 4);
+        console.log(requestString);
+        return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+    }
+    catch (error) {
+        throw `Error in ${getFuncName()}: ${error}`;
+    }
+}
+async function testValidateConfirmations(public_mirror_host, public_mirror_port, key_file, account_id, txo_id, confirmation) {
+    for (let i = 0; i < 3; i++) {
+        try {
+            let request = {
+                "method": "validate_confirmation",
+                "params": {
+                    "account_id": account_id,
+                    "txo_id": txo_id,
+                    "confirmation": confirmation
+                },
+                "jsonrpc": "2.0",
+                "id": 1
+            };
+            let requestString = JSON.stringify(request, fields, 4);
+            console.log(requestString);
+            return await client.sendRequest(public_mirror_host, public_mirror_port, key_file, requestString);
+        }
+        catch (error) {
+            if (i >= 3) {
+                throw `Error in ${getFuncName()}: ${error}`;
+            }
+            await timer(wait_time_ms);
+        }
+    }
+}
+console.log("Starting test script")
+// Command line parsing
+if (process.argv.length != 8) {
+    console.log(`Usage: node test_script.js <public mirror host> <public mirror port> <full_service_host> <full_service_port> <key file> <mnemonic>`);
+    console.log(`For example: node test_script.js 127.0.0.1 9091 127.0.0.1 5554 mirror-client.pem '<mnemonic>'`);
+    console.log('To generate keys please run the generate-rsa-keypair binary. See README.md for more details')
+    throw "invalid arguments";
+}
+
+let public_mirror_host = process.argv[2];
+let public_mirror_port = process.argv[3];
+let full_service_host = process.argv[4];
+let full_service_port = process.argv[5];
+let key_file = process.argv[6];
+let mnemonic = process.argv[7];
+
+
+runAllTests(public_mirror_host, public_mirror_port, full_service_host, full_service_port, key_file, mnemonic).then(result => {
+    console.log("Run all tests succeeded");
+}).catch((error) => {
+    console.log("Run all tests had an error: " + error)
+});

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -2,6 +2,28 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 # Set of shared functions for full-service build, test and run tools.
 
+# shellcheck disable=SC2034  # Allow unused vars in this shared file.
+
+GIT_BASE=$(git rev-parse --show-toplevel)
+AM_I_IN_MOB_PROMPT="no"
+CARGO_TARGET_DIR="${GIT_BASE}/target/${net}"
+
+# Assume that if you're git directory is /tmp/mobilenode that we're in mob prompt
+if [[ "${GIT_BASE}" == "/tmp/mobilenode" ]]
+then
+    AM_I_IN_MOB_PROMPT="yes"
+fi
+
+if [[ "${AM_I_IN_MOB_PROMPT}" == "yes" ]]
+then
+    echo "I'm in mob prompt!"
+    WORK_DIR="${WORK_DIR:-"${GIT_BASE}/.mob/${net}"}"
+    LISTEN_ADDR="0.0.0.0"
+else
+    WORK_DIR="${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}"
+    LISTEN_ADDR="127.0.0.1"
+fi
+
 # debug - echo a debug message
 #  1: message
 debug()

--- a/tools/build-fs.sh
+++ b/tools/build-fs.sh
@@ -58,8 +58,7 @@ fi
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${location}/.shared-functions.sh"
 
-# Setup workdir
-WORK_DIR="${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}"
+# Setup workdir - set in .shared-functions.sh
 mkdir -p "${WORK_DIR}"
 
 case ${net} in

--- a/tools/run-fs.sh
+++ b/tools/run-fs.sh
@@ -58,11 +58,6 @@ then
     exit 1
 fi
 
-# Grab current location and source the shared functions.
-# shellcheck source=.shared-functions.sh
-location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${location}/.shared-functions.sh"
-
 # use main instead of legacy prod
 if [[ "${net}" == "prod" ]]
 then
@@ -70,8 +65,12 @@ then
     net=main
 fi
 
-# Setup workdir
-WORK_DIR="${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}"
+# Grab current location and source the shared functions.
+# shellcheck source=.shared-functions.sh
+location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${location}/.shared-functions.sh"
+
+# Setup workdir - set in .shared-functions.sh
 mkdir -p "${WORK_DIR}"
 
 # Set default database directories
@@ -83,6 +82,7 @@ mkdir -p "${LEDGER_DB_DIR}"
 # Set vars for all networks
 MC_WALLET_DB="${WALLET_DB_DIR}/wallet.db"
 MC_LEDGER_DB="${LEDGER_DB_DIR}"
+MC_LISTEN_HOST="${LISTEN_ADDR}"
 
 case "${net}" in
     test)
@@ -144,7 +144,7 @@ esac
 
 echo "Setting '${net}' environment values"
 
-export MC_CHAIN_ID MC_PEER MC_TX_SOURCE_URL MC_FOG_INGEST_ENCLAVE_CSS MC_WALLET_DB MC_LEDGER_DB
+export MC_CHAIN_ID MC_PEER MC_TX_SOURCE_URL MC_FOG_INGEST_ENCLAVE_CSS MC_WALLET_DB MC_LEDGER_DB MC_LISTEN_HOST
 
 echo "  MC_CHAIN_ID: ${MC_CHAIN_ID}"
 if [[ -z "${offline}" ]]
@@ -157,6 +157,7 @@ fi
 echo "  MC_FOG_INGEST_ENCLAVE_CSS: ${MC_FOG_INGEST_ENCLAVE_CSS}"
 echo "  MC_WALLET_DB: ${MC_WALLET_DB}"
 echo "  MC_LEDGER_DB: ${MC_LEDGER_DB}"
+echo "  MC_LISTEN_HOST: ${MC_LISTEN_HOST}"
 
 
 # Optionally call build-fs.sh to build the current version.
@@ -181,7 +182,7 @@ then
         # Override
         "${target_dir}/release/validator-service" \
             --ledger-db "${validator_ledger_db}" \
-            --listen-uri "insecure-validator://127.0.0.1:10001/" \
+            --listen-uri "insecure-validator://127.0.0.1:11000/" \
             >/tmp/validator-service.log 2>&1 &
 
         echo $! >/tmp/.validator-service.pid
@@ -189,7 +190,7 @@ then
         sleep 30
     fi
 
-    export MC_VALIDATOR="insecure-validator://127.0.0.1:10001/"
+    export MC_VALIDATOR="insecure-validator://127.0.0.1:11000/"
     unset MC_TX_SOURCE_URL
     unset MC_PEER
 fi


### PR DESCRIPTION
### Motivation

Primary: Add v1 API mirror tests.

Secondary: 
- Improve helper scripts to launch v1 and v2 copies of mirror. Listening of ports 9091 and 9092 respectively.
- Separate target directories for main vs test cargo builds. 
- Detect `mob prompt` container and allow full-service and public mirror endpoint "publish" and use storage for ledger/wallet db's that will be persistent (.mob directory)

### Test Plan

```
# test builds
tools/build-fs.sh main

# start mirror services
cd mirror/test
./start.sh --network main

# run v1 and v2 mirror tests
./test.sh --mnemonic "<24 words>"
```

