### PR TITLE
Feature/update validator latest block info

### DIFF
--- a/validator/service/src/blockchain_api.rs
+++ b/validator/service/src/blockchain_api.rs
@@ -57,11 +57,6 @@ impl<BC: BlockchainConnection + 'static> BlockchainApi<BC> {
         &self,
         logger: &Logger,
     ) -> Result<LastBlockInfoResponse, RpcStatus> {
-        let latest_local_block = self
-            .ledger_db
-            .get_latest_block()
-            .map_err(|err| rpc_database_err(err, logger))?;
-
         // Get the last block information from all nodes we are aware of, in parallel.
         let last_block_infos = self
             .conn_manager

--- a/validator/service/src/blockchain_api.rs
+++ b/validator/service/src/blockchain_api.rs
@@ -8,9 +8,9 @@ use mc_connection::{
     BlockchainConnection, ConnectionManager, RetryableBlockchainConnection,
     _retry::delay::Fibonacci,
 };
-use mc_ledger_db::{Ledger, LedgerDB};
+use mc_ledger_db::LedgerDB;
 use mc_transaction_core::{tokens::Mob, Token};
-use mc_util_grpc::{rpc_database_err, rpc_logger, rpc_precondition_error, send_result};
+use mc_util_grpc::{rpc_logger, rpc_precondition_error, send_result};
 use mc_validator_api::{
     consensus_common::{BlocksRequest, BlocksResponse, LastBlockInfoResponse},
     consensus_common_grpc::{create_blockchain_api, BlockchainApi as GrpcBlockchainApi},


### PR DESCRIPTION
### Motivation

We want full service to be able to see the network block height while running with a validator service

### In this PR
* LastBlockInfoResponse is now returning the info from the latest network block
* Latest network block is now an n/n required quorum set for all of the nodes that you are communicating with

### Test Plan

Run full service and validator service and from full service, call "network_status" and it should return the current network block height for the targeted chain


### Future Work
* Update full service and validator service to allow for a specified quorum set requirement, such as n-1/n, instead of only enforcing full agreement from all nodes.

