### PR TITLE
Augment get_network_status with more information

### DIFF
--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -204,7 +204,7 @@ fn consensus_backed_full_service(
         ledger_db,
         watcher_db,
         peer_manager,
-        Some(APIConfig.peers_config.clone()),
+        Some(config.peers_config.clone()),
         network_state,
         config.get_fog_resolver_factory(logger.clone()),
         config.offline,
@@ -280,7 +280,7 @@ fn validator_backed_full_service(
         ledger_db,
         None,
         conn_manager,
-        Some(APIConfig.peers_config.clone()),
+        Some(config.peers_config.clone()),
         network_state,
         Arc::new(move |fog_uris| -> Result<FogResolver, String> {
             if fog_uris.is_empty() {

--- a/full-service/src/bin/main.rs
+++ b/full-service/src/bin/main.rs
@@ -13,7 +13,7 @@ use mc_consensus_scp::QuorumSet;
 use mc_fog_report_resolver::FogResolver;
 use mc_full_service::{
     check_host,
-    config::{APIConfig, NetworkSetupConfig},
+    config::{APIConfig, NetworkConfig},
     wallet::{consensus_backed_rocket, validator_backed_rocket, APIKeyState, WalletState},
     ValidatorLedgerSyncThread, WalletDb, WalletService,
 };
@@ -212,7 +212,7 @@ fn consensus_backed_full_service(
         ),
     };
 
-    let network_setup_config = NetworkSetupConfig {
+    let network_setup_config = NetworkConfig {
         offline: config.offline.clone(),
         chain_id,
         peers,
@@ -308,7 +308,7 @@ fn validator_backed_full_service(
         ),
     };
 
-    let network_setup_config = NetworkSetupConfig {
+    let network_setup_config = NetworkConfig {
         offline: config.offline.clone(),
         chain_id,
         peers,

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -190,7 +190,7 @@ pub struct PeersConfig {
 /// The Network Setup object.
 /// This holds a copy of the network parameters used to start full-service
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
-pub struct NetworkSetupConfig {
+pub struct NetworkConfig {
     pub offline: bool,
     pub chain_id: String,
     pub peers: Option<Vec<String>>,

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -19,6 +19,7 @@ use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
 use mc_validator_api::ValidatorUri;
 
 use clap::Parser;
+use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
     fs,
@@ -184,6 +185,16 @@ pub struct PeersConfig {
     /// Chain Id
     #[clap(default_value = "", long, env = "MC_CHAIN_ID")]
     pub chain_id: String,
+}
+
+/// The Network Setup object.
+/// This holds a copy of the network parameters used to start full-service
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
+pub struct NetworkSetupConfig {
+    pub offline: bool,
+    pub chain_id: String,
+    pub peers: Option<Vec<String>>,
+    pub tx_sources: Option<Vec<String>>,
 }
 
 impl PeersConfig {

--- a/full-service/src/json_rpc/v1/api/test_utils.rs
+++ b/full-service/src/json_rpc/v1/api/test_utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
 use crate::{
+    config::NetworkSetupConfig,
     json_rpc::{
         json_rpc_request::JsonRPCRequest,
         json_rpc_response::JsonRPCResponse,
@@ -107,12 +108,19 @@ pub fn create_test_setup(
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
+    let network_setup_config = NetworkSetupConfig {
+        offline: false,
+        chain_id: "rust_tests".to_string(),
+        peers: None,
+        tx_sources: None,
+    };
+
     let service = WalletService::new(
         Some(wallet_db),
         ledger_db.clone(),
         None,
         peer_manager,
-        None,
+        network_setup_config,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),
         false,

--- a/full-service/src/json_rpc/v1/api/test_utils.rs
+++ b/full-service/src/json_rpc/v1/api/test_utils.rs
@@ -112,6 +112,7 @@ pub fn create_test_setup(
         ledger_db.clone(),
         None,
         peer_manager,
+        None,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),
         false,

--- a/full-service/src/json_rpc/v1/api/test_utils.rs
+++ b/full-service/src/json_rpc/v1/api/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
 use crate::{
-    config::NetworkSetupConfig,
+    config::NetworkConfig,
     json_rpc::{
         json_rpc_request::JsonRPCRequest,
         json_rpc_response::JsonRPCResponse,
@@ -108,7 +108,7 @@ pub fn create_test_setup(
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), false);
 
-    let network_setup_config = NetworkSetupConfig {
+    let network_setup_config = NetworkConfig {
         offline: false,
         chain_id: "rust_tests".to_string(),
         peers: None,

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
 use crate::{
+    config::NetworkSetupConfig,
     json_rpc::{
         json_rpc_request::JsonRPCRequest,
         json_rpc_response::JsonRPCResponse,
@@ -165,12 +166,19 @@ pub fn create_test_setup(
         None
     };
 
+    let network_setup_config = NetworkSetupConfig {
+        offline: false,
+        chain_id: "rust_tests".to_string(),
+        peers: None,
+        tx_sources: None,
+    };
+
     let service = WalletService::new(
         wallet_db,
         ledger_db.clone(),
         watcher_db,
         peer_manager,
-        None,
+        network_setup_config,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),
         false,

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -170,6 +170,7 @@ pub fn create_test_setup(
         ledger_db.clone(),
         watcher_db,
         peer_manager,
+        None,
         network_state.clone(),
         get_resolver_factory(&mut rng).unwrap(),
         false,

--- a/full-service/src/json_rpc/v2/api/test_utils.rs
+++ b/full-service/src/json_rpc/v2/api/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 
 use crate::{
-    config::NetworkSetupConfig,
+    config::NetworkConfig,
     json_rpc::{
         json_rpc_request::JsonRPCRequest,
         json_rpc_response::JsonRPCResponse,
@@ -166,7 +166,7 @@ pub fn create_test_setup(
         None
     };
 
-    let network_setup_config = NetworkSetupConfig {
+    let network_setup_config = NetworkConfig {
         offline: false,
         chain_id: "rust_tests".to_string(),
         peers: None,

--- a/full-service/src/json_rpc/v2/models/network_status.rs
+++ b/full-service/src/json_rpc/v2/models/network_status.rs
@@ -2,7 +2,7 @@
 
 //! API definition for the Network Status object.
 
-use crate::{config::NetworkSetupConfig, service};
+use crate::{config::NetworkConfig, service};
 
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom};
@@ -26,7 +26,7 @@ pub struct NetworkStatus {
     pub block_version: String,
 
     /// How we're connecting to the network
-    pub network_info: NetworkSetupConfig,
+    pub network_info: NetworkConfig,
 }
 
 impl TryFrom<&service::balance::NetworkStatus> for NetworkStatus {

--- a/full-service/src/json_rpc/v2/models/network_status.rs
+++ b/full-service/src/json_rpc/v2/models/network_status.rs
@@ -2,9 +2,8 @@
 
 //! API definition for the Network Status object.
 
-use crate::service;
+use crate::{config::NetworkSetupConfig, service};
 
-use crate::service::balance::NetworkSetupConfig;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom};
 

--- a/full-service/src/json_rpc/v2/models/network_status.rs
+++ b/full-service/src/json_rpc/v2/models/network_status.rs
@@ -4,6 +4,7 @@
 
 use crate::service;
 
+use crate::service::balance::NetworkSetupConfig;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom};
 
@@ -24,6 +25,9 @@ pub struct NetworkStatus {
 
     /// The current block version
     pub block_version: String,
+
+    /// How we're connecting to the network
+    pub network_info: NetworkSetupConfig,
 }
 
 impl TryFrom<&service::balance::NetworkStatus> for NetworkStatus {
@@ -40,6 +44,7 @@ impl TryFrom<&service::balance::NetworkStatus> for NetworkStatus {
                 .map(|(token_id, fee)| (token_id.to_string(), fee.to_string()))
                 .collect(),
             block_version: src.block_version.to_string(),
+            network_info: src.network_info.clone(),
         })
     }
 }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -4,7 +4,7 @@
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use crate::{
-    config::NetworkSetupConfig,
+    config::NetworkConfig,
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
@@ -125,7 +125,7 @@ pub struct NetworkStatus {
     pub local_num_txos: u64,
     pub fees: FeeMap,
     pub block_version: u32,
-    pub network_info: NetworkSetupConfig,
+    pub network_info: NetworkConfig,
 }
 
 /// The Wallet Status object returned by balance services.

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use crate::{
+    config::NetworkSetupConfig,
     db::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
@@ -25,7 +26,6 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{tokens::Mob, FeeMap, FeeMapError, Token, TokenId};
 use mc_util_uri::ConnectionUri;
-use serde::{Deserialize, Serialize};
 
 /// Errors for the Address Service.
 #[derive(Display, Debug)]
@@ -116,16 +116,6 @@ impl Default for &Balance {
             orphaned: 0,
         }
     }
-}
-
-/// The Network Setup object.
-/// This holds a copy of the network parameters used to start full-service
-#[derive(Default, Clone, Debug, Deserialize, Serialize)]
-pub struct NetworkSetupConfig {
-    pub offline: bool,
-    pub chain_id: String,
-    pub peers: Option<Vec<String>>,
-    pub tx_sources: Option<Vec<String>>,
 }
 
 /// The Network Status object.

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -24,6 +24,7 @@ use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{tokens::Mob, FeeMap, FeeMapError, Token, TokenId};
+use serde::{Deserialize, Serialize};
 
 /// Errors for the Address Service.
 #[derive(Display, Debug)]
@@ -116,6 +117,16 @@ impl Default for &Balance {
     }
 }
 
+/// The Network Setup object.
+/// This holds a copy of the network parameters used to start full-service
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
+pub struct NetworkSetupConfig {
+    pub offline: bool,
+    //pub chainId : String,
+    //pub peers : Vec<String>,
+    //pub txSources: Vec<String>,
+}
+
 /// The Network Status object.
 /// This holds the number of blocks in the ledger, on the network and locally.
 pub struct NetworkStatus {
@@ -124,6 +135,7 @@ pub struct NetworkStatus {
     pub local_num_txos: u64,
     pub fees: FeeMap,
     pub block_version: u32,
+    pub network_info: NetworkSetupConfig,
 }
 
 /// The Wallet Status object returned by balance services.
@@ -250,12 +262,17 @@ where
             }
         };
 
+        let network_info = NetworkSetupConfig {
+            offline: self.offline,
+        };
+
         Ok(NetworkStatus {
             network_block_height,
             local_block_height: self.ledger_db.num_blocks()?,
             local_num_txos: self.ledger_db.num_txos()?,
             fees: fee_map,
             block_version,
+            network_info,
         })
     }
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -278,7 +278,7 @@ where
             local_num_txos: self.ledger_db.num_txos()?,
             fees: fee_map,
             block_version,
-            network_info,
+            network_info: self.network_setup_config.clone(),
         })
     }
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -25,7 +25,6 @@ use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{tokens::Mob, FeeMap, FeeMapError, Token, TokenId};
-use mc_util_uri::ConnectionUri;
 
 /// Errors for the Address Service.
 #[derive(Display, Debug)]
@@ -251,25 +250,6 @@ where
                     network_block_info.network_block_version,
                 )
             }
-        };
-
-        let peers: Option<Vec<String>> = match &self.peers_config {
-            None => None,
-            Some(peers_config) => match &peers_config.peers {
-                None => None,
-                Some(peers) => Some(
-                    peers
-                        .iter()
-                        .map(|peer_uri| peer_uri.url().clone().into())
-                        .collect(),
-                ),
-            },
-        };
-        let network_info = NetworkSetupConfig {
-            offline: self.offline,
-            chain_id: self.peers_config.clone().unwrap().chain_id,
-            peers,
-            tx_sources: self.peers_config.clone().unwrap().tx_source_urls,
         };
 
         Ok(NetworkStatus {

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -3,7 +3,7 @@
 //! The Wallet Service for interacting with the wallet.
 
 use crate::{
-    config::NetworkSetupConfig,
+    config::NetworkConfig,
     db::{Conn, WalletDb, WalletDbError},
     service::sync::SyncThread,
 };
@@ -41,7 +41,7 @@ pub struct WalletService<
     pub peer_manager: McConnectionManager<T>,
 
     /// Peer network information
-    pub network_setup_config: NetworkSetupConfig,
+    pub network_setup_config: NetworkConfig,
 
     /// Representation of the current network state.
     pub network_state: Arc<RwLock<PollingNetworkState<T>>>,
@@ -75,7 +75,7 @@ impl<
         ledger_db: LedgerDB,
         watcher_db: Option<WatcherDB>,
         peer_manager: McConnectionManager<T>,
-        network_setup_config: NetworkSetupConfig,
+        network_setup_config: NetworkConfig,
         network_state: Arc<RwLock<PollingNetworkState<T>>>,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
         offline: bool,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -3,6 +3,7 @@
 //! The Wallet Service for interacting with the wallet.
 
 use crate::{
+    config::PeersConfig,
     db::{Conn, WalletDb, WalletDbError},
     service::sync::SyncThread,
 };
@@ -38,6 +39,9 @@ pub struct WalletService<
 
     /// Peer manager for consensus validators to query for network height.
     pub peer_manager: McConnectionManager<T>,
+
+    /// Peer network information
+    pub peer_config: PeersConfig,
 
     /// Representation of the current network state.
     pub network_state: Arc<RwLock<PollingNetworkState<T>>>,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -92,23 +92,32 @@ impl<
             None
         };
 
-        let peers: Option<Vec<String>> = match &peers_config {
-            None => None,
-            Some(peers_config) => match &peers_config.peers {
-                None => None,
-                Some(peers) => Some(
-                    peers
-                        .iter()
-                        .map(|peer_uri| peer_uri.url().clone().into())
-                        .collect(),
-                ),
-            },
-        };
+        let mut chain_id = "".to_string();
+        let mut tx_sources: Option<Vec<String>> = None;
+        let mut peers: Option<Vec<String>> = None;
+
+        match peers_config {
+            None => (),
+            Some(peers_config) => {
+                chain_id = peers_config.chain_id;
+                tx_sources = peers_config.tx_source_urls;
+                peers = match peers_config.peers {
+                    None => None,
+                    Some(peers) => Some(
+                        peers
+                            .iter()
+                            .map(|peer_uri| peer_uri.url().clone().into())
+                            .collect(),
+                    ),
+                }
+            }
+        }
+
         let network_setup_config = NetworkSetupConfig {
             offline,
-            chain_id: peers_config.clone().unwrap().chain_id,
+            chain_id,
             peers,
-            tx_sources: peers_config.clone().unwrap().tx_source_urls,
+            tx_sources,
         };
 
         let mut rng = rand::thread_rng();

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -3,7 +3,7 @@
 //! The Wallet Service for interacting with the wallet.
 
 use crate::{
-    config::PeersConfig,
+    config::{NetworkSetupConfig, PeersConfig},
     db::{Conn, WalletDb, WalletDbError},
     service::sync::SyncThread,
 };

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -41,7 +41,6 @@ pub struct WalletService<
     pub peer_manager: McConnectionManager<T>,
 
     /// Peer network information
-    pub peers_config: Option<PeersConfig>,
     pub network_setup_config: NetworkSetupConfig,
 
     /// Representation of the current network state.
@@ -118,7 +117,6 @@ impl<
             ledger_db,
             watcher_db,
             peer_manager,
-            peers_config,
             network_setup_config,
             network_state,
             fog_resolver_factory,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -41,7 +41,7 @@ pub struct WalletService<
     pub peer_manager: McConnectionManager<T>,
 
     /// Peer network information
-    pub peer_config: PeersConfig,
+    pub peer_config: Option<PeersConfig>,
 
     /// Representation of the current network state.
     pub network_state: Arc<RwLock<PollingNetworkState<T>>>,
@@ -75,6 +75,7 @@ impl<
         ledger_db: LedgerDB,
         watcher_db: Option<WatcherDB>,
         peer_manager: McConnectionManager<T>,
+        peers_config: Option<PeersConfig>,
         network_state: Arc<RwLock<PollingNetworkState<T>>>,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
         offline: bool,

--- a/full-service/src/service/wallet_service.rs
+++ b/full-service/src/service/wallet_service.rs
@@ -3,7 +3,7 @@
 //! The Wallet Service for interacting with the wallet.
 
 use crate::{
-    config::{NetworkSetupConfig, PeersConfig},
+    config::NetworkSetupConfig,
     db::{Conn, WalletDb, WalletDbError},
     service::sync::SyncThread,
 };
@@ -15,7 +15,7 @@ use mc_crypto_rand::rand_core::RngCore;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::LedgerDB;
 use mc_ledger_sync::PollingNetworkState;
-use mc_util_uri::{ConnectionUri, FogUri};
+use mc_util_uri::FogUri;
 use mc_watcher::watcher_db::WatcherDB;
 use std::sync::{atomic::AtomicUsize, Arc, RwLock};
 
@@ -75,7 +75,7 @@ impl<
         ledger_db: LedgerDB,
         watcher_db: Option<WatcherDB>,
         peer_manager: McConnectionManager<T>,
-        peers_config: Option<PeersConfig>,
+        network_setup_config: NetworkSetupConfig,
         network_state: Arc<RwLock<PollingNetworkState<T>>>,
         fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
         offline: bool,
@@ -90,34 +90,6 @@ impl<
             ))
         } else {
             None
-        };
-
-        let mut chain_id = "".to_string();
-        let mut tx_sources: Option<Vec<String>> = None;
-        let mut peers: Option<Vec<String>> = None;
-
-        match peers_config {
-            None => (),
-            Some(peers_config) => {
-                chain_id = peers_config.chain_id;
-                tx_sources = peers_config.tx_source_urls;
-                peers = match peers_config.peers {
-                    None => None,
-                    Some(peers) => Some(
-                        peers
-                            .iter()
-                            .map(|peer_uri| peer_uri.url().clone().into())
-                            .collect(),
-                    ),
-                }
-            }
-        }
-
-        let network_setup_config = NetworkSetupConfig {
-            offline,
-            chain_id,
-            peers,
-            tx_sources,
         };
 
         let mut rng = rand::thread_rng();

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 #[cfg(test)]
 use crate::{
-    config::NetworkSetupConfig,
+    config::NetworkConfig,
     db::{
         account::{AccountID, AccountModel},
         models::{Account, TransactionLog, Txo},
@@ -634,7 +634,7 @@ fn setup_wallet_service_impl(
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), offline);
 
-    let network_setup_config = NetworkSetupConfig {
+    let network_setup_config = NetworkConfig {
         offline,
         chain_id: "rust_tests".to_string(),
         peers: None,

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -638,6 +638,7 @@ fn setup_wallet_service_impl(
         ledger_db,
         None,
         peer_manager,
+        None,
         network_state,
         get_resolver_factory(&mut rng).unwrap(),
         offline,

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
 #[cfg(test)]
 use crate::{
+    config::NetworkSetupConfig,
     db::{
         account::{AccountID, AccountModel},
         models::{Account, TransactionLog, Txo},
@@ -633,12 +634,19 @@ fn setup_wallet_service_impl(
     let (peer_manager, network_state) =
         setup_peer_manager_and_network_state(ledger_db.clone(), logger.clone(), offline);
 
+    let network_setup_config = NetworkSetupConfig {
+        offline,
+        chain_id: "rust_tests".to_string(),
+        peers: None,
+        tx_sources: None,
+    };
+
     WalletService::new(
         wallet_db,
         ledger_db,
         None,
         peer_manager,
-        None,
+        network_setup_config,
         network_state,
         get_resolver_factory(&mut rng).unwrap(),
         offline,

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -162,6 +162,7 @@ async def test_network_status(client):
         'local_block_height',
         'local_num_txos',
         'network_block_height',
+        'network_info'
     ]
 
 


### PR DESCRIPTION
### Motivation

We want to augment `get_network_status` so that users can provide more information about their setup when debugging or reporting issues.

### In this PR
We augment `get_network_status` to give more information about the launching configuration of the full-service instance.

