### PR TITLE
adding strip symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rpath = false
 lto = false
 debug-assertions = false
 overflow-checks = false
+strip = "symbols"
 
 [patch.crates-io]
 


### PR DESCRIPTION
FS builds on linux were > 600MB, and now they are < 30 :)