### PR TITLE
Implement rustdoc for all services modules in full service

### DIFF
--- a/docs/v1/api-endpoints/get_txos_for_account.md
+++ b/docs/v1/api-endpoints/get_txos_for_account.md
@@ -11,7 +11,7 @@ description: Get TXOs for a given account with offset and limit parameters
 | `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
 | `offset` | The pagination offset. Results start at the offset index. Optional, defaults to 0. | |
 | `limit` | Limit for the number of results. Optional, defaults to 100 | |
-| `status` | Optional txo status filer. Available status': "txo_status_unspent", "txo_status_spent", "txo_status_orphaned", "txo_status_pending", "txo_status_secreted", | |
+| `status` | Optional txo status filer. Available status: "txo_status_unspent", "txo_status_spent", "txo_status_orphaned", "txo_status_pending", "txo_status_secreted", | |
 
 ## Example
 

--- a/docs/v2/api-endpoints/get_txos.md
+++ b/docs/v2/api-endpoints/get_txos.md
@@ -10,7 +10,7 @@ description: Get TXOs for a given account with offset and limit parameters
 | :--- | :--- | :--- |
 | `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
 | `address` | The address b58 on which to perform this action. | Address must exist in the wallet. |
-| `status` | Txo status filer. Available status': "unverified", "unspent", "spent", "orphaned", "pending", "secreted", | |
+| `status` | Txo status filer. Available status: "unverified", "unspent", "spent", "orphaned", "pending", "secreted", | |
 | `min_received_block_index` | The minimum block index to query for received txos, inclusive | |
 | `max_received_block_index` | The maximum block index to query for received txos, inclusive | |
 | `offset` | The pagination offset. Results start at the offset index. | |

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -50,8 +50,17 @@ impl From<B58Error> for AddressServiceError {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// addresses.
+#[rustfmt::skip]
 pub trait AddressService {
     /// Creates a new address with default values.
+    ///
+    /// # Arguments
+    ///
+    ///| Name         | Purpose                                      | Notes                                 |
+    ///|--------------|----------------------------------------------|---------------------------------------|
+    ///| `account_id` | The account on which to perform this action. | The account must exist in the wallet. |
+    ///| `metadata`   | The metadata for this address.               | String; can contain stringified JSON. |
+    ///
     fn assign_address_for_account(
         &self,
         account_id: &AccountID,
@@ -60,8 +69,27 @@ pub trait AddressService {
     ) -> Result<AssignedSubaddress, AddressServiceError>;
 
     /// Get an assigned subaddress, if it exists.
-    fn get_address(&self, address_b58: &str) -> Result<AssignedSubaddress, AddressServiceError>;
+    ///
+    /// # Arguments
+    ///
+    ///| Name          | Purpose                                             | Notes |
+    ///|---------------|-----------------------------------------------------|-------|
+    ///| `address_b58` | The b58 subaddress on which to perform this action. |       |
+    ///
+    fn get_address(
+        &self, 
+        address_b58: &str
+    ) -> Result<AssignedSubaddress, AddressServiceError>;
 
+    /// Get an assigned address by index for an account.
+    ///
+    /// # Arguments
+    ///
+    ///| Name         | Purpose                                      | Notes                                        |
+    ///|--------------|----------------------------------------------|----------------------------------------------|
+    ///| `account_id` | The account on which to perform this action. | The account must exist in the wallet.        |
+    ///| `index`      | The subaddress index to lookup               | The address must have already been assigned. |
+    ///
     fn get_address_for_account(
         &self,
         account_id: &AccountID,
@@ -69,6 +97,15 @@ pub trait AddressService {
     ) -> Result<AssignedSubaddress, AddressServiceError>;
 
     /// Gets all the addresses for an optionally given account.
+    ///
+    /// # Arguments
+    ///
+    ///| Name         | Purpose                                                  | Notes                                 |
+    ///|--------------|----------------------------------------------------------|---------------------------------------|
+    ///| `account_id` | The account on which to perform this action.             | The account must exist in the wallet. |
+    ///| `offset`     | The pagination offset. Results start at the offset index | Optional, defaults to 0.              |
+    ///| `limit`      | Limit for the number of results                          | Optional                              |
+    ///
     fn get_addresses(
         &self,
         account_id: Option<String>,
@@ -77,7 +114,17 @@ pub trait AddressService {
     ) -> Result<Vec<AssignedSubaddress>, AddressServiceError>;
 
     /// Verifies whether an address can be decoded from b58.
-    fn verify_address(&self, public_address: &str) -> Result<PublicAddress, AddressServiceError>;
+    ///
+    /// # Arguments
+    ///
+    ///| Name             | Purpose                                      | Notes |
+    ///|------------------|----------------------------------------------|-------|
+    ///| `public_address` | The address on which to perform this action. |       |
+    /// 
+    fn verify_address(
+        &self, 
+        public_address: &str
+    ) -> Result<PublicAddress, AddressServiceError>;
 }
 
 impl<T, FPR> AddressService for WalletService<T, FPR>

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -144,22 +144,38 @@ pub struct WalletStatus {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// balances.
+#[rustfmt::skip]
 pub trait BalanceService {
-    /// Gets the balance for a given account.
+    /// Gets the balance for a given account. Balance consists of the sums of the various txo states in our wallet
     ///
-    /// Balance consists of the sums of the various txo states in our wallet
+    /// # Arguments
+    ///
+    ///| Name         | Purpose                                      | Notes                             |
+    ///|--------------|----------------------------------------------|-----------------------------------|
+    ///| `account_id` | The account on which to perform this action. | Account must exist in the wallet. |
+    ///
     fn get_balance_for_account(
         &self,
         account_id: &AccountID,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
 
+    /// Get the current balance for a given address.
+    ///
+    /// # Arguments
+    ///
+    ///| Name      | Purpose                                      | Notes                                                  |
+    ///|-----------|----------------------------------------------|--------------------------------------------------------|
+    ///| `address` | The address on which to perform this action. | Address must be assigned for an account in the wallet. |
+    ///
     fn get_balance_for_address(
         &self,
         address: &str,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
 
+    /// Get the current status of the network.
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError>;
 
+    /// Get the current status of a wallet. **Note that pmob calculations do not include view-only-accounts**
     fn get_wallet_status(&self) -> Result<WalletStatus, BalanceServiceError>;
 }
 

--- a/full-service/src/service/confirmation_number.rs
+++ b/full-service/src/service/confirmation_number.rs
@@ -102,15 +102,32 @@ pub struct Confirmation {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// tonfirmation numbers.
+#[rustfmt::skip]
 #[allow(clippy::result_large_err)]
 pub trait ConfirmationService {
     /// Get the confirmations from the outputs in a transaction log.
+    ///
+    /// # Arguments
+    ///
+    ///| Name                 | Purpose                                                       | Notes                                         |
+    ///|----------------------|---------------------------------------------------------------|-----------------------------------------------|
+    ///| `transaction_log_id` | The transaction log ID for which to get confirmation numbers. | The transaction log must exist in the wallet. |
+    ///
     fn get_confirmations(
         &self,
         transaction_log_id: &str,
     ) -> Result<Vec<Confirmation>, ConfirmationServiceError>;
 
     /// Validate the confirmation number with a given Txo.
+    ///
+    /// # Arguments
+    ///
+    ///| Name               | Purpose                                                          | Notes                                                                             |
+    ///|--------------------|------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+    ///| `account_id`       | The account on which to perform this action.                     | Account must exist in the wallet.                                                 |
+    ///| `txo_id`           | The ID of the TXO for which to validate the confirmation number. | TXO must be a received TXO.                                                       |
+    ///| `confirmation_hex` | The confirmation number to validate.                             | The confirmation number should be delivered by the sender of the Txo in question. |
+    ///
     fn validate_confirmation(
         &self,
         account_id: &AccountID,

--- a/full-service/src/service/payment_request.rs
+++ b/full-service/src/service/payment_request.rs
@@ -77,8 +77,19 @@ impl From<LedgerServiceError> for PaymentRequestServiceError {
     }
 }
 
+#[rustfmt::skip]
 pub trait PaymentRequestService {
-    /// Creates a new payment request b58.
+    /// Create a payment request b58 code to give to someone else.
+    ///
+    /// # Arguments
+    ///
+    ///| Name               | Purpose                                                          | Notes                             |
+    ///|--------------------|------------------------------------------------------------------|-----------------------------------|
+    ///| `account_id`       | The account on which to perform this action.                     | Account must exist in the wallet. |
+    ///| `subaddress_index` | The subaddress index on the account to generate the request with |                                   |
+    ///| `amount`           | The Amount to send in this transaction                           | 64-bit signed integer             |
+    ///| `memo`             | Memo for the payment request                                     |                                   |
+    ///
     fn create_payment_request(
         &self,
         account_id: String,

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -171,12 +171,18 @@ impl TryFrom<&mc_api::external::Receipt> for ReceiverReceipt {
     }
 }
 
-/// Trait defining the ways in which the wallet can interact with and manage
-/// receipts.
+#[rustfmt::skip]
+/// Trait defining the ways in which the wallet can interact with and manage receipts.
 pub trait ReceiptService {
-    /// Check the status of the Txos in the receipts.
+    /// Check the status of the Txos in the receipts and validates confirmation numbers once the Txos have landed.
     ///
-    /// Validates confirmation numbers once the Txos have landed.
+    /// # Arguments
+    /// 
+    ///| Name               | Purpose                                    | Notes                            |
+    ///|--------------------|--------------------------------------------|----------------------------------|
+    ///| `address`          | The account's public address.              | Must be a valid account address. |
+    ///| `receiver_receipt` | The receipt whose status is being checked. |                                  |
+    ///
     fn check_receipt_status(
         &self,
         address: &str,
@@ -184,6 +190,13 @@ pub trait ReceiptService {
     ) -> Result<(ReceiptTransactionStatus, Option<(Txo, TxoStatus)>), ReceiptServiceError>;
 
     /// Create a receipt from a given TxProposal
+    ///
+    /// # Arguments
+    /// 
+    ///| Name          | Purpose                         | Notes                           |
+    ///|---------------|---------------------------------|---------------------------------|
+    ///| `tx_proposal` | Transaction proposal to submit. | Created with build transaction. |
+    ///
     fn create_receiver_receipts(
         &self,
         tx_proposal: &TxProposal,

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -282,7 +282,25 @@ impl TransactionMemo {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// transactions.
+#[rustfmt::skip]
 pub trait TransactionService {
+
+    /// Build a transaction to confirm its contents before submitting it to the network.
+    ///
+    /// # Arguments
+    /// 
+    ///| Name                    | Purpose                                                           | Notes                                                                                             |
+    ///|-------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+    ///| `account_id_hex`        | The account on which to perform this action                       | Account must exist in the wallet                                                                  |
+    ///| `addresses_and_amounts` | An array of public addresses and Amounts as a tuple               | addresses are b58-encoded public addresses                                                        |
+    ///| `input_txo_ids`         | Specific TXOs to use as inputs to this transaction                | TXO IDs (obtain from get_txos_for_account)                                                        |
+    ///| `fee_value`             | The fee value to submit with this transaction                     | If not provided, uses MINIMUM_FEE of the first outputs token_id, if available, or defaults to MOB |
+    ///| `fee_token_id`          | The fee token_id to submit with this transaction                  | If not provided, uses token_id of first output, if available, or defaults to MOB                  |
+    ///| `tombstone_block`       | The block after which this transaction expires                    | If not provided, uses current height + 10                                                         |
+    ///| `max_spendable_value`   | The maximum amount for an input TXO selected for this transaction |                                                                                                   |
+    ///| `memo`                  | Memo for the transaction                                          |                                                                                                   |
+    ///| `block_version`         | The block version to build this transaction for.                  | Defaults to the network block version                                                             |
+    ///
     #[allow(clippy::too_many_arguments)]
     fn build_transaction(
         &self,
@@ -297,6 +315,22 @@ pub trait TransactionService {
         block_version: Option<BlockVersion>,
     ) -> Result<UnsignedTxProposal, TransactionServiceError>;
 
+    /// Build a transaction and sign it before submitting it to the network.
+    ///
+    /// # Arguments
+    /// 
+    ///| Name                    | Purpose                                                           | Notes                                                                                             |
+    ///|-------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+    ///| `account_id_hex`        | The account on which to perform this action                       | Account must exist in the wallet                                                                  |
+    ///| `addresses_and_amounts` | An array of public addresses and Amounts as a tuple               | addresses are b58-encoded public addresses                                                        |
+    ///| `input_txo_ids`         | Specific TXOs to use as inputs to this transaction                | TXO IDs (obtain from get_txos_for_account)                                                        |
+    ///| `fee_value`             | The fee value to submit with this transaction                     | If not provided, uses MINIMUM_FEE of the first outputs token_id, if available, or defaults to MOB |
+    ///| `fee_token_id`          | The fee token_id to submit with this transaction                  | If not provided, uses token_id of first output, if available, or defaults to MOB                  |
+    ///| `tombstone_block`       | The block after which this transaction expires                    | If not provided, uses current height + 10                                                         |
+    ///| `max_spendable_value`   | The maximum amount for an input TXO selected for this transaction |                                                                                                   |
+    ///| `memo`                  | Memo for the transaction                                          |                                                                                                   |
+    ///| `block_version`         | The block version to build this transaction for.                  | Defaults to the network block version                                                             |
+    ///
     #[allow(clippy::too_many_arguments)]
     fn build_and_sign_transaction(
         &self,
@@ -312,6 +346,15 @@ pub trait TransactionService {
     ) -> Result<TxProposal, TransactionServiceError>;
 
     /// Submits a pre-built TxProposal to the MobileCoin Consensus Network.
+    ///
+    /// # Arguments
+    ///
+    ///| Name             | Purpose                                                     | Notes                                                                                                                                                                                                     |
+    ///|------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    ///| `tx_proposal`    | Transaction proposal to submit                              | Created with build_transaction                                                                                                                                                                            |
+    ///| `comment`        | Comment to annotate this transaction in the transaction log |                                                                                                                                                                                                           |
+    ///| `account_id_hex` | Account ID for which to log the transaction.                | If omitted, the transaction is not logged and therefor the txos used will not be set to pending, if they exist. This could inadvertently cause an attempt to spend the same txo in multiple transactions. |
+    ///
     fn submit_transaction(
         &self,
         tx_proposal: &TxProposal,
@@ -319,6 +362,22 @@ pub trait TransactionService {
         account_id_hex: Option<String>,
     ) -> Result<Option<(TransactionLog, AssociatedTxos, ValueMap)>, TransactionServiceError>;
 
+    /// Build and sign a transaction and submit it to the network.
+    ///
+    /// # Arguments
+    /// 
+    ///| Name                    | Purpose                                                           | Notes                                                                                             |
+    ///|-------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+    ///| `account_id_hex`        | The account on which to perform this action                       | Account must exist in the wallet                                                                  |
+    ///| `addresses_and_amounts` | An array of public addresses and Amounts as a tuple               | addresses are b58-encoded public addresses                                                        |
+    ///| `input_txo_ids`         | Specific TXOs to use as inputs to this transaction                | TXO IDs (obtain from get_txos_for_account)                                                        |
+    ///| `fee_value`             | The fee value to submit with this transaction                     | If not provided, uses MINIMUM_FEE of the first outputs token_id, if available, or defaults to MOB |
+    ///| `fee_token_id`          | The fee token_id to submit with this transaction                  | If not provided, uses token_id of first output, if available, or defaults to MOB                  |
+    ///| `tombstone_block`       | The block after which this transaction expires                    | If not provided, uses current height + 10                                                         |
+    ///| `max_spendable_value`   | The maximum amount for an input TXO selected for this transaction |                                                                                                   |
+    ///| `memo`                  | Memo for the transaction                                          |                                                                                                   |
+    ///| `block_version`         | The block version to build this transaction for.                  | Defaults to the network block version                                                             |
+    ///
     #[allow(clippy::too_many_arguments)]
     fn build_sign_and_submit_transaction(
         &self,

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -40,9 +40,21 @@ impl From<diesel::result::Error> for TransactionLogServiceError {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// transaction logs.
+#[rustfmt::skip]
 #[allow(clippy::result_large_err)]
 pub trait TransactionLogService {
     /// List all transactions associated with the given Account ID.
+    ///
+    /// # Arguments
+    /// 
+    ///| Name              | Purpose                                                   | Notes                              |
+    ///|-------------------|-----------------------------------------------------------|------------------------------------|
+    ///| `account_id`      | The account id to scan for transaction logs               | Account must exist in the database |
+    ///| `offset`          | The pagination offset. Results start at the offset index. | Optional, defaults to 0            |
+    ///| `limit`           | Limit for the number of results.                          | Optional                           |
+    ///| `min_block_index` | The minimum block index to find transaction logs from     |                                    |
+    ///| `max_block_index` | The maximum block index to find transaction logs from     |                                    |
+    ///
     fn list_transaction_logs(
         &self,
         account_id: Option<String>,
@@ -53,6 +65,13 @@ pub trait TransactionLogService {
     ) -> Result<Vec<(TransactionLog, AssociatedTxos, ValueMap)>, WalletServiceError>;
 
     /// Get a specific transaction log.
+    ///
+    /// # Arguments
+    ///
+    ///| Name                 | Purpose                        | Notes                                     |
+    ///|----------------------|--------------------------------|-------------------------------------------|
+    ///| `transaction_log_id` | The transaction log ID to get. | Transaction log must exist in the wallet. |
+    ///
     fn get_transaction_log(
         &self,
         transaction_id_hex: &str,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -143,9 +143,24 @@ impl From<LedgerServiceError> for TxoServiceError {
 
 /// Trait defining the ways in which the wallet can interact with and manage
 /// Txos.
+#[rustfmt::skip]
 #[allow(clippy::result_large_err)]
 pub trait TxoService {
     /// List the Txos for a given account in the wallet.
+    ///
+    /// # Arguments
+    ///
+    ///| Name                       | Purpose                                                                                                  | Notes                             |
+    ///|----------------------------|----------------------------------------------------------------------------------------------------------|-----------------------------------|
+    ///| `account_id`               | The account on which to perform this action.                                                             | Account must exist in the wallet. |
+    ///| `address`                  | The address b58 on which to perform this action.                                                         | Address must exist in the wallet. |
+    ///| `status`                   | Txo status filer. Available status: `unverified`, `unspent`, `spent`, `orphaned`, `pending`, `secreted` |                                   |
+    ///| `token_id`                 | The tokenId of this a txo                                                                                |                                   |
+    ///| `min_received_block_index` | The minimum block index to query for received txos, inclusive                                            |                                   |
+    ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive                                            |                                   |
+    ///| `offset`                   | The pagination offset. Results start at the offset index.                                                | Optional, defaults to 0           |
+    ///| `limit`                    | Limit for the number of results.                                                                         | Optional                          |
+    ///
     #[allow(clippy::too_many_arguments)]
     fn list_txos(
         &self,
@@ -160,9 +175,31 @@ pub trait TxoService {
     ) -> Result<Vec<(Txo, TxoStatus)>, TxoServiceError>;
 
     /// Get a Txo from the wallet.
-    fn get_txo(&self, txo_id: &TxoID) -> Result<(Txo, TxoStatus), TxoServiceError>;
+    ///
+    /// # Arguments
+    ///
+    ///| Name     | Purpose                              | Notes |
+    ///|----------|--------------------------------------|-------|
+    ///| `txo_id` | The TXO ID for which to get details. |       |
+    ///
+    fn get_txo(
+        &self, 
+        txo_id: &TxoID
+    ) -> Result<(Txo, TxoStatus), TxoServiceError>;
 
-    /// Split a Txo
+    /// Build a transaction that will split a txo into multiple output txos to the origin account.
+    ///
+    /// # Arguments
+    ///
+    ///| Name               | Purpose                                              | Notes                                                                                             |
+    ///|--------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+    ///| `txo_id`           | The TXO on which to perform this action              | TXO must exist in the wallet                                                                      |
+    ///| `output_values`    | The output values of the generated TXOs              |                                                                                                   |
+    ///| `subaddress_index` | The subaddress index of the destination subaddress.  |                                                                                                   |
+    ///| `fee_value`        | The fee value to submit with this transaction        | If not provided, uses MINIMUM_FEE of the first outputs token_id, if available, or defaults to MOB |
+    ///| `fee_token_id`     | The fee token_id to submit with this transaction     | If not provided, uses token_id of first output, if available, or defaults to MOB                  |
+    ///| `tombstone_block`  | The block after which this transaction expires       | If not provided, uses current height + 10                                                         |
+    ///
     fn split_txo(
         &self,
         txo_id: &TxoID,

--- a/full-service/src/service/watcher.rs
+++ b/full-service/src/service/watcher.rs
@@ -21,7 +21,17 @@ impl From<WatcherDBError> for WatcherServiceError {
 }
 
 /// Trait defining the ways in which the service can interact with the watcher.
+#[rustfmt::skip]
 pub trait WatcherService {
+
+    /// Get watcher block by block index
+    ///
+    /// # Arguments
+    ///
+    ///| Name          | Purpose                                    | Notes                           |
+    ///|---------------|--------------------------------------------|---------------------------------|
+    ///| `block_index` | The block on which to perform this action. | Block must exist in the ledger. |
+    ///
     fn get_watcher_block_info(
         &self,
         block_index: u64,


### PR DESCRIPTION
### Motivation
Use rust doc to enhance documentations of full service

### In this PR
Add inline arguments for all methods of `mc_full_service::service` module

### Test Plan
Documentations change only. Need manual test or view

### Future Work

