### PR TITLE
updating rust toolchain for ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-04-29
+          toolchain: nightly-2023-01-04
           override: true
           components: llvm-tools-preview
 
@@ -102,13 +102,6 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
           RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-01-04
-          override: true
-          components: llvm-tools-preview
 
       - id: coverage
         uses: actions-rs/grcov@v0.1


### PR DESCRIPTION
Fixing an out of date rust toolchain causing compilation to fail when running tests because it requires a rust toolchain higher than the one set.

This should have been updated in the past anyways, as they should all be running on the same toolchain.