### PR TITLE
Update API's TXO model to return the memo type and address hash

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -72,6 +72,14 @@ pub enum TxoStatus {
     Unverified,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum RTHMemoType {
+    AuthenticatedSender,
+    AuthenticatedSenderWithPaymentIntentId,
+    AuthenticatedSenderWithPaymentRequestId,
+    Unsupported,
+}
+
 impl fmt::Display for TxoStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -99,6 +107,35 @@ impl FromStr for TxoStatus {
             "unspent" => Ok(TxoStatus::Unspent),
             "unverified" => Ok(TxoStatus::Unverified),
             _ => Err(WalletDbError::InvalidTxoStatus(s.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for RTHMemoType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RTHMemoType::AuthenticatedSender => write!(f, "AuthenticatedSender"),
+            RTHMemoType::AuthenticatedSenderWithPaymentIntentId => {
+                write!(f, "AuthenticatedSenderWithPaymentIntentId")
+            }
+            RTHMemoType::AuthenticatedSenderWithPaymentRequestId => {
+                write!(f, "AuthenticatedSenderWithPaymentRequestId")
+            }
+            _ => write!(f, "Unsupported memo format"),
+        }
+    }
+}
+
+impl From<i16> for RTHMemoType {
+    fn from(val: i16) -> Self {
+        let mut val_buff = [0u8; 2];
+        BigEndian::write_i16(&mut val_buff, val);
+
+        match val_buff {
+            [0x01, 0x00] => RTHMemoType::AuthenticatedSender,
+            [0x01, 0x01] => RTHMemoType::AuthenticatedSenderWithPaymentRequestId,
+            [0x01, 0x02] => RTHMemoType::AuthenticatedSenderWithPaymentIntentId,
+            _ => RTHMemoType::Unsupported,
         }
     }
 }

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -2,7 +2,10 @@
 
 //! API definition for the Txo object.
 
-use crate::{db, db::txo::TxoStatus};
+use crate::{
+    db,
+    db::txo::{RTHMemoType, TxoStatus},
+};
 use serde_derive::{Deserialize, Serialize};
 
 /// An Txo in the wallet.
@@ -82,7 +85,7 @@ impl Txo {
             key_image: txo.key_image.as_ref().map(hex::encode),
             confirmation: txo.confirmation.as_ref().map(hex::encode),
             shared_secret: txo.shared_secret.as_ref().map(hex::encode),
-            memo_type: format!("{:x}", txo.memo_type),
+            memo_type: RTHMemoType::from(txo.memo_type).to_string(),
             address_hash: txo.address_hash.as_ref().map(hex::encode),
         }
     }

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -59,6 +59,10 @@ pub struct Txo {
     /// Shared secret that's used to mask the private keys associated with the
     /// amounts in a transaction
     pub shared_secret: Option<String>,
+
+    pub memo_type: String,
+
+    pub address_hash: Option<String>,
 }
 
 impl Txo {
@@ -78,6 +82,8 @@ impl Txo {
             key_image: txo.key_image.as_ref().map(hex::encode),
             confirmation: txo.confirmation.as_ref().map(hex::encode),
             shared_secret: txo.shared_secret.as_ref().map(hex::encode),
+            memo_type: format!("{:x}", txo.memo_type),
+            address_hash: txo.address_hash.as_ref().map(hex::encode),
         }
     }
 }


### PR DESCRIPTION
### Motivation

Although we now store this info in the db, FS users can't access it. With this change, they will get this information on all APIs that return a TXO


### Future Work
Add tests