### PR TITLE
Integration testing fs/fsm+validator - TestNet

### DIFF
--- a/.github/actions/mobilecoin-cache-cargo-package/action.yaml
+++ b/.github/actions/mobilecoin-cache-cargo-package/action.yaml
@@ -12,6 +12,10 @@ inputs:
       /opt/cargo/git
       /opt/cargo/registry/index
       /opt/cargo/registry/cache
+  additional_keys:
+    description: "additional values to add to the cache key"
+    required: false
+    default: ""
 
 outputs:
   cache-hit:
@@ -28,4 +32,4 @@ runs:
       path: ${{ inputs.path }}
       # Key is a hash of all the Cargo.toml and Cargo.lock files.
       # if packages change, invalidate cache and rebuild
-      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}-cargo-cache
+      key: ${{ inputs.cache_buster }}${{ inputs.additional_keys }}-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}-cargo-cache

--- a/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
+++ b/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
@@ -10,6 +10,10 @@ inputs:
     required: false
     default: |
       rust_build_artifacts
+  additional_keys:
+    description: "additional values to add to the cache key"
+    required: false
+    default: ""
 
 outputs:
   cache-hit:
@@ -26,4 +30,4 @@ runs:
       path: ${{ inputs.path }}
       # Key is a hash of all the .rs, .proto and Cargo.toml files.
       # if code changes, invalidate cache and rebuild
-      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml', '**/*.edl', '.cargo/config') }}-rust-build-artifacts
+      key: ${{ inputs.cache_buster }}${{ inputs.additional_keys }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml', '**/*.edl', '.cargo/config') }}-rust-build-artifacts

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -7,226 +7,349 @@ name: Development CD
 env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinofficial-public
   DOCKER_ORG: mobilecoin
-  MOBILECOIN_ENCLAVE_VERSION: v3.0.0
-  MOBILECOIN_NETWORK: test
 
 on:
+  push:
+    branches:
+    - feature/*
   pull_request:
     branches:
-      - main
-      - release/*
+    - main
+    - release/*
 
 concurrency:
   group: full-service-dev-cd-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  metadata:
-    runs-on: [self-hosted, Linux, small]
-    outputs:
-      namespace: ${{ steps.meta.outputs.namespace }}
-      tag: ${{ steps.meta.outputs.tag }}
-      docker_tag: ${{ steps.meta.outputs.docker_tag }}
-      docker_org: ${{ env.DOCKER_ORG }}
-      chart_repo: ${{ env.CHART_REPO }}
-    steps:
-      - name: Generate version metadata
-        uses: mobilecoinofficial/gha-k8s-toolbox@v1
-        id: meta
-        with:
-          action: generate-metadata
-          prefix: fs
-
   build:
+    strategy:
+      matrix:
+        network:
+        - chain_id: test
+        # - chain_id: main
     runs-on: [self-hosted, Linux, large-cd]
     container:
       image: mobilecoin/rust-sgx-base:v0.0.25
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
 
-      - name: Cache rust build binaries
-        id: rust_artifact_cache
-        uses: ./.github/actions/mobilecoin-cache-rust-binaries
-        with:
-          cache_buster: ${{ secrets.CACHE_BUSTER }}
+    - name: Cache rust build binaries
+      id: rust_artifact_cache
+      uses: mobilecoinofficial/gh-actions/cache-rust-binaries@v0
+      with:
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+        additional_keys: ${{ matrix.network.chain_id }}
 
-      # Skip the following steps if we already have binaries.
-      - name: Cache cargo packages
-        if: "! steps.rust_artifact_cache.outputs.cache-hit"
-        uses: ./.github/actions/mobilecoin-cache-cargo-package
-        with:
-          cache_buster: ${{ secrets.CACHE_BUSTER }}
+    # Skip the following steps if we already have binaries.
+    - name: Cache cargo packages
+      if: "! steps.rust_artifact_cache.outputs.cache-hit"
+      uses: mobilecoinofficial/gh-actions/cache-cargo-packages@v0
+      with:
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+        additional_keys: ${{ matrix.network.chain_id }}
 
-      - name: Set Git Safe Directory
-        run: git config --global --add safe.directory /__w/full-service/full-service/
+    - name: Build all binaries
+      if: "! steps.rust_artifact_cache.outputs.cache-hit"
+      env:
+        BUILD_OPTIONS: "--locked"
+      run: |
+        id
+        git config --global -l --show-origin
+        pwd
+        tools/build-fs.sh ${{ matrix.network.chain_id }}
 
-      - name: Build all binaries
-        if: "! steps.rust_artifact_cache.outputs.cache-hit"
-        env:
-          BUILD_OPTIONS: "--locked"
-          CSS_JSON_FILE: production-${{ env.MOBILECOIN_ENCLAVE_VERSION }}.json
-          WORK_DIR: ${{ github.workspace }}/target/release
-        run: |
-          # Set git permissions
-          git config --global --add safe.directory '*'
-          tools/build-fs.sh test
-
-      - name: Copy artifacts to cache
-        if: "! steps.rust_artifact_cache.outputs.cache-hit"
-        run: |
-          mkdir -p rust_build_artifacts
-          find target/release -maxdepth 1 -executable -type f -exec cp "{}" rust_build_artifacts/ \;
-          find target/release -maxdepth 1 -name "*.css" -exec cp "{}" rust_build_artifacts/ \;
+    - name: Copy artifacts to cache
+      if: "! steps.rust_artifact_cache.outputs.cache-hit"
+      run: |
+        mkdir -p rust_build_artifacts/${{ matrix.network.chain_id }}
+        find target/release -maxdepth 1 -executable -type f -exec cp "{}" rust_build_artifacts/${{ matrix.network.chain_id }} \;
+        find target/release -maxdepth 1 -name "*.css" -exec cp "{}" rust_build_artifacts/${{ matrix.network.chain_id }} \;
 
   publish:
+    strategy:
+      matrix:
+        network:
+        - chain_id: test
+          peer: mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/
+          tx_source_url: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/,https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
+        # - chain_id: main
+        #   peer: mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/
+        #   tx_source_url: https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com/,https://ledger.mobilecoinww.com/node2.prod.mobilecoinww.com/
     runs-on: [self-hosted, Linux, small]
     needs:
-      - metadata
-      - build
+    - build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
 
-      - name: Cache rust build binaries
-        id: rust_artifact_cache
-        uses: ./.github/actions/mobilecoin-cache-rust-binaries
-        with:
-          cache_buster: ${{ secrets.CACHE_BUSTER }}
+    - name: Generate version metadata
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      id: meta
+      with:
+        action: generate-metadata
+        prefix: fs
 
-      - name: Generate Docker Tags
-        id: docker_meta
-        uses: docker/metadata-action@v4
-        with:
-          flavor: |
-            latest=false
-            suffix=.test
-          images: ${{ env.DOCKER_ORG }}/full-service
-          tags: ${{ needs.metadata.outputs.docker_tag }}
+    - name: Cache rust build binaries
+      id: rust_artifact_cache
+      uses: mobilecoinofficial/gh-actions/cache-rust-binaries@v0
+      with:
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+        additional_keys: ${{ matrix.network.chain_id }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+    - name: Generate Docker Tags
+      id: docker_meta
+      uses: docker/metadata-action@v4
+      with:
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.network.chain_id }}
+        images: ${{ env.DOCKER_ORG }}/full-service
+        tags: ${{ steps.meta.outputs.docker_tag }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
-      - name: Publish to DockerHub
-        uses: docker/build-push-action@v4
-        with:
-          build-args: |
-            RUST_BIN_PATH=rust_build_artifacts
-            MC_CHAIN_ID=test
-            MC_PEER=mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/
-            MC_TX_SOURCE_URL=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/,https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
-          context: .
-          file: .internal-ci/docker/Dockerfile.full-service
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Package and publish chart
-        uses: mobilecoinofficial/gha-k8s-toolbox@v1
-        with:
-          action: helm-publish
-          chart_repo_username: ${{ secrets.HARBOR_USERNAME }}
-          chart_repo_password: ${{ secrets.HARBOR_PASSWORD }}
-          chart_repo: ${{ env.CHART_REPO }}
-          chart_app_version: ${{ needs.metadata.outputs.tag }}.test
-          chart_version: ${{ needs.metadata.outputs.tag }}.test
-          chart_path: .internal-ci/helm/full-service
+    - name: Publish to DockerHub
+      uses: docker/build-push-action@v4
+      with:
+        build-args: |
+          RUST_BIN_PATH=rust_build_artifacts/${{ matrix.network.chain_id }}
+          MC_CHAIN_ID=${{ matrix.network.chain_id }}
+          MC_PEER=${{ matrix.network.peer }}
+          MC_TX_SOURCE_URL=${{ matrix.network.tx_source_url }}
+        context: .
+        file: .internal-ci/docker/Dockerfile.full-service
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+
+    - name: Package and publish "full-service" chart
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-publish
+        chart_repo_username: ${{ secrets.HARBOR_USERNAME }}
+        chart_repo_password: ${{ secrets.HARBOR_PASSWORD }}
+        chart_repo: ${{ env.CHART_REPO }}
+        chart_app_version: ${{ steps.meta.outputs.tag }}-${{ matrix.network.chain_id }}
+        chart_version: ${{ steps.meta.outputs.tag }}-${{ matrix.network.chain_id }}
+        chart_path: .internal-ci/helm/full-service
+
+    - name: Package and publish "full-service-mirror" chart
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-publish
+        chart_repo_username: ${{ secrets.HARBOR_USERNAME }}
+        chart_repo_password: ${{ secrets.HARBOR_PASSWORD }}
+        chart_repo: ${{ env.CHART_REPO }}
+        chart_app_version: ${{ steps.meta.outputs.tag }}-${{ matrix.network.chain_id }}
+        chart_version: ${{ steps.meta.outputs.tag }}-${{ matrix.network.chain_id }}
+        chart_path: .internal-ci/helm/full-service-mirror
 
   deploy:
+    strategy:
+      matrix:
+        network:
+        - chain_id: test
+        # - chain_id: main
+        chart:
+        - full-service
+        - full-service-mirror
     runs-on: [self-hosted, Linux, small]
     needs:
-      - metadata
-      - publish
+    - publish
+    env:
+      BASE_PATH: .tmp/
     steps:
-      - name: Create namespace
-        uses: mobilecoinofficial/gha-k8s-toolbox@v1
-        with:
-          action: namespace-create
-          namespace: ${{ needs.metadata.outputs.namespace }}
-          rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
-          rancher_url: ${{ secrets.DEV_RANCHER_URL }}
-          rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
 
-      - name: Deploy "simple" full-service
-        uses: mobilecoinofficial/gha-k8s-toolbox@v1
-        with:
-          action: helm-deploy
-          chart_repo: ${{ env.CHART_REPO }}
-          chart_name: full-service
-          chart_version: ${{ needs.metadata.outputs.tag }}.test
-          chart_set: |
-            --set=persistence.enabled=false
-          release_name: full-service
-          namespace: ${{ needs.metadata.outputs.namespace }}
-          rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
-          rancher_url: ${{ secrets.DEV_RANCHER_URL }}
-          rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+    - name: Generate version metadata
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      id: meta
+      with:
+        action: generate-metadata
+        prefix: ${{ matrix.chart }}-${{ matrix.network.chain_id }}
+
+    - name: Create namespace
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: namespace-create
+        namespace: ${{ steps.meta.outputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
+    - name: Generate secrets files
+      run: |
+        mkdir -p "${BASE_PATH}/secrets"
+        echo -n "${{ secrets.MIRROR_PRIVATE_PEM }}" > "${BASE_PATH}/secrets/mirror-private.pem"
+
+    - name: Create mirror-private secrets
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: secrets-create-from-file
+        namespace: ${{ steps.meta.outputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+        object_name: private-client-msg-encryption
+        src: "${{ env.BASE_PATH }}/secrets"
+
+    - name: Generate full-service values file
+      run: |
+        mkdir -p "${BASE_PATH}"
+        cat <<EOF > "${BASE_PATH}/values.yaml"
+        fullService:
+          persistence:
+            enabled: false
+        validator:
+          persistence:
+            enabled: false
+        config:
+          ledgerDbURL: https://mcdeveu1ledger.blob.core.windows.net/${{ matrix.network.chain_id }}/data.mdb
+        EOF
+
+    - name: Deploy chart
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ env.CHART_REPO }}
+        chart_name: ${{ matrix.chart }}
+        chart_version: ${{ steps.meta.outputs.tag }}-${{ matrix.network.chain_id }}
+        chart_values: ${{ env.BASE_PATH }}/values.yaml
+        release_name: ${{ matrix.chart }}
+        namespace: ${{ steps.meta.outputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   # This will need to run on our self-hosted so it can connect to the privately deployed full-service.
   integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        network:
+        - chain_id: test
+          chart: full-service
+          fog_report_url: fog://fog.test.mobilecoin.com
+          mnemonic_secret: TEST_ACCOUNT_MNEMONIC_1
+          account_first_block_var: TEST_ACCOUNT_FIRST_BLOCK_INDEX_1
+          fog_authority_spki_var: TEST_FOG_AUTHORITY_SPKI
+        - chain_id: test
+          chart: full-service-mirror
+          fog_report_url: fog://fog.test.mobilecoin.com
+          mnemonic_secret: TEST_ACCOUNT_MNEMONIC_2
+          account_first_block_var: TEST_ACCOUNT_FIRST_BLOCK_INDEX_2
+          fog_authority_spki_var: TEST_FOG_AUTHORITY_SPKI
+        # - chain_id: main
+        #   fog_report_url: fog://fog.prod.mobilecoinww.com
+        #   mnemonic_secret: MAIN_ACCOUNT_MNEMONIC
+        #   account_first_block_var: MAIN_ACCOUNT_FIRST_BLOCK_INDEX
+        #   fog_authority_spki_var: MAIN_FOG_AUTHORITY_SPKI
     runs-on: [self-hosted, Linux, small]
     needs:
-      - metadata
-      - deploy
+    - deploy
     container:
-      image: mobilecoin/builder-install:v0.0.23
+      image: python:3.11
     env:
       POETRY_HOME: /opt/poetry
-      MC_FULL_SERVICE_HOST: http://full-service.${{ needs.metadata.outputs.namespace }}
       MC_WALLET_FILE: ${{ github.workspace }}/.tmp/wallet.json
-      MC_FOG_REPORT_URL: fog://fog.test.mobilecoin.com
-      MC_FOG_AUTHORITY_SPKI: MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cCAwEAAQ==
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    - name: "Network: ${{ matrix.network.chain_id }} Chart: ${{ matrix.network.chart }}"
+      run: |
+        true
 
-      - name: Setup testnet wallet file
-        run: |
-          mkdir -p "$(dirname "${MC_WALLET_FILE}")"
-          echo '${{ secrets.TEST_ACCOUNT_WALLET_JSON }}' > "${MC_WALLET_FILE}"
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
 
-      - name: Install Python Poetry env/package manager
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+    - name: Generate version metadata
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      id: meta
+      with:
+        action: generate-metadata
+        prefix: ${{ matrix.network.chart }}-${{ matrix.network.chain_id }}
 
-      - name: Test full-service - TestNet
-        shell: bash
-        run: |
-          # Set git permissions
-          git config --global --add safe.directory '*'
+    - name: Setup wallet file
+      run: |
+        mkdir -p "$(dirname "${MC_WALLET_FILE}")"
+        cat << EOF > "${MC_WALLET_FILE}"
+        {
+            "name": "${{ matrix.network.mnemonic_secret }}",
+            "mnemonic": "${{ secrets[matrix.network.mnemonic_secret] }}",
+            "key_derivation_version": "2",
+            "first_block_index": ${{ vars[matrix.network.account_first_block_var] }},
+            "account_key": {
+              "fog_report_url": "${{ matrix.network.fog_report_url }}",
+              "fog_authority_spki": "${{ vars[matrix.network.fog_authority_spki_var] }}"
+            }
+        }
+        EOF
 
-          # Switch to testing directory and install dependencies.
-          pushd python || exit 1
-          "${POETRY_HOME}/bin/poetry" install
+    - name: Install Python Poetry env/package manager
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
 
-          # Run tests.
-          "${POETRY_HOME}/bin/poetry" run pytest -v
-          popd || exit 0
+    - name: Test full-service
+      env:
+        MC_FULL_SERVICE_HOST: http://full-service.${{ steps.meta.outputs.namespace }}.svc.cluster.local
+        MC_FULL_SERVICE_PORT: "9090"
+        MC_FOG_REPORT_URL: ${{ matrix.network.fog_report_url }}
+        MC_FOG_AUTHORITY_SPKI: ${{ vars[matrix.network.fog_authority_spki_var] }}
+      shell: bash
+      run: |
+        echo "MC_FULL_SERVICE_URL ${MC_FULL_SERVICE_URL}"
+        echo "MC_FOG_REPORT_URL ${MC_FOG_REPORT_URL}"
+        echo "MC_FOG_AUTHORITY_SPKI ${MC_FOG_AUTHORITY_SPKI}"
+
+        # Switch to testing directory and install dependencies.
+        pushd python || exit 1
+        "${POETRY_HOME}/bin/poetry" install
+
+        # Run tests.
+        "${POETRY_HOME}/bin/poetry" run pytest -v
+        popd || exit 0
+
 
   # remove the testing environment after all tests are run successfully when this
   #  is triggered from a PR.  For a feature branch, see dev-delete-cd.yaml
   cleanup-after-run:
     if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        network:
+        - chain_id: test
+        # - chain_id: main
+        chart:
+        - full-service
+        - full-service-mirror
     runs-on: [self-hosted, Linux, small]
     needs:
-      - metadata
-      - integration-test
+    - integration-test
     steps:
-      - name: Delete namespace
-        uses: mobilecoinofficial/gha-k8s-toolbox@v1
-        with:
-          action: namespace-delete
-          namespace: ${{ needs.metadata.outputs.namespace }}
-          rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
-          rancher_url: ${{ secrets.DEV_RANCHER_URL }}
-          rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Generate version metadata
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      id: meta
+      with:
+        action: generate-metadata
+        prefix: ${{ matrix.chart }}-${{ matrix.network.chain_id }}
+
+    - name: Delete namespace
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: namespace-delete
+        namespace: ${{ steps.meta.outputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -18,17 +18,10 @@ on:
     - release/**
 
 concurrency:
-  group: full-service-dev-cd-${{ github.sha }}
+  group: full-service-dev-cd-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  output:
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: full-service-dev-cd-${{ github.sha }}
-      run: |
-        echo full-service-dev-cd-${{ github.sha }}
-
   build:
     strategy:
       matrix:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -22,6 +22,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  output:
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: full-service-dev-cd-${{ github.sha }}
+      run: |
+        echo full-service-dev-cd-${{ github.sha }}
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -9,9 +9,6 @@ env:
   DOCKER_ORG: mobilecoin
 
 on:
-  push:
-    branches:
-    - feature/**
   pull_request:
     branches:
     - main

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -11,14 +11,14 @@ env:
 on:
   push:
     branches:
-    - feature/*
+    - feature/**
   pull_request:
     branches:
     - main
-    - release/*
+    - release/**
 
 concurrency:
-  group: full-service-dev-cd-${{ github.head_ref || github.ref }}
+  group: full-service-dev-cd-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -55,9 +55,6 @@ jobs:
       env:
         BUILD_OPTIONS: "--locked"
       run: |
-        id
-        git config --global -l --show-origin
-        pwd
         tools/build-fs.sh ${{ matrix.network.chain_id }}
 
     - name: Copy artifacts to cache
@@ -325,7 +322,6 @@ jobs:
         # Run tests.
         "${POETRY_HOME}/bin/poetry" run pytest -v
         popd || exit 0
-
 
   # remove the testing environment after all tests are run successfully when this
   #  is triggered from a PR.  For a feature branch, see dev-delete-cd.yaml

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -178,6 +178,15 @@ jobs:
         action: generate-metadata
         prefix: ${{ matrix.chart }}-${{ matrix.network.chain_id }}
 
+    - name: Clean namespace
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: namespace-delete
+        namespace: ${{ steps.meta.outputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
     - name: Create namespace
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:

--- a/.internal-ci/docker/Dockerfile.full-service
+++ b/.internal-ci/docker/Dockerfile.full-service
@@ -5,7 +5,7 @@
 #
 # assume we have pre-built binary
 
-FROM ubuntu:focal-20221019
+FROM ubuntu:focal-20230308
 
 RUN  addgroup --system --gid 1000 app \
   && adduser --system --ingroup app --uid 1000 app \
@@ -15,7 +15,7 @@ RUN  addgroup --system --gid 1000 app \
 
 RUN  apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y ca-certificates \
+  && apt-get install -y ca-certificates curl \
   && apt-get clean \
   && rm -r /var/lib/apt/lists \
   && mkdir -p /usr/share/grpc \
@@ -28,8 +28,10 @@ COPY ${RUST_BIN_PATH}/validator-service /usr/local/bin/
 COPY ${RUST_BIN_PATH}/wallet-service-mirror-private /usr/local/bin/
 COPY ${RUST_BIN_PATH}/wallet-service-mirror-public /usr/local/bin/
 COPY ${RUST_BIN_PATH}/generate-rsa-keypair /usr/local/bin/
-COPY ${RUST_BIN_PATH}/*.css /usr/local/bin/
+COPY ${RUST_BIN_PATH}/ingest-enclave.css /usr/local/bin/
 COPY .internal-ci/docker/entrypoints/full-service.sh /usr/local/bin/entrypoint.sh
+# not implemented yet
+# COPY .internal-ci/docker/support/full-service/initialize-wallets.sh /usr/local/bin/initialize-wallets.sh
 
 USER app
 VOLUME /data

--- a/.internal-ci/docker/entrypoints/full-service.sh
+++ b/.internal-ci/docker/entrypoints/full-service.sh
@@ -13,6 +13,34 @@ echo "Starting Up with command ${1}"
 mkdir -p "${MC_LEDGER_DB}"
 mkdir -p "$(dirname "${MC_WALLET_DB}")"
 
+# Remove unset wallet db value so we can run in Read Only mode.
+if [[ -n "${MC_READ_ONLY}" ]]
+then
+    echo "MC_READ_ONLY set. Unset MC_WALLET_DB value."
+    unset MC_WALLET_DB
+fi
+
+# Unset MC_PEER and TX_SOURCE_URL if we're running with a validator. The validator will need the consensus config.
+if [[ -n "${MC_VALIDATOR}" ]]
+then
+    echo "MC_VALIDATOR set. Unset MC_PEER and MC_TX_SOURCE_URL."
+    unset MC_PEER
+    unset MC_TX_SOURCE_URL
+fi
+
+# Restore from existing ledger database.
+if [[ -n "${MC_LEDGER_DB_URL}" ]]
+then
+    echo "MC_LEDGER_DB_URL set, restoring ${MC_LEDGER_DB}/data.mdb from backup"
+    if [[ -f "${MC_LEDGER_DB}/data.mdb" ]]
+    then
+        echo "${MC_LEDGER_DB}/data.mdb exists. Skipping restore"
+    else
+        echo "Restoring from ${MC_LEDGER_DB_URL}"
+        curl -L "${MC_LEDGER_DB_URL}" -o "${MC_LEDGER_DB}/data.mdb"
+    fi
+fi
+
 # Check to see if leading argument starts with "--".
 # If so execute with full-service for compatibility with the previous container/cli arg only configuration.
 if [[ "${1}" =~ ^--.* ]]

--- a/.internal-ci/docker/support/full-service/initialize-wallets.sh
+++ b/.internal-ci/docker/support/full-service/initialize-wallets.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+WALLETS_JSON=${WALLETS_JSON:-"/secrets/wallets.json"}
+FULL_SERVICE_URL=${FULL_SERVICE_URL:-"http://127.0.0.1:9090/wallet/v2"}
+
+fs_request()
+{
+    curl --connect-timeout 2 -fsSL "${FULL_SERVICE_URL}" -X POST -H 'Content-type: application/json' --data "${1}" 2>&1
+}
+
+# These would have been cleaner as a heredoc, but heredoc requires a read-write tmp fs space.
+# get_accounts payload
+get_accounts()
+{
+    echo '{ "method": "get_accounts", "params": {}, "jsonrpc": "2.0", "id": 1 }'
+}
+
+# import_account payload
+import_account()
+{
+    echo "{ \"method\": \"import_account\", \"params\": { \"name\": \"${1}\", \"mnemonic\": \"${2}\", \"key_derivation_version\": \"2\" }, \"jsonrpc\": \"2.0\",\"id\": 1 }"
+}
+
+log()
+{
+    echo "{ \"app\": \"${0}\", \"message\": \"${1}\" }"
+}
+
+log "Starting ${0}"
+
+if [[ -f "${WALLETS_JSON}" ]]
+then
+    log "Wait for full-service to come up"
+    while ! fs_request "$(get_accounts)" >/dev/null 2>&1
+    do
+        log "Waiting for full-service"
+        sleep 10
+    done
+
+    # iterate through wallets and import
+    # importing accounts doesn't throw an http error if they already exisit,
+    # so this is safe to run on each startup.
+    accounts=$(jq -r '.accounts[].name' "${WALLETS_JSON}")
+    for name in ${accounts}
+    do
+        log "Importing account ${name}"
+        mnemonic=$(jq -r ".accounts[] | select(.name==\"${name}\").mnemonic" "${WALLETS_JSON}")
+        fs_request "$(import_account "${name}" "${mnemonic}")" >/dev/null
+    done
+else
+    log "${WALLETS_JSON} not found - no wallets to import."
+fi
+
+log "${0} is finished"

--- a/.internal-ci/helm/full-service-mirror/.helmignore
+++ b/.internal-ci/helm/full-service-mirror/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/.internal-ci/helm/full-service-mirror/Chart.yaml
+++ b/.internal-ci/helm/full-service-mirror/Chart.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+apiVersion: v2
+name: full-service-mirror
+description: Mobilecoin full-service chart.
+type: application
+version: 0.0.0
+appVersion: 0.0.0

--- a/.internal-ci/helm/full-service-mirror/templates/NOTES.txt
+++ b/.internal-ci/helm/full-service-mirror/templates/NOTES.txt
@@ -1,0 +1,21 @@
+::::     ::::  ::::::::  ::::::::: ::::::::::: :::        ::::::::::
++:+:+: :+:+:+ :+:    :+: :+:    :+:    :+:     :+:        :+:
++:+ +:+:+ +:+ +:+    +:+ +:+    +:+    +:+     +:+        +:+
++#+  +:+  +#+ +#+    +:+ +#++:++#+     +#+     +#+        +#++:++#
++#+       +#+ +#+    +#+ +#+    +#+    +#+     +#+        +#+
+#+#       #+# #+#    #+# #+#    #+#    #+#     #+#        #+#
+###       ###  ########  ######### ########### ########## ##########
+ ::::::::   :::::::: ::::::::::: ::::    :::
+:+:    :+: :+:    :+:    :+:     :+:+:   :+:
++:+        +:+    +:+    +:+     :+:+:+  +:+
++#+        +#+    +:+    +#+     +#+ +:+ +#+
++#+        +#+    +#+    +#+     +#+  +#+#+#
+#+#    #+# #+#    #+#    #+#     #+#   #+#+#
+ ########   ######## ########### ###    ####
+
+full-service deployment completed successfully.
+
+You can reach this deployment by port-forwarding to the full-service "service" and then connecting to https://localhost:9090
+
+kubectl -n {{ .Release.Namespace }} port-forward service/{{ include "fullServiceMirror.fullname" . }}-public-mirror 9090:9090
+

--- a/.internal-ci/helm/full-service-mirror/templates/_helpers.tpl
+++ b/.internal-ci/helm/full-service-mirror/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* Copyright (c) 2018-2022 The MobileCoin Foundation */}}
+{{/* Expand the name of the chart. */}}
+{{- define "fullServiceMirror.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fullServiceMirror.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "fullServiceMirror.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "fullServiceMirror.labels" -}}
+helm.sh/chart: {{ include "fullServiceMirror.chart" . }}
+{{ include "fullServiceMirror.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | trunc 63 | trimSuffix "-" | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "fullServiceMirror.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fullServiceMirror.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* fullServiceMirror image */}}
+{{- define "fullServiceMirror.image" -}}
+{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/* private-mirror Secret Name */}}
+{{- define "fullServiceMirror.private.secret.name" -}}
+  {{- if .Values.private.secret.data }}
+    {{- include "fullServiceMirror.fullname" . }}-{{ .Values.private.secret.name }}
+  {{- else }}
+    {{- .Values.private.secret.name }}
+  {{- end }}
+{{- end }}
+
+{{/* fullService Secret Name */}}
+{{- define "fullServiceMirror.fullService.secret.name" -}}
+  {{- if .Values.fullService.secret.data }}
+    {{- include "fullServiceMirror.fullname" . }}-{{ .Values.fullService.secret.name }}
+  {{- else }}
+    {{- .Values.fullService.secret.name }}
+  {{- end }}
+{{- end }}

--- a/.internal-ci/helm/full-service-mirror/templates/full-service-configMap.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/full-service-configMap.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fullServiceMirror.fullname" . }}-full-service
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+    app: full-service
+data:
+  MC_VALIDATOR: "insecure-validator://validator:11000/"
+{{- if .Values.config.ledgerDbURL }}
+  MC_LEDGER_DB_URL: {{ .Values.config.ledgerDbURL | quote }}
+{{- end }}

--- a/.internal-ci/helm/full-service-mirror/templates/full-service-secret.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/full-service-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.fullService.secret.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fullServiceMirror.fullService.secret.name" . }}
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.fullService.secret.data | nindent 2 }}
+{{- end }}

--- a/.internal-ci/helm/full-service-mirror/templates/full-service-service.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/full-service-service.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: Service
+metadata:
+  name: full-service
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+    app: full-service
+spec:
+  type: ClusterIP
+  ports:
+    - name: full-service
+      port: 9090
+      targetPort: full-service
+      protocol: TCP
+  selector:
+    {{- include "fullServiceMirror.selectorLabels" . | nindent 4 }}
+    app: full-service

--- a/.internal-ci/helm/full-service-mirror/templates/full-service-statefulSet.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/full-service-statefulSet.yaml
@@ -1,24 +1,24 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
+# Copyright (c) 2018-2023 The MobileCoin Foundation
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "fullService.fullname" . }}-full-service
+  name: {{ include "fullServiceMirror.fullname" . }}-full-service
   labels:
-    {{- include "fullService.labels" . | nindent 4 }}
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.fullService.replicaCount }}
   selector:
     matchLabels:
       app: full-service
-      {{- include "fullService.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "fullService.fullname" . }}-full-service
+      {{- include "fullServiceMirror.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "fullServiceMirror.fullname" . }}-full-service
   template:
     metadata:
       annotations:
         {{- toYaml .Values.fullService.podAnnotations | nindent 8 }}
       labels:
         app: full-service
-        {{- include "fullService.selectorLabels" . | nindent 8 }}
+        {{- include "fullServiceMirror.selectorLabels" . | nindent 8 }}
     spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -28,11 +28,6 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
         fsGroupChangePolicy: "OnRootMismatch"
-      shareProcessNamespace: true
-      {{- if .Values.backupsSidecar.enabled }}
-      initContainers:
-      {{- include "fullService.backupsSidecar" . | nindent 6 }}
-      {{- end }}
       containers:
       - name: full-service
         securityContext:
@@ -40,11 +35,11 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
-        image: {{ include "fullService.image" . }}
-        imagePullPolicy: Always
+        image: {{ include "fullServiceMirror.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
-            name: {{ include "fullService.configMap.name" . }}
+            name: {{ include "fullServiceMirror.fullname" . }}-full-service
         args:
         ports:
         - name: full-service
@@ -68,27 +63,22 @@ spec:
           httpGet:
             path: /health
             port: full-service
-          failureThreshold: 10
           initialDelaySeconds: 5
+          failureThreshold: 10
           periodSeconds: 5
         volumeMounts:
         - name: data
           mountPath: /data
         resources:
           {{- toYaml .Values.fullService.resources | nindent 12 }}
-      {{- if .Values.backupsSidecar.enabled }}
-      {{- include "fullService.backupsSidecarContainer" . | nindent 6 }}
-      {{- end }}
       nodeSelector:
         {{- toYaml .Values.fullService.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.fullService.affinity | nindent 8 }}
       tolerations:
         {{- toYaml .Values.fullService.tolerations | nindent 8 }}
-      volumes:
-      - name: tmp
-        emptyDir: {}
       {{- if eq .Values.fullService.persistence.enabled false }}
+      volumes:
       - name: data
         emptyDir: {}
       {{- end }}
@@ -99,4 +89,3 @@ spec:
     spec:
       {{- toYaml .Values.fullService.persistence.spec | nindent 6 }}
   {{- end }}
-

--- a/.internal-ci/helm/full-service-mirror/templates/private-deployment.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/private-deployment.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fullServiceMirror.fullname" . }}-private
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.private.replicaCount }}
+  selector:
+    matchLabels:
+      app: private
+      {{- include "fullServiceMirror.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.private.podAnnotations | nindent 8 }}
+      labels:
+        app: private
+        {{- include "fullServiceMirror.selectorLabels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
+      containers:
+      - name: private
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: {{ include "fullServiceMirror.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - /usr/local/bin/wallet-service-mirror-private
+        - --mirror-public-uri=insecure-wallet-service-mirror://public:10000/
+        - --wallet-service-uri=http://full-service:9090/wallet/v2
+        - --mirror-key=/secrets/mirror-private.pem
+        resources:
+          {{- toYaml .Values.private.resources | nindent 12 }}
+        volumeMounts:
+        - name: mirror-private
+          readOnly: true
+          mountPath: "/secrets"
+      nodeSelector:
+        {{- toYaml .Values.private.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.private.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.private.tolerations | nindent 8 }}
+      volumes:
+      - name: mirror-private
+        secret:
+          secretName: {{ include "fullServiceMirror.private.secret.name" . }}

--- a/.internal-ci/helm/full-service-mirror/templates/private-secret.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/private-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.private.secret.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fullServiceMirror.private.secret.name" . }}
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+type: Opaque
+data:
+  mirror-private.pem: {{ index .Values "private" "secret" "data" "mirror-private.pem" | b64enc }}
+{{- end }}

--- a/.internal-ci/helm/full-service-mirror/templates/public-deployment.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/public-deployment.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fullServiceMirror.fullname" . }}-public
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.public.replicaCount }}
+  selector:
+    matchLabels:
+      app: public
+      {{- include "fullServiceMirror.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.public.podAnnotations | nindent 8 }}
+      labels:
+        app: public
+        {{- include "fullServiceMirror.selectorLabels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
+      containers:
+      - name: public
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: {{ include "fullServiceMirror.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - /usr/local/bin/wallet-service-mirror-public
+        - --client-listen-uri=http://0.0.0.0:9090/
+        - --mirror-listen-uri=insecure-wallet-service-mirror://0.0.0.0:10000/
+        ports:
+        - name: client
+          containerPort: 9090
+          protocol: TCP
+        - name: mirror
+          containerPort: 10000
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.public.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.public.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.public.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.public.tolerations | nindent 8 }}
+

--- a/.internal-ci/helm/full-service-mirror/templates/public-service.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/public-service.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: Service
+metadata:
+  name: public
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+    app: public
+spec:
+  type: ClusterIP
+  ports:
+    - name: client
+      port: 9090
+      targetPort: client
+      protocol: TCP
+    - name: mirror
+      port: 10000
+      targetPort: mirror
+      protocol: TCP
+  selector:
+    {{- include "fullServiceMirror.selectorLabels" . | nindent 4 }}
+    app: public

--- a/.internal-ci/helm/full-service-mirror/templates/validator-configMap.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/validator-configMap.yaml
@@ -1,10 +1,11 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
+# Copyright (c) 2018-2023 The MobileCoin Foundation
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "fullService.fullname" . }}
+  name: {{ include "fullServiceMirror.fullname" . }}-validator
   labels:
-    {{- include "fullService.labels" . | nindent 4 }}
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+    app: validator
 data:
 {{- if .Values.config.chainId }}
   MC_CHAIN_ID: {{ .Values.config.chainId | quote }}
@@ -17,7 +18,4 @@ data:
 {{- end }}
 {{- if .Values.config.ledgerDbURL }}
   MC_LEDGER_DB_URL: {{ .Values.config.ledgerDbURL | quote }}
-{{- end }}
-{{- if .Values.fullService.configMap.data }}
-  {{- toYaml .Values.fullService.configMap.data | nindent 2 }}
 {{- end }}

--- a/.internal-ci/helm/full-service-mirror/templates/validator-service.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/validator-service.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: Service
+metadata:
+  name: validator
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+    app: validator
+spec:
+  type: ClusterIP
+  ports:
+    - name: validator
+      port: 11000
+      targetPort: validator
+      protocol: TCP
+  selector:
+    {{- include "fullServiceMirror.selectorLabels" . | nindent 4 }}
+    app: validator

--- a/.internal-ci/helm/full-service-mirror/templates/validator-statefulSet.yaml
+++ b/.internal-ci/helm/full-service-mirror/templates/validator-statefulSet.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "fullServiceMirror.fullname" . }}-validator
+  labels:
+    {{- include "fullServiceMirror.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.validator.replicaCount }}
+  selector:
+    matchLabels:
+      app: validator
+      {{- include "fullServiceMirror.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "fullServiceMirror.fullname" . }}-validator
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.validator.podAnnotations | nindent 8 }}
+      labels:
+        app: validator
+        {{- include "fullServiceMirror.selectorLabels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 2000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: validator
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: {{ include "fullServiceMirror.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - /usr/local/bin/validator-service
+        - --listen-uri=insecure-validator://0.0.0.0:11000/
+        - --ledger-db=/data/ledger
+        envFrom:
+        - configMapRef:
+            name: {{ include "fullServiceMirror.fullname" . }}-validator
+        ports:
+        - name: validator
+          containerPort: 11000
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        resources:
+          {{- toYaml .Values.validator.resources | nindent 12 }}
+      nodeSelector:
+        {{- toYaml .Values.validator.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.validator.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.validator.tolerations | nindent 8 }}
+      volumes:
+      {{- if eq .Values.validator.persistence.enabled false }}
+      - name: data
+        emptyDir: {}
+      {{- end }}
+  {{- if .Values.validator.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      {{- toYaml .Values.validator.persistence.spec | nindent 6 }}
+  {{- end }}

--- a/.internal-ci/helm/full-service-mirror/values.yaml
+++ b/.internal-ci/helm/full-service-mirror/values.yaml
@@ -7,6 +7,9 @@ imagePullSecrets:
 
 image:
   org: mobilecoin
+  name: full-service
+  tag: ''
+  pullPolicy: Always
 
 ## config: is optional. The built containers are batteries included and have the appropriate chainId, peers and txSourceURLs defined by default. config is provided here so you can override if needed.
 
@@ -39,10 +42,6 @@ config:
 
 fullService:
   replicaCount: 1
-  image:
-    org: ''
-    name: full-service
-    tag: ''
   podAnnotations:
     fluentbit.io/include: 'true'
   resources: {}
@@ -54,25 +53,71 @@ fullService:
     spec:
       storageClassName: fast
       accessModes:
-        - "ReadWriteOnce"
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 128Gi
+
+  secret:
+    name: full-service-wallets
+    data: {}
+      # add an optional list of accounts to import at start up.
+      # Add the secret inline with --set-file=fullService.secret.data."wallets\.json"=.mob/wallets.json
+      # Or define inline:
+      # wallets.json: |
+        # {
+        #   "accounts": [
+        #     {
+        #       "name": ""
+        #       "mnemonic": ""
+        #       "main_address": ""
+        #     }
+        #   ]
+        # }
+
+private:
+  replicaCount: 1
+  podAnnotations:
+    fluentbit.io/include: 'true'
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  secret:
+    name: private-client-msg-encryption
+    data: {}
+      # The mirror setup uses an additional RSA 4096 key to send encrypted message payloads.
+      # Add an external secret called .Values.private.secret.name with a value of mirror-private.pem: ""
+      # OR
+      # Add the secret inline with --set-file=private.secret.data."mirror-private\.pem"=mirror-private.pem
+
+public:
+  replicaCount: 1
+  podAnnotations:
+    fluentbit.io/include: 'true'
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ledger-validator
+validator:
+  replicaCount: 1
+  podAnnotations:
+    fluentbit.io/include: 'true'
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  persistence:
+    enabled: true
+    spec:
+      storageClassName: fast
+      accessModes:
+      - "ReadWriteOnce"
       resources:
         requests:
           storage: 128Gi
   configMap:
-    name: full-service
     data: {}
 
-backupsSidecar:
-  enabled: false
-  image:
-    org: ''
-    name: infra-replication-sidecar
-    tag: v0.0.1
-  # Create backups-sidecar secret or set external 'false'
-  secret:
-    external: true
-    name: backups-sidecar
-    data:
-      ENCRYPT_KEY: <file encryption passphrase>
-      AZURE_STORAGE_ACCOUNT: <azure storage account name>
-      AZURE_STORAGE_KEY: <azure storage account access key>

--- a/.internal-ci/helm/full-service/templates/full-service-service.yaml
+++ b/.internal-ci/helm/full-service/templates/full-service-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fullService.fullname" . }}
+  name: full-service
   labels:
     {{- include "fullService.labels" . | nindent 4 }}
 spec:

--- a/full-service/src/config.rs
+++ b/full-service/src/config.rs
@@ -73,7 +73,7 @@ pub struct APIConfig {
 
     /// Path to watcher db (lmdb). When provided, watcher syncing will take
     /// place.
-    #[structopt(long)]
+    #[clap(long, value_parser, env = "MC_WATCHER_DB")]
     pub watcher_db: Option<PathBuf>,
 
     /// Allowed CORS origin. When provided, the http server will add CORS

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -6,7 +6,6 @@
 
 GIT_BASE=$(git rev-parse --show-toplevel)
 AM_I_IN_MOB_PROMPT="no"
-CARGO_TARGET_DIR="${GIT_BASE}/target"
 
 # Assume that if you're git directory is /tmp/mobilenode that we're in mob prompt
 if [[ "${GIT_BASE}" == "/tmp/mobilenode" ]]
@@ -16,12 +15,20 @@ fi
 
 if [[ "${AM_I_IN_MOB_PROMPT}" == "yes" ]]
 then
-    WORK_DIR="${WORK_DIR:-"${GIT_BASE}/.mob/${net}"}"
+    # Set cargo target dir to include the "net"
+    CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"${GIT_BASE}/target"}/${net}
+    # CBB: Deprecate the concept of "workdir" to simplify paths/scripts.
+    #      This is now a symlink to RELEASE_DIR
+    WORK_DIR=".mob/${net}"
     LISTEN_ADDR="0.0.0.0"
 else
-    WORK_DIR="${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}"
+    CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"${GIT_BASE}/target"}
+    WORK_DIR=${WORK_DIR:-"${HOME}/.mobilecoin/${net}"}
     LISTEN_ADDR="127.0.0.1"
 fi
+
+RELEASE_DIR=${CARGO_TARGET_DIR}/release
+export CARGO_TARGET_DIR
 
 # debug - echo a debug message
 #  1: message

--- a/tools/build-fs.sh
+++ b/tools/build-fs.sh
@@ -49,7 +49,7 @@ fi
 # use main instead of legacy prod
 if [[ "${net}" == "prod" ]]
 then
-    echo "Detected \"prod\" legacy network setting. Using \"main\" instead."
+    echo "Detected 'prod' legacy network setting. Using 'main' instead."
     net=main
 fi
 
@@ -58,42 +58,71 @@ fi
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${location}/.shared-functions.sh"
 
-# Setup workdir - set in .shared-functions.sh
-mkdir -p "${WORK_DIR}"
+# Setup release dir - set in .shared-functions.sh
+mkdir -p "${RELEASE_DIR}"
+
+# link workdir to release dir path
+if [[ "${AM_I_IN_MOB_PROMPT}" == "yes" ]]
+then
+    # migrate wallet/ledger db to release_dir and remove workdir to make room
+    # for the symlink
+    if [[ ! -L "${WORK_DIR}" && -d "${WORK_DIR}" ]]
+    then
+        if [[ -d "${WORK_DIR}/wallet-db" ]]
+        then
+            mv "${WORK_DIR}/wallet-db" "${RELEASE_DIR}/wallet-db"
+        fi
+        if [[ -d "${WORK_DIR}/ledger-db" ]]
+        then
+            mv "${WORK_DIR}/ledger-db" "${RELEASE_DIR}/ledger-db"
+        fi
+        rm -rf "${WORK_DIR}"
+    fi
+
+    # create parent workdir and link release_dir to work_dir
+    mkdir -p "$(dirname "${WORK_DIR}")"
+
+    # At this point WORK_DIR can only be a symlink, remove it and create a new one.
+    rm -f "${WORK_DIR}"
+
+    # this needs to be a relative link from GIT_BASE
+    ln -s -r "${RELEASE_DIR}" "${WORK_DIR}"
+fi
 
 case ${net} in
     test)
         echo "Setting '${net}' SGX, IAS and enclave values"
         SGX_MODE=HW
         IAS_MODE=PROD
-        CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${WORK_DIR}/consensus-enclave.css")
-        INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${WORK_DIR}/ingest-enclave.css")
+        CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/consensus-enclave.css")
+        INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/ingest-enclave.css")
         ;;
     main)
         echo "Setting '${net}' SGX, IAS and enclave values"
         SGX_MODE=HW
         IAS_MODE=PROD
-        CONSENSUS_ENCLAVE_CSS=$(get_css_file prod "${WORK_DIR}/consensus-enclave.css")
-        INGEST_ENCLAVE_CSS=$(get_css_file prod "${WORK_DIR}/ingest-enclave.css")
+        CONSENSUS_ENCLAVE_CSS=$(get_css_file prod "${RELEASE_DIR}/consensus-enclave.css")
+        INGEST_ENCLAVE_CSS=$(get_css_file prod "${RELEASE_DIR}/ingest-enclave.css")
         ;;
     alpha)
         echo "Setting '${net}' SGX, IAS and enclave values"
         SGX_MODE=HW
         IAS_MODE=DEV
         # User must provide their own .css files
-        CONSENSUS_ENCLAVE_CSS="${WORK_DIR}/consensus-enclave.css"
-        INGEST_ENCLAVE_CSS="${WORK_DIR}/ingest-enclave.css"
+        CONSENSUS_ENCLAVE_CSS="${RELEASE_DIR}/consensus-enclave.css"
+        INGEST_ENCLAVE_CSS="${RELEASE_DIR}/ingest-enclave.css"
         ;;
     local)
         echo "Setting '${net}' SGX, IAS and enclave values"
         SGX_MODE=SW
         IAS_MODE=DEV
 
-        INGEST_ENCLAVE_CSS="${WORK_DIR}/ingest-enclave.css"
-        if test -f "${WORK_DIR}/consensus-enclave.css"; then
-            CONSENSUS_ENCLAVE_CSS="${WORK_DIR}/consensus-enclave.css"
+        INGEST_ENCLAVE_CSS="${RELEASE_DIR}/ingest-enclave.css"
+        if [[ -f "${RELEASE_DIR}/consensus-enclave.css" ]]
+        then
+            CONSENSUS_ENCLAVE_CSS="${RELEASE_DIR}/consensus-enclave.css"
         else
-            CONSENSUS_ENCLAVE_CSS=`pwd`/mobilecoin/target/docker/release/consensus-enclave.css
+            CONSENSUS_ENCLAVE_CSS=$(pwd)/mobilecoin/target/docker/release/consensus-enclave.css
         fi
         ;;
     *)
@@ -112,11 +141,4 @@ echo "building full service..."
 # shellcheck disable=SC2086 # split away - Use BUILD_OPTIONS to set additional build options
 cargo build --release ${BUILD_OPTIONS}
 
-target_dir=${CARGO_TARGET_DIR:-"target"}
-
-if [[ "${target_dir}/release" != "${WORK_DIR}" ]]
-then
-    echo "  binaries are available in ${target_dir}/release and ${WORK_DIR}"
-    cp "${target_dir}/release/full-service" "${WORK_DIR}"
-    cp "${target_dir}/release/validator-service" "${WORK_DIR}"
-fi
+echo "  Binaries are available in ${RELEASE_DIR} and ${WORK_DIR}"

--- a/tools/run-fs.sh
+++ b/tools/run-fs.sh
@@ -200,6 +200,5 @@ then
     unset MC_PEER
 fi
 
-echo peer $MC_PEER
 echo "Starting Full-Service Wallet from ${WORK_DIR}"
 "${WORK_DIR}/full-service"


### PR DESCRIPTION
### Motivation

Integration test standalone full-service and full-service with mirror and validator on testnet.
 
### In this PR
Full-service
* minor fix for full-service option - MC_WATCHER_DB to use clap

Charts/Docker
* make dockerfile "batteries included" - sets MC_PEER, MC_TX_SOURCE_URL for test/main builds.
* update runtime container base image
* Improve fs container entrypoint script, MC_READ_ONLY option, MC_VALIDATOR detection, and restore from MC_LEDGER_DB_URL
* Optional: Import wallets on startup - still needs a bit of work.
* Add full-service-mirror helm chart for deploying setup in k8s clusters
* standardize configuration for full-service and full-service-mirror charts.

CI/CD
* Add cache key differentiation for test/main builds.
* Use mobilecoinofficial/gh-actions for "standard" cache and checkout actions.
* trigger "cd" testing on feature/* branch
*  "cd" testing use the `matrix` feature for testnet and full-service standalone and fs with mirror+validator (add main/alpha testing later).
* restore partial ledger from azure blob storage for faster startup times.
* wire up secrets for 2 test wallets so fs and fsm+v tests don't get confused.

Tools
* Clean up some differences in CARGO_TARGET_DIR between `mob prompt` and local development
* CARGO_TARGET_DIR includes "network" so test/main builds don't stomp on each other.
* Stop duplicating binaries, make WORK_DIR a symlink to  CARGO_TARGET_DIR path, and migrate ledger/wallet dbs if they exist.


### Test Plan

Automated testing under "Development CD"


### Future Work
* Need automatic update process for full-service ledger db being stored in azure blob storage
* Come back and move other ci/cd processes to use new standardized github actions (mco/gh-actions)
* wire up mainnet integration testing
* refactor other fs build processes to deduplicate workflows.

