### PR TITLE
Modify the API and add test

### DIFF
--- a/full-service/src/db/gift_code.rs
+++ b/full-service/src/db/gift_code.rs
@@ -183,6 +183,7 @@ mod tests {
             0,
             Amount::new(value, Mob::ID),
             &mut rng,
+            None,
         );
 
         let mut tx_log_bytes = [0u8; 32];

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -88,7 +88,8 @@ pub struct Txo {
     /// The memo type, indicated by the first two bytes. See
     /// mobilecoin/transaction/extra/src/memo/mod.rs
     pub memo_type: i16,
-    /// If the memo is an AuthenticatedSender memo, the sender's address hash.
+    /// If the memo is an AuthenticatedSender memo (or one of its derivatives),
+    /// the sender's address hash.
     pub address_hash: Option<Vec<u8>>,
 }
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2848,7 +2848,7 @@ mod tests {
             account_key.default_subaddress_spend_private(),
         );
 
-        let sender_memo_creds = SenderMemoCredential::From(&account_key);
+        let sender_memo_creds = SenderMemoCredential::from(&account_key);
 
         let view_public_key = RistrettoPublic::from_random(&mut rng);
         let tx_out_spend_public_key = RistrettoPublic::from_random(&mut rng);
@@ -2892,6 +2892,9 @@ mod tests {
             );
             src_txos.push(txo);
         }
+
+        // Take the txo and decrypt the memo (using shared secret), look at it and try
+        // to access the address hash bytes and assert that they're correct
 
         // 3 memo-free txos
         // 9 authenticated sender memo txos

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2843,11 +2843,6 @@ mod tests {
             src_txos.push(txo);
         }
 
-        let sender_memo_creds = SenderMemoCredential::new_from_address_and_spend_private_key(
-            &account_key.default_subaddress(),
-            account_key.default_subaddress_spend_private(),
-        );
-
         let sender_memo_creds = SenderMemoCredential::from(&account_key);
 
         let view_public_key = RistrettoPublic::from_random(&mut rng);

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2240,6 +2240,7 @@ mod tests {
             145,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         let (_txo_hex, _txo, _key_image) = create_test_received_txo(
@@ -2249,6 +2250,7 @@ mod tests {
             146,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         // Create some small TXOs for the account, more than the max number of TXOs we
@@ -2261,6 +2263,7 @@ mod tests {
                 (146 + i) as u64,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -2315,6 +2318,7 @@ mod tests {
                 144 + i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -2430,6 +2434,7 @@ mod tests {
                 144 + i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -2496,6 +2501,7 @@ mod tests {
                 144 + i as u64,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -2783,6 +2789,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
             src_txos.push(txo);
         }
@@ -2841,6 +2848,7 @@ mod tests {
                 144_u64,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
         assert_eq!(
@@ -2922,6 +2930,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -2978,6 +2987,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -3032,6 +3042,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
         for i in 1..=5 {
@@ -3042,6 +3053,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
         // Create some txos with token id != 0 to make sure it doesn't select those
@@ -3053,6 +3065,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
         for i in 1..=5 {
@@ -3063,6 +3076,7 @@ mod tests {
                 i,
                 &mut rng,
                 &wallet_db,
+                None,
             );
         }
 
@@ -3220,6 +3234,7 @@ mod tests {
                 15,
                 &mut rng,
                 &wallet_db,
+                None,
             );
 
             for i in 1..=15 {
@@ -3230,6 +3245,7 @@ mod tests {
                     i,
                     &mut rng,
                     &wallet_db,
+                    None,
                 );
             }
 
@@ -3241,6 +3257,7 @@ mod tests {
                     i,
                     &mut rng,
                     &wallet_db,
+                    None,
                 );
             }
 
@@ -3252,6 +3269,7 @@ mod tests {
                     i,
                     &mut rng,
                     &wallet_db,
+                    None,
                 );
             }
         } else {
@@ -3263,6 +3281,7 @@ mod tests {
                     i,
                     &mut rng,
                     &wallet_db,
+                    None,
                 );
             }
             // Create some txos with token id != 0
@@ -3274,6 +3293,7 @@ mod tests {
                     i,
                     &mut rng,
                     &wallet_db,
+                    None,
                 );
             }
         }

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2849,8 +2849,9 @@ mod tests {
             &wallet_db.get_conn().unwrap(),
         )
         .unwrap();
-        let sender_memo_creds = SenderMemoCredential::from(&account_key);
+        let mut sender_memo_creds = SenderMemoCredential::from(&account_key);
 
+        // make 3 txos for each 2 different account_keys
         for j in 0..2 {
             let root_id = RootIdentity::from_random(&mut rng);
             let account_key = AccountKey::from(&root_id);
@@ -2866,7 +2867,7 @@ mod tests {
                 &wallet_db.get_conn().unwrap(),
             )
             .unwrap();
-            let sender_memo_creds = SenderMemoCredential::from(&account_key);
+            sender_memo_creds = SenderMemoCredential::from(&account_key);
 
             let tx_out_spend_public_key = RistrettoPublic::from_random(&mut rng);
             let asm = AuthenticatedSenderMemo::new(
@@ -2917,12 +2918,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(all_txos.len(), 6);
-        for t in all_txos.iter() {
-            assert_eq!(
-                RTHMemoType::from(t.memo_type),
-                RTHMemoType::AuthenticatedSender
-            );
-        }
 
         let txos_by_type = Txo::list(
             None,
@@ -2939,7 +2934,6 @@ mod tests {
         assert_eq!(txos_by_type.len(), 6);
 
         let address_hash_for_query = hex::encode(sender_memo_creds.address_hash.as_ref());
-
         let txos_by_memo_addr = Txo::list(
             None,
             None,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -634,6 +634,7 @@ impl TxoModel for Txo {
         offset: Option<u64>,
         limit: Option<u64>,
         token_id: Option<u64>,
+        // Todo: add addr hash and memo type to parameters
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
@@ -725,6 +726,9 @@ impl TxoModel for Txo {
         if let Some(max_received_block_index) = max_received_block_index {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
+
+        // TODO: Add query extension for memo type
+        // TODO: Add query extension for addr hash
 
         Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1788,6 +1788,7 @@ mod tests {
             0,
             Amount::new(1000 * MOB, Mob::ID),
             &mut rng,
+            None,
         );
 
         // Let's add this txo to the ledger
@@ -3111,7 +3112,8 @@ mod tests {
 
         let amount = Amount::new(28922973268924, Mob::ID);
 
-        let (txo, key_image) = create_test_txo_for_recipient(&account_key, 1, amount, &mut rng);
+        let (txo, key_image) =
+            create_test_txo_for_recipient(&account_key, 1, amount, &mut rng, None);
 
         // create 1 txo with no key image and no subaddress
         Txo::create_received(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -267,6 +267,8 @@ pub trait TxoModel {
         offset: Option<u64>,
         limit: Option<u64>,
         token_id: Option<u64>,
+        memo_type: Option<RTHMemoType>,
+        memo_address_hash: Option<String>,
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError>;
 
@@ -651,7 +653,9 @@ impl TxoModel for Txo {
         offset: Option<u64>,
         limit: Option<u64>,
         token_id: Option<u64>,
-        // Todo: add addr hash and memo type to parameters
+        memo_type: Option<RTHMemoType>,
+        memo_address_hash: Option<String>,
+        // TODO: use addr hash and memo type to parameters
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2825,7 +2825,7 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn applesauce(logger: Logger) {
+    fn test_memo_querying_in_db(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
 
         let db_test_context = WalletDbTestContext::default();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -126,6 +126,23 @@ impl fmt::Display for RTHMemoType {
     }
 }
 
+impl FromStr for RTHMemoType {
+    type Err = WalletDbError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AuthenticatedSender" => Ok(RTHMemoType::AuthenticatedSender),
+            "AuthenticatedSenderWithPaymentIntentId" => {
+                Ok(RTHMemoType::AuthenticatedSenderWithPaymentIntentId)
+            }
+            "AuthenticatedSenderWithPaymentRequestId" => {
+                Ok(RTHMemoType::AuthenticatedSenderWithPaymentRequestId)
+            }
+            _ => Ok(RTHMemoType::Unsupported),
+        }
+    }
+}
+
 impl From<i16> for RTHMemoType {
     fn from(val: i16) -> Self {
         let mut val_buff = [0u8; 2];

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -655,7 +655,6 @@ impl TxoModel for Txo {
         token_id: Option<u64>,
         memo_type: Option<RTHMemoType>,
         memo_address_hash: Option<String>,
-        // TODO: use addr hash and memo type to parameters
         conn: &Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
         use crate::db::schema::txos;
@@ -748,8 +747,15 @@ impl TxoModel for Txo {
             query = query.filter(txos::received_block_index.le(max_received_block_index as i64));
         }
 
-        // TODO: Add query extension for memo type
-        // TODO: Add query extension for addr hash
+        if let Some(memo_type) = memo_type {
+            query = query.filter(txos::memo_type.eq(memo_type as i16));
+        }
+
+        if let Some(memo_address_hash) = memo_address_hash {
+            if let Ok(memo_address_bytes) = hex::decode(memo_address_hash) {
+                query = query.filter(txos::address_hash.eq(memo_address_bytes));
+            }
+        }
 
         Ok(query.order(txos::received_block_index.desc()).load(conn)?)
     }

--- a/full-service/src/db/wallet_db_error.rs
+++ b/full-service/src/db/wallet_db_error.rs
@@ -4,6 +4,7 @@ use crate::{db::gift_code::GiftCodeDbError, util::b58::B58Error};
 use mc_transaction_extra;
 
 use displaydoc::Display;
+use hex::FromHexError;
 use mc_transaction_extra::MemoDecodingError;
 
 #[derive(Display, Debug)]
@@ -157,6 +158,9 @@ pub enum WalletDbError {
 
     /// Expected to find a key image for a txo with id: {0}
     MissingKeyImageForInputTxo(String),
+
+    /// Hex Error
+    FromHexError(FromHexError),
 }
 
 impl From<diesel::result::Error> for WalletDbError {
@@ -228,5 +232,11 @@ impl From<mc_crypto_keys::KeyError> for WalletDbError {
 impl From<MemoDecodingError> for WalletDbError {
     fn from(src: MemoDecodingError) -> Self {
         Self::MemoDecodingError(src)
+    }
+}
+
+impl From<FromHexError> for WalletDbError {
+    fn from(src: FromHexError) -> Self {
+        Self::FromHexError(src)
     }
 }

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -535,6 +535,8 @@ where
                     Some(block_index),
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .map_err(format_error)?;
 
@@ -588,7 +590,18 @@ where
             let mut transaction_log_map: Map<String, serde_json::Value> = Map::new();
 
             let received_txos = service
-                .list_txos(None, None, None, Some(*Mob::ID), None, None, None, None)
+                .list_txos(
+                    None,
+                    None,
+                    None,
+                    Some(*Mob::ID),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
                 .map_err(format_error)?;
 
             let received_tx_logs: Vec<TransactionLog> = received_txos
@@ -635,6 +648,8 @@ where
                     Some(address),
                     None,
                     Some(*Mob::ID),
+                    None,
+                    None,
                     None,
                     None,
                     None,
@@ -797,6 +812,8 @@ where
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .map_err(format_error)?;
 
@@ -883,6 +900,8 @@ where
                     None,
                     Some(o),
                     Some(l),
+                    None,
+                    None,
                 )
                 .map_err(format_error)?;
             let txo_map: Map<String, serde_json::Value> = Map::from_iter(

--- a/full-service/src/json_rpc/v1/models/txo.rs
+++ b/full-service/src/json_rpc/v1/models/txo.rs
@@ -250,6 +250,7 @@ mod tests {
             0,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         let txo_details = db::models::Txo::get(&txo_hex, &wallet_db.get_conn().unwrap())

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -208,7 +208,8 @@ pub enum JsonCommandRequest {
         max_received_block_index: Option<String>,
         offset: Option<u64>,
         limit: Option<u64>,
-        // TODO: add memo type and addr hash
+        memo_type: Option<String>,
+        memo_address_hash: Option<String>,
     },
     get_wallet_status,
     import_account_from_legacy_root_entropy {

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -208,6 +208,7 @@ pub enum JsonCommandRequest {
         max_received_block_index: Option<String>,
         offset: Option<u64>,
         limit: Option<u64>,
+        // TODO: add memo type and addr hash
     },
     get_wallet_status,
     import_account_from_legacy_root_entropy {

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -928,6 +928,8 @@ where
             max_received_block_index,
             offset,
             limit,
+            memo_type,
+            memo_address_hash,
         } => {
             let status = match status {
                 Some(s) => Some(TxoStatus::from_str(&s).map_err(format_error)?),

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -530,6 +530,8 @@ where
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .map_err(format_error)?;
 
@@ -956,7 +958,6 @@ where
                 None => None,
             };
 
-            // TODO: pass in the memo_type and addr hash
             let txos_and_statuses = service
                 .list_txos(
                     account_id,
@@ -967,6 +968,8 @@ where
                     max_received_block_index,
                     offset,
                     limit,
+                    memo_type,
+                    memo_address_hash,
                 )
                 .map_err(format_error)?;
 

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -948,6 +948,7 @@ where
                 Some(i) => Some(i.parse::<u64>().map_err(format_error)?),
                 None => None,
             };
+            // TODO: get and parse out the memo_type and the address_hash
 
             let txos_and_statuses = service
                 .list_txos(

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -2,7 +2,7 @@ use crate::{
     db::{
         account::AccountID,
         transaction_log::TransactionId,
-        txo::{TxoID, TxoStatus},
+        txo::{RTHMemoType, TxoID, TxoStatus},
     },
     json_rpc::{
         json_rpc_request::JsonRPCRequest,
@@ -950,8 +950,13 @@ where
                 Some(i) => Some(i.parse::<u64>().map_err(format_error)?),
                 None => None,
             };
-            // TODO: get and parse out the memo_type and the address_hash
 
+            let memo_type = match memo_type {
+                Some(mt) => Some(RTHMemoType::from_str(&mt).map_err(format_error)?),
+                None => None,
+            };
+
+            // TODO: pass in the memo_type and addr hash
             let txos_and_statuses = service
                 .list_txos(
                     account_id,

--- a/full-service/src/json_rpc/v2/e2e_tests/other.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/other.rs
@@ -158,6 +158,7 @@ mod e2e_misc {
             13,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         add_block_with_tx_outs(
@@ -222,6 +223,7 @@ mod e2e_misc {
             13,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         add_block_with_tx_outs(

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -63,8 +63,11 @@ pub struct Txo {
     /// amounts in a transaction
     pub shared_secret: Option<String>,
 
+    /// The memo type on the TXO
     pub memo_type: String,
 
+    /// If the memo_type is supported by Full Service and has an address hash,
+    /// the address hash
     pub address_hash: Option<String>,
 }
 

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -138,6 +138,7 @@ mod tests {
             0,
             &mut rng,
             &wallet_db,
+            None,
         );
 
         let txo_details = db::models::Txo::get(&txo_hex, &wallet_db.get_conn().unwrap())

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -813,6 +813,7 @@ mod tests {
             0,
             mc_transaction_core::Amount::new(1000 * MOB, Mob::ID),
             &mut rng,
+            None,
         );
 
         // Let's add this txo to the ledger

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -958,6 +958,7 @@ mod tests {
             13_u64,
             &mut rng,
             wallet_db,
+            None,
         );
 
         let txos = Txo::list_for_account(

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -471,7 +471,18 @@ mod tests {
 
         // Get corresponding Txo for Bob
         let txos_and_statuses = service
-            .list_txos(Some(bob.id), None, None, None, None, None, None, None)
+            .list_txos(
+                Some(bob.id),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
             .expect("Could not get Bob Txos");
         assert_eq!(txos_and_statuses.len(), 1);
 

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -517,6 +517,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
             )
             .unwrap();
 

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -7,7 +7,7 @@ use crate::{
         account::{AccountID, AccountModel},
         assigned_subaddress::AssignedSubaddressModel,
         models::{Account, AssignedSubaddress, Txo},
-        txo::{TxoID, TxoModel, TxoStatus},
+        txo::{RTHMemoType, TxoID, TxoModel, TxoStatus},
         WalletDbError,
     },
     error::WalletTransactionBuilderError,
@@ -172,6 +172,8 @@ pub trait TxoService {
         max_received_block_index: Option<u64>,
         offset: Option<u64>,
         limit: Option<u64>,
+        memo_type: Option<RTHMemoType>,
+        memo_address_hash: Option<String>,
     ) -> Result<Vec<(Txo, TxoStatus)>, TxoServiceError>;
 
     /// Get a Txo from the wallet.
@@ -226,7 +228,8 @@ where
         max_received_block_index: Option<u64>,
         offset: Option<u64>,
         limit: Option<u64>,
-        // TODO: add memotype and addr hash to parameters
+        memo_type: Option<RTHMemoType>,
+        memo_address_hash: Option<String>,
     ) -> Result<Vec<(Txo, TxoStatus)>, TxoServiceError> {
         let conn = &self.get_conn()?;
 
@@ -255,6 +258,7 @@ where
                 conn,
             )?;
         } else {
+            // TODO: use memo type here
             txos = Txo::list(
                 status,
                 min_received_block_index,
@@ -419,6 +423,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(txos.len(), 1);
@@ -460,6 +466,8 @@ mod tests {
                 Some(alice.id.clone()),
                 None,
                 Some(TxoStatus::Pending),
+                None,
+                None,
                 None,
                 None,
                 None,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -258,7 +258,6 @@ where
                 conn,
             )?;
         } else {
-            // TODO: use memo type here
             txos = Txo::list(
                 status,
                 min_received_block_index,
@@ -266,6 +265,8 @@ where
                 offset,
                 limit,
                 token_id,
+                memo_type,
+                memo_address_hash,
                 conn,
             )?;
         }

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -226,6 +226,7 @@ where
         max_received_block_index: Option<u64>,
         offset: Option<u64>,
         limit: Option<u64>,
+        // TODO: add memotype and addr hash to parameters
     ) -> Result<Vec<(Txo, TxoStatus)>, TxoServiceError> {
         let conn = &self.get_conn()?;
 

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use diesel::{Connection as DSLConnection, SqliteConnection};
 use diesel_migrations::embed_migrations;
-use mc_account_keys::{AccountKey, PublicAddress, RootIdentity, ViewAccountKey};
+use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
 use mc_blockchain_test_utils::make_block_metadata;
 use mc_blockchain_types::{Block, BlockContents, BlockVersion};
 use mc_common::logger::{log, Logger};
@@ -38,7 +38,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut},
-    Amount, FeeMap, Token, TokenId,
+    Amount, FeeMap, MemoPayload, Token, TokenId,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_uri::{ConnectionUri, FogUri};
@@ -371,6 +371,7 @@ pub fn create_test_txo_for_recipient(
     recipient_subaddress_index: u64,
     amount: Amount,
     rng: &mut StdRng,
+    memo: Option<MemoPayload>,
 ) -> (TxOut, KeyImage) {
     let recipient = recipient_account_key.subaddress(recipient_subaddress_index);
     let tx_private_key = RistrettoPrivate::from_random(rng);
@@ -403,7 +404,7 @@ pub fn create_test_received_txo(
     wallet_db: &WalletDb,
 ) -> (String, TxOut, KeyImage) {
     let (txo, key_image) =
-        create_test_txo_for_recipient(account_key, recipient_subaddress_index, amount, rng);
+        create_test_txo_for_recipient(account_key, recipient_subaddress_index, amount, rng, None);
 
     let txo_id_hex = Txo::create_received(
         txo.clone(),

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -414,6 +414,7 @@ pub fn create_test_received_txo(
     received_block_index: u64,
     rng: &mut StdRng,
     wallet_db: &WalletDb,
+    memo_payload: Option<MemoPayload>,
 ) -> (String, TxOut, KeyImage) {
     let (txo, key_image) =
         create_test_txo_for_recipient(account_key, recipient_subaddress_index, amount, rng, None);

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -377,13 +377,13 @@ pub fn create_test_txo_for_recipient(
     let tx_private_key = RistrettoPrivate::from_random(rng);
     let hint = EncryptedFogHint::fake_onetime_hint(rng);
     let tx_out = match memo_payload {
-        Some(payload) => TxOut::new_with_memo(
+        Some(memo_payload) => TxOut::new_with_memo(
             BlockVersion::MAX,
             amount,
             &recipient,
             &tx_private_key,
             hint,
-            |_| Ok(payload),
+            |_| Ok(memo_payload),
         ),
         None => TxOut::new(BlockVersion::MAX, amount, &recipient, &tx_private_key, hint),
     }

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2020-2021 MobileCoin Inc.
-use crate::db::schema::txos::memo;
 #[cfg(test)]
 use crate::{
     config::NetworkConfig,

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -371,12 +371,12 @@ pub fn create_test_txo_for_recipient(
     recipient_subaddress_index: u64,
     amount: Amount,
     rng: &mut StdRng,
-    memo_payload: Option<MemoPayload>,
+    _memo_payload: Option<MemoPayload>,
 ) -> (TxOut, KeyImage) {
     let recipient = recipient_account_key.subaddress(recipient_subaddress_index);
     let tx_private_key = RistrettoPrivate::from_random(rng);
     let hint = EncryptedFogHint::fake_onetime_hint(rng);
-    let tx_out = match memo_payload {
+    let tx_out = match _memo_payload {
         Some(memo_payload) => TxOut::new_with_memo(
             BlockVersion::MAX,
             amount,
@@ -415,8 +415,13 @@ pub fn create_test_received_txo(
     wallet_db: &WalletDb,
     memo_payload: Option<MemoPayload>,
 ) -> (String, TxOut, KeyImage) {
-    let (txo, key_image) =
-        create_test_txo_for_recipient(account_key, recipient_subaddress_index, amount, rng, None);
+    let (txo, key_image) = create_test_txo_for_recipient(
+        account_key,
+        recipient_subaddress_index,
+        amount,
+        rng,
+        memo_payload,
+    );
 
     let txo_id_hex = Txo::create_received(
         txo.clone(),

--- a/full-service/src/util/b58/tests.rs
+++ b/full-service/src/util/b58/tests.rs
@@ -60,6 +60,7 @@ mod tests {
             0,
             Amount::new(1_000_000_000_000, Mob::ID),
             &mut rng,
+            None,
         );
 
         let proto_tx_pubkey: mc_api::external::CompressedRistretto = (&txo.public_key).into();
@@ -111,6 +112,7 @@ mod tests {
             0,
             Amount::new(1_000_000_000_000, Mob::ID),
             &mut rng,
+            None,
         );
 
         let proto_tx_pubkey: mc_api::external::CompressedRistretto = (&txo.public_key).into();
@@ -137,6 +139,7 @@ mod tests {
             0,
             Amount::new(1_000_000_000_000, Mob::ID),
             &mut rng,
+            None,
         );
 
         let proto_tx_pubkey: mc_api::external::CompressedRistretto = (&txo.public_key).into();
@@ -207,6 +210,7 @@ mod tests {
             0,
             Amount::new(1_000_000_000_000, Mob::ID),
             &mut rng,
+            None,
         );
 
         let proto_tx_pubkey: mc_api::external::CompressedRistretto = (&txo.public_key).into();

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -51,14 +51,14 @@ get_css_file()
 
     # Get remote css
     debug "  Pulling index file from ${CSS_BASE_URL}/${CSS_JSON_FILE}"
-    json=$(curl -fsSL --retry 0 "${CSS_BASE_URL}/${CSS_JSON_FILE}")
+    json=$(curl -fsSL --retry 3 "${CSS_BASE_URL}/${CSS_JSON_FILE}")
 
     # Extract url - could we install jq?
     css_file_base=$(basename "${css_file}")
     css_url=$(echo "${json}" | grep "${css_file_base}" | awk '{print $2}' | tr -d \" | tr -d ,)
 
     debug "  Pulling css file from ${CSS_BASE_URL}/${css_url}"
-    curl -fsSL --retry 0 "${CSS_BASE_URL}/${css_url}" -o "${css_file}"
+    curl -fsSL --retry 3 "${CSS_BASE_URL}/${css_url}" -o "${css_file}"
 
     debug "  css file saved ${css_file}"
     echo "${css_file}"

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -51,14 +51,14 @@ get_css_file()
 
     # Get remote css
     debug "  Pulling index file from ${CSS_BASE_URL}/${CSS_JSON_FILE}"
-    json=$(curl -fsSL --retry 3 "${CSS_BASE_URL}/${CSS_JSON_FILE}")
+    json=$(curl -fsSL --retry 0 "${CSS_BASE_URL}/${CSS_JSON_FILE}")
 
     # Extract url - could we install jq?
     css_file_base=$(basename "${css_file}")
     css_url=$(echo "${json}" | grep "${css_file_base}" | awk '{print $2}' | tr -d \" | tr -d ,)
 
     debug "  Pulling css file from ${CSS_BASE_URL}/${css_url}"
-    curl -fsSL --retry 3 "${CSS_BASE_URL}/${css_url}" -o "${css_file}"
+    curl -fsSL --retry 0 "${CSS_BASE_URL}/${css_url}" -o "${css_file}"
 
     debug "  css file saved ${css_file}"
     echo "${css_file}"


### PR DESCRIPTION
### Motivation

Now that we store the memo type and associated address hash in the db, the user may want to query for TXOs based on that info. Here, we modify the json_rpc api to allow get_txos to filter based on the addr hash, and the memo type.
