### PR TITLE
update mbedtls version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=98d3af413c1e23ea89cc5f41ab4dddb1944405af#98d3af413c1e23ea89cc5f41ab4dddb1944405af"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=e966091845f27d49b0d9ba91fc99125e0c5f111c#e966091845f27d49b0d9ba91fc99125e0c5f111c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.1.0",
  "byteorder",
  "cc",
  "cfg-if",
@@ -2053,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=98d3af413c1e23ea89cc5f41ab4dddb1944405af#98d3af413c1e23ea89cc5f41ab4dddb1944405af"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=e966091845f27d49b0d9ba91fc99125e0c5f111c#e966091845f27d49b0d9ba91fc99125e0c5f111c"
 dependencies = [
  "bindgen 0.64.0",
  "cc",
@@ -2063,7 +2063,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dal
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
 
 # mbedtls patched to allow certificate verification with a profile
-mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "98d3af413c1e23ea89cc5f41ab4dddb1944405af" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "98d3af413c1e23ea89cc5f41ab4dddb1944405af" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "e966091845f27d49b0d9ba91fc99125e0c5f111c" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "e966091845f27d49b0d9ba91fc99125e0c5f111c" }
 
 # Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
 lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }


### PR DESCRIPTION
This fixes a bug on macOS when using command line tools for Xcode 14.3+