### PR TITLE
remove key derivation version param

### DIFF
--- a/full-service/src/json_rpc/v1/api/request.rs
+++ b/full-service/src/json_rpc/v1/api/request.rs
@@ -183,7 +183,6 @@ pub enum JsonCommandRequest {
     get_wallet_status,
     import_account {
         mnemonic: String,
-        key_derivation_version: String,
         name: Option<String>,
         first_block_index: Option<String>,
         next_subaddress_index: Option<String>,

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -929,7 +929,6 @@ where
         }
         JsonCommandRequest::import_account {
             mnemonic,
-            key_derivation_version,
             name,
             first_block_index,
             next_subaddress_index,
@@ -945,12 +944,10 @@ where
                 .map(|ns| ns.parse::<u64>())
                 .transpose()
                 .map_err(format_error)?;
-            let kdv = key_derivation_version.parse::<u8>().map_err(format_error)?;
 
             let account = service
                 .import_account(
                     mnemonic,
-                    kdv,
                     name,
                     fb,
                     ns,

--- a/full-service/src/json_rpc/v1/e2e_tests/account/create_import/import_account.rs
+++ b/full-service/src/json_rpc/v1/e2e_tests/account/create_import/import_account.rs
@@ -6,7 +6,7 @@
 mod e2e_account {
     use crate::{
         db::account::AccountID,
-        json_rpc::v1::api::test_utils::{dispatch, dispatch_expect_error, setup},
+        json_rpc::v1::api::test_utils::{dispatch, setup},
         test_utils::{add_block_to_ledger_db, manually_sync_account},
         util::b58::b58_decode_public_address,
     };
@@ -51,42 +51,6 @@ mod e2e_account {
         );
         assert_eq!(account_obj.get("next_subaddress_index").unwrap(), "2");
         assert_eq!(account_obj.get("fog_enabled").unwrap(), false);
-    }
-
-    #[test_with_logger]
-    fn test_e2e_import_account_unknown_version(logger: Logger) {
-        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "import_account",
-            "params": {
-                "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
-                "key_derivation_version": "3",
-                "name": "",
-            }
-        });
-        dispatch_expect_error(
-            &client,
-            body,
-            &logger,
-            json!({
-                "method": "import_account",
-                "error": json!({
-                    "code": -32603,
-                    "message": "InternalError",
-                    "data": json!({
-                        "server_error": "UnknownKeyDerivation(3)",
-                        "details": "Unknown key version version: 3",
-                    })
-                }),
-                "jsonrpc": "2.0",
-                "id": 1,
-            })
-            .to_string(),
-        );
     }
 
     #[test_with_logger]

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -219,7 +219,6 @@ pub enum JsonCommandRequest {
     },
     import_account {
         mnemonic: String,
-        key_derivation_version: String,
         name: Option<String>,
         first_block_index: Option<String>,
         next_subaddress_index: Option<String>,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1024,7 +1024,6 @@ where
         },
         JsonCommandRequest::import_account {
             mnemonic,
-            key_derivation_version,
             name,
             first_block_index,
             next_subaddress_index,
@@ -1038,14 +1037,12 @@ where
                 .map(|ns| ns.parse::<u64>())
                 .transpose()
                 .map_err(format_error)?;
-            let kdv = key_derivation_version.parse::<u8>().map_err(format_error)?;
 
             let fog_info = fog_info.unwrap_or_default();
 
             let account = service
                 .import_account(
                     mnemonic,
-                    kdv,
                     name,
                     fb,
                     ns,

--- a/full-service/src/json_rpc/v2/e2e_tests/account/create_import/import_account.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/account/create_import/import_account.rs
@@ -6,7 +6,7 @@
 mod e2e_account {
     use crate::{
         db::account::AccountID,
-        json_rpc::v2::api::test_utils::{dispatch, dispatch_expect_error, setup},
+        json_rpc::v2::api::test_utils::{dispatch, setup},
         test_utils::{add_block_to_ledger_db, manually_sync_account},
         util::b58::b58_decode_public_address,
     };
@@ -52,42 +52,6 @@ mod e2e_account {
         );
         assert_eq!(account_obj.get("next_subaddress_index").unwrap(), "2");
         assert_eq!(account_obj.get("fog_enabled").unwrap(), false);
-    }
-
-    #[test_with_logger]
-    fn test_e2e_import_account_unknown_version(logger: Logger) {
-        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
-        let (client, _ledger_db, _db_ctx, _network_state) = setup(&mut rng, logger.clone());
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "import_account",
-            "params": {
-                "mnemonic": "sheriff odor square mistake huge skate mouse shoot purity weapon proof stuff correct concert blanket neck own shift clay mistake air viable stick group",
-                "key_derivation_version": "3",
-                "name": "",
-            }
-        });
-        dispatch_expect_error(
-            &client,
-            body,
-            &logger,
-            json!({
-                "method": "import_account",
-                "error": json!({
-                    "code": -32603,
-                    "message": "InternalError",
-                    "data": json!({
-                        "server_error": "UnknownKeyDerivation(3)",
-                        "details": "Unknown key version version: 3",
-                    })
-                }),
-                "jsonrpc": "2.0",
-                "id": 1,
-            })
-            .to_string(),
-        );
     }
 
     #[test_with_logger]

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -18,11 +18,8 @@ use crate::{
         ledger::{LedgerService, LedgerServiceError},
         WalletService,
     },
-    util::{
-        constants::MNEMONIC_KEY_DERIVATION_VERSION,
-        encoding_helpers::{
-            hex_to_ristretto, hex_to_ristretto_public, ristretto_public_to_hex, ristretto_to_hex,
-        },
+    util::encoding_helpers::{
+        hex_to_ristretto, hex_to_ristretto_public, ristretto_public_to_hex, ristretto_to_hex,
     },
 };
 
@@ -154,7 +151,6 @@ pub trait AccountService {
     ///| Name                     | Purpose                                                                                    | Notes                                                            |
     ///|--------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------|
     ///| `mnemonic_phrase`        | The secret mnemonic to recover the account.                                                | A label can have duplicates, but it is not recommended.          |
-    ///| `key_derivation_version` | The version number of the key derivation used to derive an account key from this mnemonic. | The current version is 2.                                        |
     ///| `name`                   | A Optional label for this account.                                                         |                                                                  |
     ///| `first_block_index`      | The block from which to start scanning the ledger.                                         | All subaddresses below this index will be created.               |
     ///| `next_subaddress_index`  | The next known unused subaddress index for the account.                                    |                                                                  |
@@ -165,7 +161,6 @@ pub trait AccountService {
     fn import_account(
         &self,
         mnemonic_phrase: String,
-        key_derivation_version: u8,
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
@@ -394,7 +389,6 @@ where
     fn import_account(
         &self,
         mnemonic_phrase: String,
-        key_derivation_version: u8,
         name: Option<String>,
         first_block_index: Option<u64>,
         next_subaddress_index: Option<u64>,
@@ -408,12 +402,6 @@ where
             name,
             first_block_index,
         );
-
-        if key_derivation_version != MNEMONIC_KEY_DERIVATION_VERSION {
-            return Err(AccountServiceError::UnknownKeyDerivation(
-                key_derivation_version,
-            ));
-        }
 
         // Get mnemonic from phrase
         let mnemonic = match Mnemonic::from_phrase(&mnemonic_phrase, Language::English) {


### PR DESCRIPTION
This is a legacy field from a long time ago when the import and import_from_legacy_root_entropy methods were combined. Since they have been separated, it no longer is necessary to specify the KDV