### PR TITLE
Fix the git sha returned by the version endpoint. It was broken by the Renovate bot.

### DIFF
--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -1093,7 +1093,7 @@ where
                 env!("CARGO_PKG_VERSION_PATCH").to_string(),
                 env!("CARGO_PKG_VERSION_PRE").to_string(),
             ),
-            commit: env!("VERGEN_GIT_DESCRIBE").to_string(),
+            commit: env!("VERGEN_GIT_SHA").to_string(),
         },
     };
 

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1252,7 +1252,7 @@ where
                 env!("CARGO_PKG_VERSION_PATCH").to_string(),
                 env!("CARGO_PKG_VERSION_PRE").to_string(),
             ),
-            commit: env!("VERGEN_GIT_DESCRIBE").to_string(),
+            commit: env!("VERGEN_GIT_SHA").to_string(),
         },
     };
 


### PR DESCRIPTION
-
