### PR TITLE
Add token 8192, FauxUSD to mob cli's known tokens list

### DIFF
--- a/python/mobilecoin/token.py
+++ b/python/mobilecoin/token.py
@@ -30,6 +30,7 @@ class Token:
         return int(round(display_value * self.conversion_factor()))
 
 
+# FauxUSD is on TestNet and AlphaNet only. Not on MainNet.
 TOKENS = [
     Token(0, 'MobileCoin', 'MOB', 12, 4),
     Token(1, 'Electronic Dollar', 'eUSD', 6, 2),

--- a/python/mobilecoin/token.py
+++ b/python/mobilecoin/token.py
@@ -33,6 +33,7 @@ class Token:
 TOKENS = [
     Token(0, 'MobileCoin', 'MOB', 12, 4),
     Token(1, 'Electronic Dollar', 'eUSD', 6, 2),
+    Token(8192, 'Fauxble Dollar', 'FauxUSD', 6, 2),
 ]
 TOKENS_BY_ID = { t.token_id: t for t in TOKENS }
 TOKENS_BY_SHORT_CODE = { t.short_code.lower(): t for t in TOKENS }

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -156,7 +156,7 @@ async def test_network_status(client):
 
 
 async def test_network_status_fees(fees):
-    assert sorted( t.short_code for t in fees.keys() ) == ['MOB', 'eUSD']
+    assert sorted( t.short_code for t in fees.keys() ) == ['FauxUSD', 'MOB', 'eUSD']
     assert all( isinstance(a, Amount) for a in fees.values() )
 
 


### PR DESCRIPTION
### Motivation

Alpha and TestNet define token 8192, aka Fauxble Dollar aka FauxUSD.  The `mob` cli crashes when any FauxUSD has been used within an account that is imported to `mob`'s full-service. 

### In this PR

This PR adds token 8192 with 6 decimals and a display precision of 2 to the TOKENS table in tokens.py, allowing `mob` to be be more useful when used with TestNet and Alpha.