### PR TITLE
Filter by account and address

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1262,7 +1262,9 @@ impl TxoModel for Txo {
 
         if let Some(subaddress_b58) = assigned_subaddress_b58 {
             let subaddress = AssignedSubaddress::get(subaddress_b58, conn)?;
-            query = query.filter(txos::subaddress_index.eq(subaddress.subaddress_index));
+            query = query
+                .filter(txos::subaddress_index.eq(subaddress.subaddress_index))
+                .filter(txos::account_id.eq(subaddress.account_id));
         }
 
         if let Some(token_id) = token_id {
@@ -1328,7 +1330,9 @@ impl TxoModel for Txo {
 
         if let Some(subaddress_b58) = assigned_subaddress_b58 {
             let subaddress = AssignedSubaddress::get(subaddress_b58, conn)?;
-            query = query.filter(txos::subaddress_index.eq(subaddress.subaddress_index));
+            query = query
+                .filter(txos::subaddress_index.eq(subaddress.subaddress_index))
+                .filter(txos::account_id.eq(subaddress.account_id));
         }
 
         if let Some(token_id) = token_id {
@@ -1499,7 +1503,9 @@ impl TxoModel for Txo {
 
         if let Some(subaddress_b58) = assigned_subaddress_b58 {
             let subaddress = AssignedSubaddress::get(subaddress_b58, conn)?;
-            query = query.filter(txos::subaddress_index.eq(subaddress.subaddress_index));
+            query = query
+                .filter(txos::subaddress_index.eq(subaddress.subaddress_index))
+                .filter(txos::account_id.eq(subaddress.account_id));
         }
 
         if let Some(token_id) = token_id {
@@ -1596,7 +1602,9 @@ impl TxoModel for Txo {
 
         if let Some(subaddress_b58) = assigned_subaddress_b58 {
             let subaddress = AssignedSubaddress::get(subaddress_b58, conn)?;
-            query = query.filter(txos::subaddress_index.eq(subaddress.subaddress_index));
+            query = query
+                .filter(txos::subaddress_index.eq(subaddress.subaddress_index))
+                .filter(txos::account_id.eq(subaddress.account_id));
         }
 
         if let Some(token_id) = token_id {
@@ -1700,7 +1708,9 @@ impl TxoModel for Txo {
 
         if let Some(subaddress_b58) = assigned_subaddress_b58 {
             let subaddress = AssignedSubaddress::get(subaddress_b58, conn)?;
-            query = query.filter(txos::subaddress_index.eq(subaddress.subaddress_index));
+            query = query
+                .filter(txos::subaddress_index.eq(subaddress.subaddress_index))
+                .filter(txos::account_id.eq(subaddress.account_id));
         }
 
         if let Some(account_id_hex) = account_id_hex {


### PR DESCRIPTION
This is fixing a bug where we weren't filtering properly on account as well as address index when querying for txos at a specific subaddress, so if there were multiple accounts in the same instance of full service and one tried to query for balance at a specific address, it would report all txos at the specified subaddress index across all accounts.