### PR TITLE
add public_key to v1 transaction_log txo_abbrevs

### DIFF
--- a/full-service/src/json_rpc/v1/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v1/models/transaction_log.rs
@@ -145,11 +145,6 @@ impl TransactionLog {
         txo: &db::models::Txo,
         assigned_address: Option<String>,
     ) -> Result<Self, String> {
-        let public_key_hex = match txo.public_key() {
-            Ok(pk) => hex::encode(pk.as_bytes()),
-            Err(_) => "".to_string(),
-        };
-
         Ok(TransactionLog {
             object: "transaction_log".to_string(),
             transaction_log_id: txo.id.clone(),
@@ -164,7 +159,11 @@ impl TransactionLog {
                 txo_id_hex: txo.id.to_string(),
                 recipient_address_id: "".to_string(),
                 value_pmob: txo.value.to_string(),
-                public_key: public_key_hex,
+                public_key: hex::encode(
+                    txo.public_key()
+                        .map_err(|_| "failed to decode txo public key")?
+                        .as_bytes(),
+                ),
             }],
             change_txos: vec![],
             assigned_address_id: assigned_address,

--- a/full-service/src/json_rpc/v1/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v1/models/transaction_log.rs
@@ -145,6 +145,11 @@ impl TransactionLog {
         txo: &db::models::Txo,
         assigned_address: Option<String>,
     ) -> Result<Self, String> {
+        let public_key_hex = match txo.public_key() {
+            Ok(pk) => hex::encode(pk.as_bytes()),
+            Err(_) => "".to_string(),
+        };
+
         Ok(TransactionLog {
             object: "transaction_log".to_string(),
             transaction_log_id: txo.id.clone(),
@@ -159,7 +164,7 @@ impl TransactionLog {
                 txo_id_hex: txo.id.to_string(),
                 recipient_address_id: "".to_string(),
                 value_pmob: txo.value.to_string(),
-                public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
+                public_key: public_key_hex,
             }],
             change_txos: vec![],
             assigned_address_id: assigned_address,
@@ -250,11 +255,16 @@ pub struct TxoAbbrev {
 
 impl TxoAbbrev {
     pub fn new(txo: &db::models::Txo, recipient_address_id: String) -> Self {
+        let public_key_hex = match txo.public_key() {
+            Ok(pk) => hex::encode(pk.as_bytes()),
+            Err(_) => "".to_string(),
+        };
+
         Self {
             txo_id_hex: txo.id.clone(),
             recipient_address_id,
             value_pmob: (txo.value as u64).to_string(),
-            public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
+            public_key: public_key_hex,
         }
     }
 }

--- a/full-service/src/json_rpc/v1/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v1/models/transaction_log.rs
@@ -159,6 +159,7 @@ impl TransactionLog {
                 txo_id_hex: txo.id.to_string(),
                 recipient_address_id: "".to_string(),
                 value_pmob: txo.value.to_string(),
+                public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
             }],
             change_txos: vec![],
             assigned_address_id: assigned_address,
@@ -241,6 +242,10 @@ pub struct TxoAbbrev {
     /// Available pico MOB for this Txo.
     /// If the account is syncing, this value may change.
     pub value_pmob: String,
+
+    /// Hex encoded bytes of the public key of this txo, which can be found on
+    /// the blockchain.
+    pub public_key: String,
 }
 
 impl TxoAbbrev {
@@ -249,6 +254,7 @@ impl TxoAbbrev {
             txo_id_hex: txo.id.clone(),
             recipient_address_id,
             value_pmob: (txo.value as u64).to_string(),
+            public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
         }
     }
 }

--- a/full-service/src/json_rpc/v2/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v2/models/transaction_log.rs
@@ -138,10 +138,15 @@ pub struct OutputTxo {
 
 impl OutputTxo {
     pub fn new(txo: &db::models::Txo, recipient_public_address_b58: String) -> Self {
+        let public_key_hex = match txo.public_key() {
+            Ok(pk) => hex::encode(pk.as_bytes()),
+            Err(_) => "".to_string(),
+        };
+
         Self {
             txo_id: txo.id.clone(),
             txo_id_hex: txo.id.clone(),
-            public_key: hex::encode(txo.public_key().unwrap().as_bytes()),
+            public_key: public_key_hex,
             amount: Amount::from(&txo.amount()),
             recipient_public_address_b58,
         }


### PR DESCRIPTION
This is to support more easily finding the public key for input and output txos in a transaction