### PR TITLE
Update ledger refresh job to strip leading directory tar components

### DIFF
--- a/.github/workflows/refresh-ledger.yaml
+++ b/.github/workflows/refresh-ledger.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Unpack full-service
       run: |
         cd "${DOWNLOAD_DIR}"
-        tar --skip-old-files -xvzf linux.tar.gz
+        tar --skip-old-files --strip-components=1 --show-stored-names -xvzf linux.tar.gz
 
     - name: Run full-service - wait for ledger sync
       shell: bash


### PR DESCRIPTION
### Motivation

A previous change in the packaging directory structure of the releases did not include updates to the ledger-refresh process that keeps ledger data synced for testing.  This change fixes that.

### In this PR
* Strip leading directory component in the un-tar of the release package, to match previous behavior.

### Test Plan

* Only the GitHub action is updated, so no code changes were made.

### Future Work

* nothing forseen