### PR TITLE
add hw wallet account check prior to executing operations

### DIFF
--- a/full-service/src/service/models/tx_proposal.rs
+++ b/full-service/src/service/models/tx_proposal.rs
@@ -66,7 +66,7 @@ impl UnsignedTxProposal {
         match account.view_only {
             true => {
                 global_log::debug!("signing tx proposal with hardware wallet");
-                Ok(hardware_wallet::sign_tx_proposal(self).await?)
+                Ok(hardware_wallet::sign_tx_proposal(self, &account.view_account_key()?).await?)
             }
             false => {
                 global_log::debug!("signing tx proposal with local signer");


### PR DESCRIPTION
This adds a check to make sure the account is the expected one prior to executing the operations.