### PR TITLE
Account resyncing

### DIFF
--- a/full-service/migrations/2023-11-11-154436_force_account_resync/down.sql
+++ b/full-service/migrations/2023-11-11-154436_force_account_resync/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts DROP COLUMN resyncing;

--- a/full-service/migrations/2023-11-11-154436_force_account_resync/up.sql
+++ b/full-service/migrations/2023-11-11-154436_force_account_resync/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE accounts ADD COLUMN resyncing BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE accounts SET next_block_index = 0;
+UPDATE accounts SET resyncing = TRUE;

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -38,6 +38,7 @@ pub struct Account {
     /// and is required in order to spend funds and generate key images for this
     /// account.
     pub managed_by_hardware_wallet: bool,
+    pub resyncing: bool,
 }
 
 /// A structure that can be inserted to create a new entity in the `accounts`

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -13,6 +13,7 @@ diesel::table! {
         fog_enabled -> Bool,
         view_only -> Bool,
         managed_by_hardware_wallet -> Bool,
+        resyncing -> Bool,
     }
 }
 

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -120,12 +120,8 @@ where
     if service.resync_in_progress().map_err(format_error)? {
         let wallet_status = service.get_wallet_status().map_err(format_error)?;
 
-        let percent_complete = (wallet_status.min_synced_block_index as f64
-            / wallet_status.local_block_height as f64
-            * 100.0) as u64;
-
-        return Err(format_error(&format!(
-            "Resync in progress, please wait until it is completed to perform API calls... ({percent_complete}% complete)"
+        return Err(format_error(format!(
+            "Resync in progress, please wait until it is completed to perform API calls... ({}% complete)", wallet_status.percent_synced()
         )));
     }
 

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -117,6 +117,18 @@ where
 {
     global_log::info!("Running command {:?}", command);
 
+    if service.resync_in_progress().map_err(format_error)? {
+        let wallet_status = service.get_wallet_status().map_err(format_error)?;
+
+        let percent_complete = (wallet_status.min_synced_block_index as f64
+            / wallet_status.local_block_height as f64
+            * 100.0) as u64;
+
+        return Err(format_error(&format!(
+            "Resync in progress, please wait until it is completed to perform API calls... ({percent_complete}% complete)"
+        )));
+    }
+
     let response = match command {
         JsonCommandRequest::assign_address_for_account {
             account_id,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -142,12 +142,8 @@ where
     if service.resync_in_progress().map_err(format_error)? {
         let wallet_status = service.get_wallet_status().map_err(format_error)?;
 
-        let percent_complete = (wallet_status.min_synced_block_index as f64
-            / wallet_status.local_block_height as f64
-            * 100.0) as u64;
-
-        return Err(format_error(&format!(
-            "Resync in progress, please wait until it is completed to perform API calls... ({percent_complete}% complete)"
+        return Err(format_error(format!(
+            "Resync in progress, please wait until it is completed to perform API calls... ({}% complete)", wallet_status.percent_synced()
         )));
     }
 

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -139,6 +139,18 @@ where
 {
     global_log::info!("Running command {:?}", command);
 
+    if service.resync_in_progress().map_err(format_error)? {
+        let wallet_status = service.get_wallet_status().map_err(format_error)?;
+
+        let percent_complete = (wallet_status.min_synced_block_index as f64
+            / wallet_status.local_block_height as f64
+            * 100.0) as u64;
+
+        return Err(format_error(&format!(
+            "Resync in progress, please wait until it is completed to perform API calls... ({percent_complete}% complete)"
+        )));
+    }
+
     let response = match command {
         JsonCommandRequest::assign_address_for_account {
             account_id,

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -718,7 +718,12 @@ where
     }
 
     fn resync_in_progress(&self) -> Result<bool, AccountServiceError> {
-        let mut pooled_conn = self.get_pooled_conn()?;
+        let mut pooled_conn = match self.get_pooled_conn() {
+            Ok(pooled_conn) => Ok(pooled_conn),
+            Err(WalletDbError::WalletFunctionsDisabled) => return Ok(false),
+            Err(err) => Err(err),
+        }?;
+
         let conn = pooled_conn.deref_mut();
         Ok(Account::resync_in_progress(conn)?)
     }

--- a/full-service/src/service/account.rs
+++ b/full-service/src/service/account.rs
@@ -356,6 +356,8 @@ pub trait AccountService {
         &self, 
         account_id: &AccountID
     ) -> Result<bool, AccountServiceError>;
+
+    fn resync_in_progress(&self) -> Result<bool, AccountServiceError>;
 }
 
 #[async_trait]
@@ -713,6 +715,12 @@ where
             account.delete(conn)?;
             Ok(true)
         })
+    }
+
+    fn resync_in_progress(&self) -> Result<bool, AccountServiceError> {
+        let mut pooled_conn = self.get_pooled_conn()?;
+        let conn = pooled_conn.deref_mut();
+        Ok(Account::resync_in_progress(conn)?)
     }
 }
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -144,6 +144,12 @@ pub struct WalletStatus {
     pub account_map: HashMap<AccountID, Account>,
 }
 
+impl WalletStatus {
+    pub fn percent_synced(&self) -> u64 {
+        self.min_synced_block_index * 100 / self.local_block_height
+    }
+}
+
 /// Trait defining the ways in which the wallet can interact with and manage
 /// balances.
 #[rustfmt::skip]

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -126,7 +126,14 @@ pub fn sync_all_accounts(
 
     for account in accounts {
         // If there are no new blocks for this account, don't do anything.
+        //
+        // If the account is currently resyncing, we need to set it to false
+        // here.
         if account.next_block_index as u64 > num_blocks - 1 {
+            if account.resyncing {
+                account.update_resyncing(false, conn)?;
+            }
+
             continue;
         }
         sync_account_next_chunk(ledger_db, conn, &account.id, logger)?;


### PR DESCRIPTION
Forcing each account in the wallet to resync with the ledger from block index 0, which will cause each one to scan txos and pick up any Authorized Sender Memos that are found.

During this sync, normal API calls will be unavailable, and an error will be returned with the current percentage completed of the sync.

