### PR TITLE
Update mirror endpoints

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2159,7 +2159,7 @@ impl TxoModel for Txo {
             .as_ref()
             .map(|account_id| Account::get(&AccountID(account_id.to_string()), conn))
             .transpose()?)
-     }
+    }
 }
 
 fn add_authenticated_memo_to_database(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2154,14 +2154,12 @@ impl TxoModel for Txo {
     }
 
     fn account(&self, conn: Conn) -> Result<Option<Account>, WalletDbError> {
-        match &self.account_id {
-            Some(account_id) => Ok(Some(Account::get(
-                &AccountID(account_id.to_string()),
-                conn,
-            )?)),
-            None => Ok(None),
-        }
-    }
+        Ok(self
+            .account_id
+            .as_ref()
+            .map(|account_id| Account::get(&AccountID(account_id.to_string()), conn))
+            .transpose()?)
+     }
 }
 
 fn add_authenticated_memo_to_database(

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -741,6 +741,8 @@ pub trait TxoModel {
     /// If we created the txo, it would be the address at which we received it. Otherwise,
     /// it will require a lookup of who we sent it to in the transaction_txo_outputs table
     fn recipient_public_address(&self, conn: Conn) -> Result<Option<PublicAddress>, WalletDbError>;
+
+    fn account(&self, conn: Conn) -> Result<Option<Account>, WalletDbError>;
 }
 
 impl TxoModel for Txo {
@@ -2148,6 +2150,16 @@ impl TxoModel for Txo {
             // The rest are either orphaned txos or invalid states we should never hit, which we
             // both want to ignore
             _ => Ok(None),
+        }
+    }
+
+    fn account(&self, conn: Conn) -> Result<Option<Account>, WalletDbError> {
+        match &self.account_id {
+            Some(account_id) => Ok(Some(Account::get(
+                &AccountID(account_id.to_string()),
+                conn,
+            )?)),
+            None => Ok(None),
         }
     }
 }

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -273,7 +273,6 @@ pub enum JsonCommandRequest {
         confirmation: String,
     },
     validate_sender_memo {
-        account_id: String,
         txo_id: String,
         sender_address: String,
     },

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1435,12 +1435,11 @@ where
             JsonCommandResponse::validate_confirmation { validated: result }
         }
         JsonCommandRequest::validate_sender_memo {
-            account_id,
             txo_id,
             sender_address,
         } => {
             let result = service
-                .validate_sender_memo(&AccountID(account_id), &txo_id, &sender_address)
+                .validate_sender_memo(&txo_id, &sender_address)
                 .map_err(format_error)?;
             JsonCommandResponse::validate_sender_memo { validated: result }
         }

--- a/full-service/src/service/memo.rs
+++ b/full-service/src/service/memo.rs
@@ -96,9 +96,8 @@ where
         let conn = pooled_conn.deref_mut();
 
         let txo = Txo::get(txo_id_hex, conn)?;
-        let account = match txo.account(conn)? {
-            Some(account) => account,
-            None => return Ok(false),
+        let Some(account) = txo.account(conn)? else {
+            return Ok(false);
         };
 
         let account_key = account.account_key()?;

--- a/full-service/src/service/memo.rs
+++ b/full-service/src/service/memo.rs
@@ -1,15 +1,10 @@
 use crate::{
-    db::{
-        account::{AccountID, AccountModel},
-        models::Account,
-        WalletDbError,
-    },
+    db::{account::AccountModel, models::Txo, txo::TxoModel, WalletDbError},
     service::ledger::{LedgerService, LedgerServiceError},
     util::b58::{b58_decode_public_address, B58Error},
     WalletService,
 };
 use displaydoc::Display;
-use mc_account_keys::AccountKey;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_crypto_keys::RistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
@@ -80,7 +75,6 @@ impl From<MemoDecodingError> for MemoServiceError {
 pub trait MemoService {
     fn validate_sender_memo(
         &self,
-        account_id: &AccountID,
         txo_id_hex: &str,
         sender_address: &str,
     ) -> Result<bool, MemoServiceError>;
@@ -93,7 +87,6 @@ where
 {
     fn validate_sender_memo(
         &self,
-        account_id: &AccountID,
         txo_id_hex: &str,
         sender_address: &str,
     ) -> Result<bool, MemoServiceError> {
@@ -102,13 +95,18 @@ where
         let mut pooled_conn = self.get_pooled_conn()?;
         let conn = pooled_conn.deref_mut();
 
-        let account = Account::get(account_id, conn)?;
-        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+        let txo = Txo::get(txo_id_hex, conn)?;
+        let account = match txo.account(conn)? {
+            Some(account) => account,
+            None => return Ok(false),
+        };
 
-        let txo = self.get_txo_object(txo_id_hex)?;
+        let account_key = account.account_key()?;
+
+        let tx_out = self.get_txo_object(txo_id_hex)?;
         let shared_secret =
-            account.get_shared_secret(&RistrettoPublic::try_from(&txo.public_key)?)?;
-        let memo_payload = match txo.e_memo {
+            account.get_shared_secret(&RistrettoPublic::try_from(&tx_out.public_key)?)?;
+        let memo_payload = match tx_out.e_memo {
             Some(e_memo) => e_memo.decrypt(&shared_secret),
             None => UnusedMemo.into(),
         };
@@ -118,7 +116,7 @@ where
                 .validate(
                     &sender_address,
                     account_key.view_private_key(),
-                    &txo.public_key,
+                    &tx_out.public_key,
                 )
                 .into()),
             Ok(_) => Err(MemoServiceError::InvalidMemoTypeForValidation),

--- a/mirror/src/private/main.rs
+++ b/mirror/src/private/main.rs
@@ -40,6 +40,7 @@ const SUPPORTED_ENDPOINTS: &[&str] = &[
     "get_transaction_log",
     "get_wallet_status",
     "validate_confirmation",
+    "validate_sender_memo",
     "verify_address",
     "get_txos",
     "get_all_accounts",


### PR DESCRIPTION
Updating the mirror to include validate sender memo as a whitelisted API call

Updating the validate sender memo to not require account id, as it can be derived from the txo that is being validated