### PR TITLE
Feature/destination memos

### DIFF
--- a/full-service/migrations/2023-11-27-175035_destination_memos/down.sql
+++ b/full-service/migrations/2023-11-27-175035_destination_memos/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE destination_memos;

--- a/full-service/migrations/2023-11-27-175035_destination_memos/up.sql
+++ b/full-service/migrations/2023-11-27-175035_destination_memos/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE destination_memos (
+  txo_id TEXT PRIMARY KEY NOT NULL,
+  recipient_address_hash TEXT NOT NULL,
+  num_recipients INT NOT NULL,
+  fee UNSIGNED BIG INT NOT NULL,
+  total_outlay UNSIGNED BIG INT NOT NULL,
+  payment_request_id UNSIGNED BIG INT,
+  payment_intent_id UNSIGNED BIG INT,
+  FOREIGN KEY (txo_id) REFERENCES txos(id)
+);
+
+UPDATE accounts SET next_block_index = 0;
+UPDATE accounts SET resyncing = TRUE;

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -4,7 +4,8 @@
 
 use super::schema::{
     __diesel_schema_migrations, accounts, assigned_subaddresses, authenticated_sender_memos,
-    gift_codes, transaction_input_txos, transaction_logs, transaction_output_txos, txos,
+    destination_memos, gift_codes, transaction_input_txos, transaction_logs,
+    transaction_output_txos, txos,
 };
 use mc_crypto_keys::CompressedRistrettoPublic;
 use serde::Serialize;
@@ -252,6 +253,32 @@ pub struct AuthenticatedSenderMemo {
 pub struct NewAuthenticatedSenderMemo<'a> {
     pub txo_id: &'a str,
     pub sender_address_hash: &'a str,
+    pub payment_request_id: Option<i64>,
+    pub payment_intent_id: Option<i64>,
+}
+
+#[derive(Clone, Serialize, Associations, Identifiable, Queryable, PartialEq, Eq, Debug)]
+#[diesel(belongs_to(Txo, foreign_key = txo_id))]
+#[diesel(table_name = destination_memos)]
+#[diesel(primary_key(txo_id))]
+pub struct DestinationMemo {
+    pub txo_id: String,
+    pub recipient_address_hash: String,
+    pub num_recipients: i8,
+    pub fee: i64,
+    pub total_outlay: i64,
+    pub payment_request_id: Option<i64>,
+    pub payment_intent_id: Option<i64>,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = destination_memos)]
+pub struct NewDestinationMemo<'a> {
+    pub txo_id: &'a str,
+    pub recipient_address_hash: &'a str,
+    pub num_recipients: i8,
+    pub fee: i64,
+    pub total_outlay: i64,
     pub payment_request_id: Option<i64>,
     pub payment_intent_id: Option<i64>,
 }

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -264,7 +264,7 @@ pub struct NewAuthenticatedSenderMemo<'a> {
 pub struct DestinationMemo {
     pub txo_id: String,
     pub recipient_address_hash: String,
-    pub num_recipients: i8,
+    pub num_recipients: i32,
     pub fee: i64,
     pub total_outlay: i64,
     pub payment_request_id: Option<i64>,
@@ -276,7 +276,7 @@ pub struct DestinationMemo {
 pub struct NewDestinationMemo<'a> {
     pub txo_id: &'a str,
     pub recipient_address_hash: &'a str,
-    pub num_recipients: i8,
+    pub num_recipients: i32,
     pub fee: i64,
     pub total_outlay: i64,
     pub payment_request_id: Option<i64>,

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -37,6 +37,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    destination_memos (txo_id) {
+        txo_id -> Text,
+        recipient_address_hash -> Text,
+        num_recipients -> Integer,
+        fee -> BigInt,
+        total_outlay -> BigInt,
+        payment_request_id -> Nullable<BigInt>,
+        payment_intent_id -> Nullable<BigInt>,
+    }
+}
+
+diesel::table! {
     gift_codes (id) {
         id -> Integer,
         gift_code_b58 -> Text,
@@ -115,6 +127,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     accounts,
     assigned_subaddresses,
     authenticated_sender_memos,
+    destination_memos,
     gift_codes,
     transaction_input_txos,
     transaction_logs,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2171,11 +2171,10 @@ impl TxoModel for Txo {
     }
 
     fn account(&self, conn: Conn) -> Result<Option<Account>, WalletDbError> {
-        Ok(self
-            .account_id
+        self.account_id
             .as_ref()
             .map(|account_id| Account::get(&AccountID(account_id.to_string()), conn))
-            .transpose()?)
+            .transpose()
     }
 }
 
@@ -2203,6 +2202,7 @@ fn add_authenticated_memo_to_database(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_destination_memo_to_database(
     txo_id: &str,
     recipient_address_hash: &str,

--- a/full-service/src/json_rpc/v2/models/memo.rs
+++ b/full-service/src/json_rpc/v2/models/memo.rs
@@ -1,6 +1,12 @@
 // Copyright (c) 2020-2023 MobileCoin Inc.
 
-use crate::db::{models::AuthenticatedSenderMemo as AuthenticatedSenderMemoDbModel, txo::TxoMemo};
+use crate::db::{
+    models::{
+        AuthenticatedSenderMemo as AuthenticatedSenderMemoDbModel,
+        DestinationMemo as DestinationMemoDbModel,
+    },
+    txo::TxoMemo,
+};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
@@ -8,6 +14,7 @@ pub enum Memo {
     #[default]
     Unused,
     AuthenticatedSender(AuthenticatedSenderMemo),
+    Destination(DestinationMemo),
 }
 
 /// This represents data that is included in any of:
@@ -31,10 +38,38 @@ impl From<&AuthenticatedSenderMemoDbModel> for AuthenticatedSenderMemo {
     }
 }
 
+/// This represents data that is included in any of:
+/// * DestinationMemo,
+/// * DestinationWithPaymentRequest
+/// * DestinationWithPaymentIntent
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct DestinationMemo {
+    pub recipient_address_hash: String,
+    pub num_recipients: String,
+    pub fee: String,
+    pub total_outlay: String,
+    pub payment_request_id: Option<String>,
+    pub payment_intent_id: Option<String>,
+}
+
+impl From<&DestinationMemoDbModel> for DestinationMemo {
+    fn from(memo: &DestinationMemoDbModel) -> Self {
+        DestinationMemo {
+            recipient_address_hash: memo.recipient_address_hash.clone(),
+            num_recipients: memo.num_recipients.to_string(),
+            fee: memo.fee.to_string(),
+            total_outlay: memo.total_outlay.to_string(),
+            payment_request_id: memo.payment_request_id.map(|id| id.to_string()),
+            payment_intent_id: memo.payment_intent_id.map(|id| id.to_string()),
+        }
+    }
+}
+
 impl From<&TxoMemo> for Memo {
     fn from(memo: &TxoMemo) -> Self {
         match memo {
             TxoMemo::AuthenticatedSender(memo) => Memo::AuthenticatedSender(memo.into()),
+            TxoMemo::Destination(memo) => Memo::Destination(memo.into()),
             TxoMemo::Unused => Memo::Unused,
         }
     }


### PR DESCRIPTION
This PR adds destination memos to txos in the wallet database in a decrypted state to allow for querying, similar to #925 

Future Work will be to add some API endpoint to query this information (or maybe we include it in this PR, based on reviews)