### PR TITLE
fixes to integration tests

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -92,7 +92,6 @@ async def source_account(client):
 
 @pytest.fixture(scope='session')
 async def account_factory(client, source_account, fees):
-
     network_status = await client.get_network_status()
     local_block_height = int(network_status['local_block_height'])
 
@@ -114,11 +113,14 @@ async def account_factory(client, source_account, fees):
             return temp_account
 
         async def create_fog(self):
+            fog_info = {
+                "report_url": os.environ["MC_FOG_REPORT_URL"],
+                "authority_spki": os.environ["MC_FOG_AUTHORITY_SPKI"],
+            }
             temp_fog_account = await client.import_account(
                 mnemonic=self.next_mnemonic(),
                 first_block_index=local_block_height - 1000,
-                fog_report_url=os.environ['MC_FOG_REPORT_URL'],
-                fog_authority_spki=os.environ['MC_FOG_AUTHORITY_SPKI'],
+                fog_info=fog_info,
             )
             self.temp_accounts.append(temp_fog_account)
             return temp_fog_account

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -75,6 +75,7 @@ async def test_account_status(client, source_account):
         'id',
         'key_derivation_version',
         'main_address',
+        'managed_by_hardware_wallet',
         'name',
         'next_block_index',
         'next_subaddress_index',


### PR DESCRIPTION
### Motivation

3 of the integration tests full-service were always failing because of issues with the test or testing fixtures

### In this PR
- Update`create_fog` account creating fixture to pass fog information in the format that `import_account` expects.
- Update the `account_status` test to include `managed_by_hardware_wallet` in the list of expected account status keys.
