### PR TITLE
Remove command substitution in help message

### DIFF
--- a/tools/build-fs.sh
+++ b/tools/build-fs.sh
@@ -26,7 +26,7 @@ usage()
     echo "                SGX_MODE IAS_MODE CONSENSUS_ENCLAVE_CSS INGEST_ENCLAVE_CSS"
     echo "    check"
     echo "                Sets build parameters to those used for network=local, and"
-    echo "                runs `cargo check`"
+    echo "                runs 'cargo check'"
 }
 
 while (( "$#" ))


### PR DESCRIPTION
Previously there was a command substitution '`cargo check`' in the help
message for `tools/build-fs.sh`. This resulted in `cargo check` being
executed when the help message was printed. Now single quotes are used
around the 'cargo check' text to separate it from the rest of the text
in the help message.

