### PR TITLE
Feature/short address hash

### DIFF
--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -102,6 +102,7 @@ pub enum JsonCommandResponse {
     },
     get_address_details {
         details: PublicAddress,
+        short_address_hash: String,
     },
     get_address {
         address: Address,

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -102,7 +102,7 @@ pub enum JsonCommandResponse {
     },
     get_address_details {
         details: PublicAddress,
-        short_address_hash: String,
+        address_hash: String,
     },
     get_address {
         address: Address,
@@ -215,7 +215,7 @@ pub enum JsonCommandResponse {
     },
     verify_address {
         verified: bool,
-        short_address_hash: Option<String>,
+        address_hash: Option<String>,
     },
     version {
         string: String,

--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -215,6 +215,7 @@ pub enum JsonCommandResponse {
     },
     verify_address {
         verified: bool,
+        short_address_hash: Option<String>,
     },
     version {
         string: String,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -54,7 +54,7 @@ use crate::{
         PrintableWrapperType,
     },
 };
-use mc_account_keys::{burn_address, DEFAULT_SUBADDRESS_INDEX};
+use mc_account_keys::{ShortAddressHash, burn_address, DEFAULT_SUBADDRESS_INDEX};
 use mc_blockchain_types::BlockVersion;
 use mc_common::logger::global_log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
@@ -691,6 +691,7 @@ where
 
             JsonCommandResponse::get_address_details {
                 details: PublicAddress::from(&address),
+                short_address_hash: hex::encode(ShortAddressHash::from(&address).as_ref()),
             }
         }
         JsonCommandRequest::get_address_for_account { account_id, index } => {

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -54,7 +54,7 @@ use crate::{
         PrintableWrapperType,
     },
 };
-use mc_account_keys::{ShortAddressHash, burn_address, DEFAULT_SUBADDRESS_INDEX};
+use mc_account_keys::{burn_address, ShortAddressHash, DEFAULT_SUBADDRESS_INDEX};
 use mc_blockchain_types::BlockVersion;
 use mc_common::logger::global_log;
 use mc_connection::{BlockchainConnection, UserTxConnection};
@@ -1444,18 +1444,18 @@ where
                 .map_err(format_error)?;
             JsonCommandResponse::validate_sender_memo { validated: result }
         }
-        JsonCommandRequest::verify_address { address } => {
-            match service.verify_address(&address) {
-                Ok(public_address) => JsonCommandResponse::verify_address {
-                    verified: true,
-                    short_address_hash: Some(hex::encode(ShortAddressHash::from(&public_address).as_ref())),
-                },
-                Err(_) => JsonCommandResponse::verify_address {
-                    verified: false,
-                    short_address_hash: None,
-                },
-            }
-        }      
+        JsonCommandRequest::verify_address { address } => match service.verify_address(&address) {
+            Ok(public_address) => JsonCommandResponse::verify_address {
+                verified: true,
+                short_address_hash: Some(hex::encode(
+                    ShortAddressHash::from(&public_address).as_ref(),
+                )),
+            },
+            Err(_) => JsonCommandResponse::verify_address {
+                verified: false,
+                short_address_hash: None,
+            },
+        },
         JsonCommandRequest::version => JsonCommandResponse::version {
             string: env!("CARGO_PKG_VERSION").to_string(),
             number: (

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -691,7 +691,7 @@ where
 
             JsonCommandResponse::get_address_details {
                 details: PublicAddress::from(&address),
-                short_address_hash: hex::encode(ShortAddressHash::from(&address).as_ref()),
+                address_hash: hex::encode(ShortAddressHash::from(&address).as_ref()),
             }
         }
         JsonCommandRequest::get_address_for_account { account_id, index } => {
@@ -1447,13 +1447,13 @@ where
         JsonCommandRequest::verify_address { address } => match service.verify_address(&address) {
             Ok(public_address) => JsonCommandResponse::verify_address {
                 verified: true,
-                short_address_hash: Some(hex::encode(
+                address_hash: Some(hex::encode(
                     ShortAddressHash::from(&public_address).as_ref(),
                 )),
             },
             Err(_) => JsonCommandResponse::verify_address {
                 verified: false,
-                short_address_hash: None,
+                address_hash: None,
             },
         },
         JsonCommandRequest::version => JsonCommandResponse::version {

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1444,9 +1444,18 @@ where
                 .map_err(format_error)?;
             JsonCommandResponse::validate_sender_memo { validated: result }
         }
-        JsonCommandRequest::verify_address { address } => JsonCommandResponse::verify_address {
-            verified: service.verify_address(&address).is_ok(),
-        },
+        JsonCommandRequest::verify_address { address } => {
+            match service.verify_address(&address) {
+                Ok(public_address) => JsonCommandResponse::verify_address {
+                    verified: true,
+                    short_address_hash: Some(hex::encode(ShortAddressHash::from(&public_address).as_ref())),
+                },
+                Err(_) => JsonCommandResponse::verify_address {
+                    verified: false,
+                    short_address_hash: None,
+                },
+            }
+        }      
         JsonCommandRequest::version => JsonCommandResponse::version {
             string: env!("CARGO_PKG_VERSION").to_string(),
             number: (


### PR DESCRIPTION
### Motivation

full-service decrypts and returns sender and destination memos as part of the response when using the `get_txo` and `get_txos` API request methods.  These memo formats identify the sender or recipient of a MobileCoin transaction to enable recovering transaction history from the blockchain. To save space in the ledger, as well as preserve privacy, the counterparty is identified via a `short address hash` of their full public address. Users of the full-service API need a way to generate the `short address hash` from the B58 public addresses that they have for their contacts, to aid in identifying transaction counterparties via these memos.

(Side note: full-service can only decrypt the memo on txos that are owned by accounts for which it has the view private key.)

### In this PR

We `add short_address_hash` as part of the response to `verify_address` and `get_address_details`, two methods that full-service provides for working with B58 Public Addresses.