### PR TITLE
update ci and release workflows to use mco-dev-large-x64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mco-dev-large-x64
     container:
       image: mobilecoin/rust-sgx-base:v0.0.28
     steps:
@@ -68,7 +68,7 @@ jobs:
           cargo clippy --all --all-features
 
   test:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mco-dev-large-x64
     container:
       image: mobilecoin/rust-sgx-base:v0.0.28
 
@@ -125,7 +125,7 @@ jobs:
           CODECOV_TOKEN: 5be757b6-e923-40f2-80ea-5deac1e02b1e
 
   docs:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mco-dev-large-x64
     container:
       image: mobilecoin/rust-sgx-base:v0.0.28
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: mco-dev-large-x64
     # Needs write permission for publishing release
     permissions:
       contents: write


### PR DESCRIPTION
### Motivation

ci workflows not being picked up by any runner.

### In this PR

changed ci and release workflows from using runs-on: [self-hosted, Linux, large] to runs-on: mco-dev-large-x64
