### PR TITLE
Fixes a bug where (Signal) receiver_receipts could not be decoded with view_only FS.

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -6,7 +6,7 @@ use diesel::{
     dsl::{count, exists, not},
     prelude::*,
 };
-use mc_account_keys::{AccountKey, PublicAddress};
+use mc_account_keys::{ViewAccountKey, AccountKey, PublicAddress};
 use mc_common::{logger::global_log, HashMap};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
@@ -1953,7 +1953,7 @@ impl TxoModel for Txo {
         let txo = Txo::get(txo_id_hex, conn)?;
         let public_key: RistrettoPublic = mc_util_serial::decode(&txo.public_key)?;
         let account = Account::get(account_id, conn)?;
-        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+        let account_key: ViewAccountKey = mc_util_serial::decode(&account.account_key)?;
         Ok(confirmation.validate(&public_key, account_key.view_private_key()))
     }
 

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -20,7 +20,7 @@ use crate::{
     WalletService,
 };
 use displaydoc::Display;
-use mc_account_keys::AccountKey;
+use mc_account_keys::ViewAccountKey;
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 use mc_fog_report_validation::FogPubkeyResolver;
@@ -237,7 +237,7 @@ where
         }
 
         // Decrypt the amount to get the expected value
-        let account_key: AccountKey = mc_util_serial::decode(&account.account_key)?;
+        let account_key: ViewAccountKey = mc_util_serial::decode(&account.account_key)?;
         let public_key: RistrettoPublic = RistrettoPublic::try_from(&receiver_receipt.public_key)?;
         let shared_secret = get_tx_out_shared_secret(account_key.view_private_key(), &public_key);
         let expected_value = match receiver_receipt.amount.get_value(&shared_secret) {


### PR DESCRIPTION
Use ViewAccountKey instead of AccountKey to use support check_receiver_receipt in view_only mode.

### Motivation

Allows view-only FS accounts to process incoming Signal transactions.

### In this PR

* We decode the AccountKey only as a ViewAccountKey when we just need to access the view_private_key and not the spend_private_key field.

### Test Plan

I tested it manually, ie - with a bot.

### Future Work
* Add test to ensure view-only decoding of receiver receipts is supported.
* Document how/why to limit access to spend_private_key.

