### PR TITLE
Chore/uprev ci tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           - runner-tags: [self-hosted, macOS, ARM64]
             container: ""
           - runner-tags: [self-hosted, Linux, large]
-            container: mobilecoin/rust-sgx-base:v0.0.28
+            container: mobilecoin/rust-sgx-base:v0.0.32
           - namespace: test
             network: testnet
           - namespace: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   lint:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.28
+      image: mobilecoin/rust-sgx-base:v0.0.32
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
   test:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.28
+      image: mobilecoin/rust-sgx-base:v0.0.32
 
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
   docs:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.28
+      image: mobilecoin/rust-sgx-base:v0.0.32
 
     permissions:
       contents: write

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -27,7 +27,7 @@
 #         # - chain_id: main
 #     runs-on: [self-hosted, Linux, large-cd]
 #     container:
-#       image: mobilecoin/rust-sgx-base:v0.0.28
+#       image: mobilecoin/rust-sgx-base:v0.0.32
 #     steps:
 #       - name: Checkout
 #         uses: mobilecoinofficial/gh-actions/checkout@v0
@@ -71,7 +71,7 @@
 #         # - chain_id: main
 #         #   peer: mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/
 #         #   tx_source_url: https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com/,https://ledger.mobilecoinww.com/node2.prod.mobilecoinww.com/
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     needs:
 #       - build
 #     steps:
@@ -156,7 +156,7 @@
 #         chart:
 #           - full-service
 #           # - full-service-mirror
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     needs:
 #       - publish
 #     env:
@@ -257,7 +257,7 @@
 #         #   mnemonic_secret: MAIN_ACCOUNT_MNEMONIC
 #         #   account_first_block_var: MAIN_ACCOUNT_FIRST_BLOCK_INDEX
 #         #   fog_authority_spki_var: MAIN_FOG_AUTHORITY_SPKI
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     needs:
 #       - deploy
 #     container:
@@ -333,7 +333,7 @@
 #         chart:
 #           - full-service
 #           # - full-service-mirror
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     needs:
 #       - integration-test
 #     steps:

--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -25,7 +25,7 @@
 #         network:
 #           - chain_id: test
 #         # - chain_id: main
-#     runs-on: [self-hosted, Linux, large-cd]
+#     runs-on: mco-dev-large-x64
 #     container:
 #       image: mobilecoin/rust-sgx-base:v0.0.32
 #     steps:

--- a/.github/workflows/dev-delete-cd.yaml
+++ b/.github/workflows/dev-delete-cd.yaml
@@ -10,7 +10,7 @@
 # jobs:
 #   metadata:
 #     if: startsWith(github.event.ref, 'feature/')
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     outputs:
 #       namespace: ${{ steps.meta.outputs.namespace }}
 #     steps:
@@ -24,7 +24,7 @@
 #   delete:
 #     needs:
 #       - metadata
-#     runs-on: [self-hosted, Linux, small]
+#     runs-on: mco-dev-small-x64
 #     steps:
 #       - name: Delete namespace
 #         uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/refresh-ledger.yaml
+++ b/.github/workflows/refresh-ledger.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   refresh-ledger:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mco-dev-small-x64
     container:
       image: mobilecoin/gha-azure-helper:latest
     strategy:

--- a/.internal-ci/docker/Dockerfile.full-service-with-build
+++ b/.internal-ci/docker/Dockerfile.full-service-with-build
@@ -28,7 +28,7 @@
 # In order to create a consistent and verifiable the build environment, only add
 # or update in the mobilecoin/rust-sgx-base image and refer to the image by its hash.
 
-FROM mobilecoin/rust-sgx-base:v0.0.28 as builder
+FROM mobilecoin/rust-sgx-base:v0.0.32 as builder
 
 ARG NAMESPACE=test
 ARG SIGNED_ENCLAVE_BASE=enclave-distribution.${NAMESPACE}.mobilecoin.com

--- a/.internal-ci/docker/Dockerfile.full-service-with-build
+++ b/.internal-ci/docker/Dockerfile.full-service-with-build
@@ -59,15 +59,15 @@ RUN  --mount=type=cache,target=/opt/cargo/git \
   --mount=type=cache,target=/opt/cargo/registry/index \
   --mount=type=cache,target=/opt/cargo/registry/cache \
   --mount=type=cache,target=/app/target \
-  cargo build --locked --release ${BUILD_OPTS}
-
-RUN cp /app/target/release/full-service /usr/local/bin/
-RUN cp /app/target/release/signer /usr/local/bin/
-RUN cp /app/target/release/signer-service /usr/local/bin/
-RUN cp /app/target/release/validator-service /usr/local/bin/
-RUN cp /app/target/release/wallet-service-mirror-private /usr/local/bin/
-RUN cp /app/target/release/wallet-service-mirror-public /usr/local/bin/
-RUN cp /app/target/release/generate-rsa-keypair /usr/local/bin/
+  cargo build --locked --release ${BUILD_OPTS} \
+  && cp /app/target/release/full-service \ 
+        /app/target/release/signer \
+        /app/target/release/signer-service \
+        /app/target/release/validator-service \
+        /app/target/release/wallet-service-mirror-private \
+        /app/target/release/wallet-service-mirror-public \
+        /app/target/release/generate-rsa-keypair \
+          /usr/local/bin/ 
 
 # This is the runtime container.
 # Adding/updating OS will not affect the ability to verify the build environment.


### PR DESCRIPTION
### In this PR

* update version of mobilecoin/rust-sgx-base to use to v0.0.32
* update various runners to current preferred ones
* fix to `Dockerfile.full-service-with-build` to copy a build's executable artifacts from the `/app/target` specialized cache within the same RUN layer as does the `cargo build`.  Previously, the numerous `RUN cp /app/target/...` commands failed because `/app/target/` has been mounted from a cache in the `cargo build` layer and was not present in these layers.