### PR TITLE
Fix refresh ledger

### DIFF
--- a/.github/workflows/refresh-ledger.yaml
+++ b/.github/workflows/refresh-ledger.yaml
@@ -50,8 +50,8 @@ jobs:
 
     - name: Install libdbus and libusb dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libdbus-1-3 libusb-1.0-0
+        apt-get update
+        apt-get install -y libdbus-1-3 libusb-1.0-0
 
     - name: Run full-service - wait for ledger sync
       shell: bash

--- a/.github/workflows/refresh-ledger.yaml
+++ b/.github/workflows/refresh-ledger.yaml
@@ -48,6 +48,11 @@ jobs:
         cd "${DOWNLOAD_DIR}"
         tar --skip-old-files --strip-components=1 --show-stored-names -xvzf linux.tar.gz
 
+    - name: Install libdbus and libusb dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libdbus-1-3 libusb-1.0-0
+
     - name: Run full-service - wait for ledger sync
       shell: bash
       env:


### PR DESCRIPTION
### Motivation

refresh-ledger github action workflow failing because of libraries missing in container

### In this PR

install libdbus-1-3 and libusb-1.0-0 before running full-service.