### PR TITLE
Bugfix/value pmob cast

### DIFF
--- a/full-service/src/json_rpc/v1/models/transaction_log.rs
+++ b/full-service/src/json_rpc/v1/models/transaction_log.rs
@@ -165,7 +165,7 @@ impl TransactionLog {
             output_txos: vec![TxoAbbrev {
                 txo_id_hex: txo.id.to_string(),
                 recipient_address_id: "".to_string(),
-                value_pmob: txo.value.to_string().into(),
+                value_pmob: (txo.value as u64).to_string().into(),
                 public_key: hex::encode(
                     txo.public_key()
                         .map_err(|_| "failed to decode txo public key")?
@@ -174,7 +174,7 @@ impl TransactionLog {
             }],
             change_txos: vec![],
             assigned_address_id: assigned_address,
-            value_pmob: txo.value.to_string().into(),
+            value_pmob: (txo.value as u64).to_string().into(),
             fee_pmob: Secret::new(None),
             submitted_block_index: Secret::new(None),
             finalized_block_index: Secret::new(

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -254,7 +254,7 @@ where
             return Ok((
                 ReceiptTransactionStatus::AmountMismatch(format!(
                     "Expected: {}, Got: {}",
-                    expected_value.value, txo_info.txo.value
+                    expected_value.value, (txo_info.txo.value as u64)
                 )),
                 Some(txo_info),
             ));

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -254,7 +254,8 @@ where
             return Ok((
                 ReceiptTransactionStatus::AmountMismatch(format!(
                     "Expected: {}, Got: {}",
-                    expected_value.value, (txo_info.txo.value as u64)
+                    expected_value.value,
+                    (txo_info.txo.value as u64)
                 )),
                 Some(txo_info),
             ));


### PR DESCRIPTION
### Motivation

The wallet database doesn't store u64s and full-service casts u64s to i64 for storage.  In a few places, those values being retrieved from the database were not being cast back to u64 before being used, notably in transaction_log processing and receipt processing.

### In this PR
* fixed two missing u64 casts in v1 transaction_log retrieval
* fixed a missing u64 cast when forming an response indicating that that a receipt's value doesn't match the txo.