### PR TITLE
Update function parameters when calling mobilecoind::UnspentTxOut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-crypto-memo-mac"
+version = "6.0.0"
+dependencies = [
+ "hmac",
+ "mc-crypto-keys",
+ "sha2",
+]
+
+[[package]]
 name = "mc-crypto-message-cipher"
 version = "6.0.0"
 dependencies = [
@@ -4049,12 +4058,12 @@ dependencies = [
  "cfg-if",
  "curve25519-dalek",
  "displaydoc",
- "hmac",
  "mc-account-keys",
  "mc-core",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
+ "mc-crypto-memo-mac",
  "mc-crypto-ring-signature",
  "mc-crypto-ring-signature-signer",
  "mc-transaction-core",
@@ -4070,7 +4079,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
- "sha2",
  "subtle",
  "zeroize",
 ]

--- a/full-service/src/json_rpc/v1/models/tx_proposal.rs
+++ b/full-service/src/json_rpc/v1/models/tx_proposal.rs
@@ -10,6 +10,7 @@ use mc_common::HashMap;
 use mc_mobilecoind_json::data_types::{JsonOutlayV2, JsonTx, JsonUnspentTxOut};
 
 use mc_transaction_extra::TxOutConfirmationNumber;
+use mc_transaction_core::MemoPayload;
 use redact::{expose_secret, Secret};
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -57,6 +58,7 @@ impl TryFrom<&TxProposalServiceModel> for mc_mobilecoind::payments::TxProposal {
                 attempted_spend_height: 0,
                 attempted_spend_tombstone: 0,
                 token_id: *input_txo.amount.token_id,
+                memo_payload: MemoPayload::default().into()
             })
             .collect();
 

--- a/full-service/src/json_rpc/v1/models/tx_proposal.rs
+++ b/full-service/src/json_rpc/v1/models/tx_proposal.rs
@@ -9,8 +9,8 @@ use crate::{
 use mc_common::HashMap;
 use mc_mobilecoind_json::data_types::{JsonOutlayV2, JsonTx, JsonUnspentTxOut};
 
-use mc_transaction_extra::TxOutConfirmationNumber;
 use mc_transaction_core::MemoPayload;
+use mc_transaction_extra::TxOutConfirmationNumber;
 use redact::{expose_secret, Secret};
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -58,7 +58,7 @@ impl TryFrom<&TxProposalServiceModel> for mc_mobilecoind::payments::TxProposal {
                 attempted_spend_height: 0,
                 attempted_spend_tombstone: 0,
                 token_id: *input_txo.amount.token_id,
-                memo_payload: MemoPayload::default().into()
+                memo_payload: MemoPayload::default().into(),
             })
             .collect();
 


### PR DESCRIPTION
### Motivation & In This PR

The 6.0 release branch of the mobilecoin.git core repo, on top of which full-service is currently being built, contains a breaking change to the mobilecoind::UnspentTxOut function.  This PR updates full-service to be compatible.


