### PR TITLE
Introduce Spend Only from Subaddress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arc-swap"
@@ -656,9 +656,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.32"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -716,23 +716,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clear_on_drop"
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1966,6 +1966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,7 +2343,7 @@ checksum = "59318e4561e37d83571927c35cdfd1ce52f0fad14d326ee7778309288b73ea2b"
 dependencies = [
  "async-trait",
  "btleplug",
- "clap 4.4.18",
+ "clap 4.5.4",
  "encdec",
  "futures",
  "hidapi",
@@ -2358,7 +2364,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
- "clap 4.4.18",
+ "clap 4.5.4",
  "ed25519-dalek",
  "encdec",
  "futures",
@@ -2427,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libdbus-sys"
@@ -2474,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.14"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
  "libc",
@@ -2523,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "loom"
@@ -2602,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2626,14 +2632,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "bs58 0.4.0",
  "cargo-emit",
@@ -2647,7 +2653,7 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-ring-signature-signer",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-types",
  "mc-transaction-core",
  "mc-transaction-extra",
@@ -2663,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2686,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2698,7 +2704,7 @@ dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-keys",
  "mc-crypto-noise",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-types",
  "mc-util-build-grpc",
  "mc-util-build-script",
@@ -2708,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
  "bitflags 2.4.2",
@@ -2721,7 +2727,7 @@ dependencies = [
  "mc-attest-verifier-types",
  "mc-common",
  "mc-crypto-digestible",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-types",
  "mc-sgx-types",
  "mc-util-build-script",
@@ -2738,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2753,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -2769,8 +2775,8 @@ dependencies = [
  "mc-attest-verifier-types",
  "mc-attestation-verifier",
  "mc-common",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-sys-types 0.11.0",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-css",
  "mc-sgx-dcap-types",
  "mc-sgx-types",
@@ -2785,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2793,7 +2799,7 @@ dependencies = [
  "hex_fmt",
  "mc-crypto-digestible",
  "mc-crypto-keys",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-sys-types",
  "mc-sgx-dcap-types",
  "mc-util-encodings",
@@ -2807,16 +2813,16 @@ dependencies = [
 
 [[package]]
 name = "mc-attestation-verifier"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa489aed434f230862bb92ad3059380203793c30f99c603172f602290edd610"
+checksum = "fcf39fb1af41156ec868564ab53156d6dd75f1dc8a7a073acdfb217b6140d9e4"
 dependencies = [
  "der",
  "displaydoc",
  "hex",
  "mbedtls",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-sys-types 0.11.0",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-types",
  "p256",
  "serde",
@@ -2827,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2841,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2864,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -2899,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2929,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2940,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2956,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2978,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2991,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-common",
  "mc-consensus-scp-types",
@@ -3009,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3024,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -3042,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -3053,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aead",
  "digest",
@@ -3067,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -3080,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3089,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -3097,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "blake2",
  "digest",
@@ -3106,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3135,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "hmac",
  "mc-crypto-keys",
@@ -3144,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3157,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3167,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3187,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3208,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3228,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3238,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3268,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3293,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "der",
  "displaydoc",
@@ -3309,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "digest",
  "displaydoc",
@@ -3324,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3341,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3356,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -3371,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-digestible",
@@ -3381,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3394,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3402,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3418,14 +3424,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible-signature",
@@ -3436,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -3451,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-util-uri",
 ]
@@ -3465,7 +3471,7 @@ dependencies = [
  "base64",
  "bs58 0.5.0",
  "chrono",
- "clap 4.4.18",
+ "clap 4.5.4",
  "crossbeam-channel",
  "diesel",
  "diesel-derive-enum",
@@ -3581,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -3608,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
- "clap 4.4.18",
+ "clap 4.5.4",
  "lmdb-rkv",
  "mc-common",
  "mc-ledger-db",
@@ -3621,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -3651,10 +3657,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes-gcm",
- "clap 4.4.18",
+ "clap 4.5.4",
  "crossbeam-channel",
  "displaydoc",
  "grpcio",
@@ -3686,6 +3692,8 @@ dependencies = [
  "mc-mobilecoind-api",
  "mc-rand",
  "mc-sgx-css",
+ "mc-t3-api",
+ "mc-t3-connection",
  "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-extra",
@@ -3712,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3728,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
- "clap 4.4.18",
+ "clap 4.5.4",
  "grpcio",
  "hex",
  "mc-api",
@@ -3772,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cfg-if",
  "mc-sgx-types",
@@ -3790,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-build"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f26e46d3279e257c6a418450332c94d0815486b8dbfdac76387e314e0c1093"
+checksum = "94420a570e76dfc39924b4ec712c2df21a8d77e61ca5ba0857300b1c59889a5d"
 dependencies = [
  "bindgen 0.66.1",
  "cargo-emit",
@@ -3813,13 +3821,13 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-sys-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b56553b93bd334e1f468394e739f1e404cc54085872da7993cbf85438f25d6c"
+checksum = "1c5c33323d0f2855e63efaa538bdd7094104ff79f963734b4122f23302cff581"
 dependencies = [
  "bindgen 0.66.1",
  "cargo-emit",
- "mc-sgx-core-build 0.10.1",
+ "mc-sgx-core-build 0.11.0",
  "serde",
  "serde_with",
 ]
@@ -3844,16 +3852,16 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc4a12a26208d90e08c0eaf85f8318c8f9ab8fd8abd9c505bcf64def220d2ff"
+checksum = "1191b0bb2868ff5bdf7766d3b3e9fa9bb94c23149ae21a82485e6f5f44074106"
 dependencies = [
  "bitflags 2.4.2",
  "displaydoc",
  "getrandom",
  "hex",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-util 0.10.1",
+ "mc-sgx-core-sys-types 0.11.0",
+ "mc-sgx-util 0.11.0",
  "nom",
  "rand_core 0.6.4",
  "serde",
@@ -3862,36 +3870,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "sha2",
 ]
 
 [[package]]
 name = "mc-sgx-dcap-sys-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6add229c047dc25fa8950ebf8e5fcc21a7f4d2b52c0b85b67b13d2edca08e9"
+checksum = "2dd3e93a316a5c142de6fb9179970abc04ca4767732b90d118c90d531db47e89"
 dependencies = [
  "bindgen 0.66.1",
- "mc-sgx-core-build 0.10.1",
- "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-core-build 0.11.0",
+ "mc-sgx-core-sys-types 0.11.0",
 ]
 
 [[package]]
 name = "mc-sgx-dcap-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8592ab2cf83ec03324dba68e3f24d9dac716d1cefa7db434f8fdf79e2aafcf9f"
+checksum = "42c618d93a3f9561bdc27231fa7965ebe855c8d74f5cd5467da194042e0671a9"
 dependencies = [
  "const-oid",
  "displaydoc",
  "hex",
- "mc-sgx-core-types 0.10.1",
+ "mc-sgx-core-types 0.11.0",
  "mc-sgx-dcap-sys-types",
- "mc-sgx-util 0.10.1",
+ "mc-sgx-util 0.11.0",
  "nom",
  "p256",
  "serde",
@@ -3903,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3915,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
- "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-core-sys-types 0.11.0",
 ]
 
 [[package]]
@@ -3928,9 +3936,9 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-sgx-util"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a17bdd557d482382794a59232314fe9cfb7a9c4450aec867f737d815e5f5b0"
+checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-signer"
@@ -3938,7 +3946,7 @@ version = "2.10.1"
 dependencies = [
  "anyhow",
  "base64",
- "clap 4.4.18",
+ "clap 4.5.4",
  "displaydoc",
  "hex",
  "log",
@@ -3971,8 +3979,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-t3-api"
+version = "6.0.1"
+dependencies = [
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-uri",
+ "protobuf",
+]
+
+[[package]]
+name = "mc-t3-connection"
+version = "6.0.1"
+dependencies = [
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "mc-common",
+ "mc-connection",
+ "mc-t3-api",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "protobuf",
+]
+
+[[package]]
 name = "mc-transaction-builder"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -4001,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -4039,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -4054,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -4086,10 +4122,10 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-signer"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "anyhow",
- "clap 4.4.18",
+ "clap 4.5.4",
  "displaydoc",
  "hex",
  "log",
@@ -4114,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4133,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4151,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "cargo_metadata",
@@ -4167,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -4175,14 +4211,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -4193,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -4204,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
  "displaydoc",
@@ -4215,17 +4251,17 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-grpc"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
- "clap 4.4.18",
+ "clap 4.5.4",
  "cookie",
  "displaydoc",
  "futures",
@@ -4253,11 +4289,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "6.0.0"
+version = "6.0.1"
 
 [[package]]
 name = "mc-util-lmdb"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -4267,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4276,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "chrono",
  "grpcio",
@@ -4289,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "hex",
  "itertools 0.12.0",
@@ -4298,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -4308,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "prost 0.12.3",
  "protobuf",
@@ -4319,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -4331,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
- "clap 4.4.18",
+ "clap 4.5.4",
  "lazy_static",
  "mc-account-keys",
  "rand 0.8.5",
@@ -4342,11 +4378,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.0"
+version = "6.0.1"
 
 [[package]]
 name = "mc-util-uri"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64",
  "displaydoc",
@@ -4361,7 +4397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "heapless 0.8.0",
@@ -4369,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "serde",
 ]
@@ -4413,7 +4449,7 @@ dependencies = [
 name = "mc-validator-service"
 version = "2.10.1"
 dependencies = [
- "clap 4.4.18",
+ "clap 4.5.4",
  "grpcio",
  "mc-attest-core",
  "mc-attest-verifier",
@@ -4436,10 +4472,10 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "aes-gcm",
- "clap 4.4.18",
+ "clap 4.5.4",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4479,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "displaydoc",
  "serde",
@@ -5383,9 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -5758,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -6067,9 +6103,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
@@ -6107,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6459,6 +6495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,13 +6695,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -7567,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
-    "gimli",
+ "gimli",
 ]
 
 [[package]]
@@ -23,8 +23,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
-    "crypto-common",
-    "generic-array",
+ "crypto-common",
+ "generic-array",
 ]
 
 [[package]]
@@ -33,9 +33,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
-    "cfg-if",
-    "cipher",
-    "cpufeatures",
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -44,12 +44,12 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
-    "aead",
-    "aes",
-    "cipher",
-    "ctr",
-    "ghash",
-    "subtle",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
-    "winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -97,12 +97,12 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
-    "anstyle",
-    "anstyle-parse",
-    "anstyle-query",
-    "anstyle-wincon",
-    "colorchoice",
-    "utf8parse",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
-    "utf8parse",
+ "utf8parse",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
-    "windows-sys 0.52.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -135,8 +135,8 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
-    "anstyle",
-    "windows-sys 0.52.0",
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -169,11 +169,11 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
-    "flate2",
-    "futures-core",
-    "memchr",
-    "pin-project-lite",
-    "tokio",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -182,9 +182,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
-    "async-stream-impl",
-    "futures-core",
-    "pin-project-lite",
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -193,9 +193,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -204,9 +204,9 @@ version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
-    "bytemuck",
+ "bytemuck",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
-    "critical-section",
+ "critical-section",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
-    "hermit-abi 0.1.19",
-    "libc",
-    "winapi",
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -256,13 +256,13 @@ version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
-    "addr2line",
-    "cc",
-    "cfg-if",
-    "libc",
-    "miniz_oxide",
-    "object",
-    "rustc-demangle",
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -295,21 +295,21 @@ version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
-    "bitflags 1.3.2",
-    "cexpr",
-    "clang-sys",
-    "clap 2.34.0",
-    "env_logger",
-    "lazy_static",
-    "lazycell",
-    "log",
-    "peeking_take_while",
-    "proc-macro2",
-    "quote",
-    "regex",
-    "rustc-hash",
-    "shlex",
-    "which",
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
 ]
 
 [[package]]
@@ -318,20 +318,20 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
-    "bitflags 1.3.2",
-    "cexpr",
-    "clang-sys",
-    "lazy_static",
-    "lazycell",
-    "log",
-    "peeking_take_while",
-    "proc-macro2",
-    "quote",
-    "regex",
-    "rustc-hash",
-    "shlex",
-    "syn 1.0.109",
-    "which",
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
 ]
 
 [[package]]
@@ -340,21 +340,21 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
-    "bitflags 2.4.2",
-    "cexpr",
-    "clang-sys",
-    "lazy_static",
-    "lazycell",
-    "log",
-    "peeking_take_while",
-    "prettyplease",
-    "proc-macro2",
-    "quote",
-    "regex",
-    "rustc-hash",
-    "shlex",
-    "syn 2.0.48",
-    "which",
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
 ]
 
 [[package]]
@@ -363,18 +363,18 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
-    "bitflags 2.4.2",
-    "cexpr",
-    "clang-sys",
-    "lazy_static",
-    "lazycell",
-    "peeking_take_while",
-    "proc-macro2",
-    "quote",
-    "regex",
-    "rustc-hash",
-    "shlex",
-    "syn 2.0.48",
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -404,10 +404,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
-    "funty",
-    "radium",
-    "tap",
-    "wyz",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
-    "digest",
+ "digest",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
-    "generic-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -440,19 +440,19 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce7d4413c940e8e3cb6afc122d3f4a07096aca259d286781128683fc9f39d9b"
 dependencies = [
-    "async-trait",
-    "bitflags 2.4.2",
-    "bluez-generated",
-    "dbus",
-    "dbus-tokio",
-    "futures",
-    "itertools 0.10.5",
-    "log",
-    "serde",
-    "serde-xml-rs",
-    "thiserror",
-    "tokio",
-    "uuid",
+ "async-trait",
+ "bitflags 2.4.2",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures",
+ "itertools 0.10.5",
+ "log",
+ "serde",
+ "serde-xml-rs",
+ "thiserror",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d1c659dbc82f0b8ca75606c91a371e763589b7f6acf36858eeed0c705afe367"
 dependencies = [
-    "dbus",
+ "dbus",
 ]
 
 [[package]]
@@ -470,11 +470,11 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15fabc62c27039b971303b808e3d2683863cc4bbcffbf1615f18d6190b20eaa6"
 dependencies = [
-    "bitflags 2.4.2",
-    "boring-sys",
-    "foreign-types 0.5.0",
-    "libc",
-    "once_cell",
+ "bitflags 2.4.2",
+ "boring-sys",
+ "foreign-types 0.5.0",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -483,10 +483,10 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007c69b35cbe5c5963eecfc50f224d60199c95b2bfbeb957eedba5988e57f91c"
 dependencies = [
-    "bindgen 0.68.1",
-    "cmake",
-    "fs_extra",
-    "fslock",
+ "bindgen 0.68.1",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -495,7 +495,7 @@ version = "0.6.0+e46383f"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5edec42197c014d84ea2396589f0da14b2257f63f319442b5e8475a077b90457"
 dependencies = [
-    "cmake",
+ "cmake",
 ]
 
 [[package]]
@@ -510,7 +510,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
-    "tinyvec",
+ "tinyvec",
 ]
 
 [[package]]
@@ -519,25 +519,25 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790e133b9d27f6dbd1289e046e735cef97fb0b4c840f18db52c959521dfb8145"
 dependencies = [
-    "async-trait",
-    "bitflags 1.3.2",
-    "bluez-async",
-    "cocoa",
-    "dashmap",
-    "dbus",
-    "futures",
-    "jni",
-    "jni-utils",
-    "libc",
-    "log",
-    "objc",
-    "once_cell",
-    "static_assertions",
-    "thiserror",
-    "tokio",
-    "tokio-stream",
-    "uuid",
-    "windows 0.48.0",
+ "async-trait",
+ "bitflags 1.3.2",
+ "bluez-async",
+ "cocoa",
+ "dashmap",
+ "dbus",
+ "futures",
+ "jni",
+ "jni-utils",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "static_assertions",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -545,15 +545,15 @@ name = "bulletproofs-og"
 version = "3.0.0-pre.1"
 source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=9abfdc054d9ba65f1e185ea1e6eff3947ce879dc#9abfdc054d9ba65f1e185ea1e6eff3947ce879dc"
 dependencies = [
-    "byteorder",
-    "clear_on_drop",
-    "curve25519-dalek",
-    "merlin",
-    "rand_core 0.6.4",
-    "serde",
-    "serde_derive",
-    "sha3",
-    "subtle",
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek",
+ "merlin",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
+ "sha3",
+ "subtle",
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -616,12 +616,12 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
-    "camino",
-    "cargo-platform",
-    "semver",
-    "serde",
-    "serde_json",
-    "thiserror",
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
-    "nom",
+ "nom",
 ]
 
 [[package]]
@@ -660,12 +660,12 @@ version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
-    "android-tzdata",
-    "iana-time-zone",
-    "js-sys",
-    "num-traits",
-    "wasm-bindgen",
-    "windows-targets 0.52.0",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -674,8 +674,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
-    "crypto-common",
-    "inout",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -684,9 +684,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
-    "glob",
-    "libc",
-    "libloading",
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -695,13 +695,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
-    "ansi_term",
-    "atty",
-    "bitflags 1.3.2",
-    "strsim 0.8.0",
-    "textwrap",
-    "unicode-width",
-    "vec_map",
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -710,8 +710,8 @@ version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
-    "clap_builder",
-    "clap_derive",
+ "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -720,10 +720,10 @@ version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
-    "anstream",
-    "anstyle",
-    "clap_lex",
-    "strsim 0.10.0",
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -732,10 +732,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
-    "heck 0.4.1",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -768,14 +768,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
-    "bitflags 1.3.2",
-    "block",
-    "cocoa-foundation",
-    "core-foundation",
-    "core-graphics",
-    "foreign-types 0.3.2",
-    "libc",
-    "objc",
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -784,12 +784,12 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
-    "bitflags 1.3.2",
-    "block",
-    "core-foundation",
-    "core-graphics-types",
-    "libc",
-    "objc",
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -804,8 +804,8 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
-    "bytes",
-    "memchr",
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -820,9 +820,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
 dependencies = [
-    "percent-encoding",
-    "time",
-    "version_check",
+ "percent-encoding",
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -831,8 +831,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -847,11 +847,11 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
-    "bitflags 1.3.2",
-    "core-foundation",
-    "core-graphics-types",
-    "foreign-types 0.3.2",
-    "libc",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -860,9 +860,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
-    "bitflags 1.3.2",
-    "core-foundation",
-    "libc",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -880,7 +880,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
-    "crc-catalog",
+ "crc-catalog",
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -919,8 +919,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
-    "crossbeam-epoch",
-    "crossbeam-utils",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
-    "crossbeam-utils",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -950,10 +950,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
-    "generic-array",
-    "rand_core 0.6.4",
-    "subtle",
-    "zeroize",
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -962,9 +962,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
-    "generic-array",
-    "rand_core 0.6.4",
-    "typenum",
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
 ]
 
 [[package]]
@@ -973,7 +973,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
-    "cipher",
+ "cipher",
 ]
 
 [[package]]
@@ -982,17 +982,17 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "curve25519-dalek-derive",
-    "digest",
-    "fiat-crypto",
-    "platforms",
-    "rand_core 0.6.4",
-    "rustc_version",
-    "serde",
-    "subtle",
-    "zeroize",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1001,9 +1001,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1012,8 +1012,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
-    "darling_core 0.14.4",
-    "darling_macro 0.14.4",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1022,8 +1022,8 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
-    "darling_core 0.20.3",
-    "darling_macro 0.20.3",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1032,12 +1032,12 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
-    "fnv",
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.10.0",
-    "syn 1.0.109",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1046,12 +1046,12 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
-    "fnv",
-    "ident_case",
-    "proc-macro2",
-    "quote",
-    "strsim 0.10.0",
-    "syn 2.0.48",
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1060,9 +1060,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
-    "darling_core 0.14.4",
-    "quote",
-    "syn 1.0.109",
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1071,9 +1071,9 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
-    "darling_core 0.20.3",
-    "quote",
-    "syn 2.0.48",
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1082,11 +1082,11 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
-    "cfg-if",
-    "hashbrown",
-    "lock_api",
-    "once_cell",
-    "parking_lot_core",
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1095,11 +1095,11 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
 dependencies = [
-    "futures-channel",
-    "futures-util",
-    "libc",
-    "libdbus-sys",
-    "winapi",
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "libdbus-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1108,9 +1108,9 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
 dependencies = [
-    "dbus",
-    "libc",
-    "tokio",
+ "dbus",
+ "libc",
+ "tokio",
 ]
 
 [[package]]
@@ -1119,8 +1119,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
-    "serde",
-    "uuid",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -1129,11 +1129,11 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
-    "const-oid",
-    "der_derive",
-    "flagset",
-    "pem-rfc7468",
-    "zeroize",
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -1142,9 +1142,9 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
-    "powerfmt",
+ "powerfmt",
 ]
 
 [[package]]
@@ -1162,8 +1162,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6eacefd3f541c66fc61433d65e54e0e46e0a029a819a7dbbc7a7b489e8a85f8"
 dependencies = [
-    "devise_codegen",
-    "devise_core",
+ "devise_codegen",
+ "devise_core",
 ]
 
 [[package]]
@@ -1172,8 +1172,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8cf4b8dd484ede80fd5c547592c46c3745a617c8af278e2b72bea86b2dfed6"
 dependencies = [
-    "devise_core",
-    "quote",
+ "devise_core",
+ "quote",
 ]
 
 [[package]]
@@ -1182,11 +1182,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
 dependencies = [
-    "bitflags 2.4.2",
-    "proc-macro2",
-    "proc-macro2-diagnostics",
-    "quote",
-    "syn 2.0.48",
+ "bitflags 2.4.2",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1195,11 +1195,11 @@ version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
 dependencies = [
-    "chrono",
-    "diesel_derives",
-    "libsqlite3-sys",
-    "r2d2",
-    "time",
+ "chrono",
+ "diesel_derives",
+ "libsqlite3-sys",
+ "r2d2",
+ "time",
 ]
 
 [[package]]
@@ -1208,10 +1208,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81c5131a2895ef64741dad1d483f358c2a229a3a2d1b256778cdc5e146db64d4"
 dependencies = [
-    "heck 0.4.1",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1220,10 +1220,10 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
-    "diesel_table_macro_syntax",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "diesel_table_macro_syntax",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1232,9 +1232,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
-    "diesel",
-    "migrations_internals",
-    "migrations_macros",
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
-    "syn 2.0.48",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1252,10 +1252,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
-    "block-buffer",
-    "const-oid",
-    "crypto-common",
-    "subtle",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1264,8 +1264,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
-    "cfg-if",
-    "dirs-sys-next",
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
@@ -1274,9 +1274,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
-    "libc",
-    "redox_users",
-    "winapi",
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1285,9 +1285,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1308,11 +1308,11 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
-    "der",
-    "digest",
-    "elliptic-curve",
-    "rfc6979",
-    "signature",
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
 ]
 
 [[package]]
@@ -1321,9 +1321,9 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
-    "pkcs8",
-    "serde",
-    "signature",
+ "pkcs8",
+ "serde",
+ "signature",
 ]
 
 [[package]]
@@ -1332,14 +1332,14 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
-    "curve25519-dalek",
-    "ed25519",
-    "rand_core 0.6.4",
-    "serde",
-    "sha2",
-    "signature",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "signature",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1354,18 +1354,18 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
-    "base16ct",
-    "crypto-bigint",
-    "digest",
-    "ff",
-    "generic-array",
-    "group",
-    "pem-rfc7468",
-    "pkcs8",
-    "rand_core 0.6.4",
-    "sec1",
-    "subtle",
-    "zeroize",
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1374,8 +1374,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25de94e10baa85551f7c65730423239370ed5bed60bf8d2a9cbf2683327ba421"
 dependencies = [
-    "encdec-base 0.9.0",
-    "encdec-macros",
+ "encdec-base 0.9.0",
+ "encdec-macros",
 ]
 
 [[package]]
@@ -1384,8 +1384,8 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8542ff2a35da7fc94ffcf280f35dc759219c4b48fa930e0a0f268220d7fb6a"
 dependencies = [
-    "byteorder",
-    "num-traits",
+ "byteorder",
+ "num-traits",
 ]
 
 [[package]]
@@ -1394,10 +1394,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516ae3c7d00515548bf26a6531883335ceac2e9cde4938e70feea7456569be09"
 dependencies = [
-    "byteorder",
-    "heapless 0.7.17",
-    "num-traits",
-    "thiserror",
+ "byteorder",
+ "heapless 0.7.17",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -1406,11 +1406,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15497932aae6b53bf8548cc63c65929b4fab6be54e28709c80fc72f5707eeed"
 dependencies = [
-    "darling 0.14.4",
-    "encdec-base 0.8.3",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "darling 0.14.4",
+ "encdec-base 0.8.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
-    "cfg-if",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1428,11 +1428,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
-    "atty",
-    "humantime",
-    "log",
-    "regex",
-    "termcolor",
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1447,7 +1447,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -1456,8 +1456,8 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
-    "libc",
-    "windows-sys 0.52.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1466,8 +1466,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
-    "backtrace",
-    "failure_derive",
+ "backtrace",
+ "failure_derive",
 ]
 
 [[package]]
@@ -1476,10 +1476,10 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
-    "synstructure",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -1494,8 +1494,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
-    "rand_core 0.6.4",
-    "subtle",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1510,12 +1510,12 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
 dependencies = [
-    "atomic 0.6.0",
-    "pear",
-    "serde",
-    "toml 0.8.8",
-    "uncased",
-    "version_check",
+ "atomic 0.6.0",
+ "pear",
+ "serde",
+ "toml 0.8.8",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -1524,10 +1524,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
-    "byteorder",
-    "rand 0.8.5",
-    "rustc-hex",
-    "static_assertions",
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1548,8 +1548,8 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
-    "crc32fast",
-    "miniz_oxide",
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
-    "foreign-types-shared 0.1.1",
+ "foreign-types-shared 0.1.1",
 ]
 
 [[package]]
@@ -1573,8 +1573,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
-    "foreign-types-macros",
-    "foreign-types-shared 0.3.1",
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1583,9 +1583,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1606,7 +1606,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
-    "percent-encoding",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1627,8 +1627,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
-    "libc",
-    "winapi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1649,13 +1649,13 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
-    "futures-channel",
-    "futures-core",
-    "futures-executor",
-    "futures-io",
-    "futures-sink",
-    "futures-task",
-    "futures-util",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1664,8 +1664,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
-    "futures-core",
-    "futures-sink",
+ "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1680,9 +1680,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
-    "futures-core",
-    "futures-task",
-    "futures-util",
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -1697,9 +1697,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1720,16 +1720,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
-    "futures-channel",
-    "futures-core",
-    "futures-io",
-    "futures-macro",
-    "futures-sink",
-    "futures-task",
-    "memchr",
-    "pin-project-lite",
-    "pin-utils",
-    "slab",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1738,11 +1738,11 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
 dependencies = [
-    "cc",
-    "libc",
-    "log",
-    "rustversion",
-    "windows 0.48.0",
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -1751,10 +1751,10 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
-    "serde",
-    "typenum",
-    "version_check",
-    "zeroize",
+ "serde",
+ "typenum",
+ "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1763,7 +1763,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 dependencies = [
-    "void",
+ "void",
 ]
 
 [[package]]
@@ -1772,9 +1772,9 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
-    "cfg-if",
-    "libc",
-    "wasi",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1783,8 +1783,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
-    "opaque-debug",
-    "polyval",
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1805,9 +1805,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
-    "ff",
-    "rand_core 0.6.4",
-    "subtle",
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1816,13 +1816,13 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e398946b5721d72478eb647260a1b7c1d5f70f0de35399846c3913bd369a33e"
 dependencies = [
-    "futures-executor",
-    "futures-util",
-    "grpcio-sys",
-    "libc",
-    "log",
-    "parking_lot",
-    "protobuf",
+ "futures-executor",
+ "futures-util",
+ "grpcio-sys",
+ "libc",
+ "log",
+ "parking_lot",
+ "protobuf",
 ]
 
 [[package]]
@@ -1831,7 +1831,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f1abac9f330ac9ee0950220c10eea84d66479cede4836f0b924407fecf093c"
 dependencies = [
-    "protobuf",
+ "protobuf",
 ]
 
 [[package]]
@@ -1840,14 +1840,14 @@ version = "0.13.0+1.56.2-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3dae9132320ae1b03ea55b5ddc88ca72a31fb85fa631a241a40157f5feffe43"
 dependencies = [
-    "bindgen 0.59.2",
-    "boringssl-src",
-    "cc",
-    "cmake",
-    "libc",
-    "libz-sys",
-    "pkg-config",
-    "walkdir",
+ "bindgen 0.59.2",
+ "boringssl-src",
+ "cc",
+ "cmake",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -1856,17 +1856,17 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
-    "bytes",
-    "fnv",
-    "futures-core",
-    "futures-sink",
-    "futures-util",
-    "http",
-    "indexmap",
-    "slab",
-    "tokio",
-    "tokio-util",
-    "tracing",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
-    "byteorder",
+ "byteorder",
 ]
 
 [[package]]
@@ -1890,7 +1890,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
-    "byteorder",
+ "byteorder",
 ]
 
 [[package]]
@@ -1899,8 +1899,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
-    "allocator-api2",
-    "serde",
+ "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -1909,13 +1909,13 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
-    "base64",
-    "bytes",
-    "headers-core",
-    "http",
-    "httpdate",
-    "mime",
-    "sha1",
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
-    "http",
+ "http",
 ]
 
 [[package]]
@@ -1933,11 +1933,11 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
-    "atomic-polyfill",
-    "hash32 0.2.1",
-    "rustc_version",
-    "spin 0.9.8",
-    "stable_deref_trait",
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1946,8 +1946,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
-    "hash32 0.3.1",
-    "stable_deref_trait",
+ "hash32 0.3.1",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
-    "unicode-segmentation",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -1986,7 +1986,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -2001,10 +2001,10 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723777263b0dcc5730aec947496bd8c3940ba63c15f5633b288cc615f4f6af79"
 dependencies = [
-    "cc",
-    "libc",
-    "pkg-config",
-    "winapi",
+ "cc",
+ "libc",
+ "pkg-config",
+ "winapi",
 ]
 
 [[package]]
@@ -2013,7 +2013,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
-    "hmac",
+ "hmac",
 ]
 
 [[package]]
@@ -2022,7 +2022,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
-    "digest",
+ "digest",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
-    "windows-sys 0.52.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2046,9 +2046,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
-    "libc",
-    "match_cfg",
-    "winapi",
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -2057,9 +2057,9 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
-    "bytes",
-    "fnv",
-    "itoa",
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -2068,9 +2068,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
-    "bytes",
-    "http",
-    "pin-project-lite",
+ "bytes",
+ "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2097,22 +2097,22 @@ version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
-    "bytes",
-    "futures-channel",
-    "futures-core",
-    "futures-util",
-    "h2",
-    "http",
-    "http-body",
-    "httparse",
-    "httpdate",
-    "itoa",
-    "pin-project-lite",
-    "socket2",
-    "tokio",
-    "tower-service",
-    "tracing",
-    "want",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -2121,12 +2121,12 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
-    "futures-util",
-    "http",
-    "hyper",
-    "rustls",
-    "tokio",
-    "tokio-rustls",
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2135,12 +2135,12 @@ version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
-    "android_system_properties",
-    "core-foundation-sys",
-    "iana-time-zone-haiku",
-    "js-sys",
-    "wasm-bindgen",
-    "windows-core",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
 ]
 
 [[package]]
@@ -2149,7 +2149,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
-    "cc",
+ "cc",
 ]
 
 [[package]]
@@ -2164,8 +2164,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
-    "unicode-bidi",
-    "unicode-normalization",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
-    "parity-scale-codec",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -2183,9 +2183,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2194,9 +2194,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
-    "equivalent",
-    "hashbrown",
-    "serde",
+ "equivalent",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2211,7 +2211,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
-    "generic-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -2232,9 +2232,9 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
-    "hermit-abi 0.3.4",
-    "rustix",
-    "windows-sys 0.52.0",
+ "hermit-abi 0.3.4",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2243,7 +2243,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
-    "either",
+ "either",
 ]
 
 [[package]]
@@ -2252,7 +2252,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
-    "either",
+ "either",
 ]
 
 [[package]]
@@ -2267,12 +2267,12 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
 dependencies = [
-    "cesu8",
-    "combine",
-    "jni-sys",
-    "log",
-    "thiserror",
-    "walkdir",
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -2287,13 +2287,13 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
 dependencies = [
-    "dashmap",
-    "futures",
-    "jni",
-    "log",
-    "once_cell",
-    "static_assertions",
-    "uuid",
+ "dashmap",
+ "futures",
+ "jni",
+ "log",
+ "once_cell",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
-    "wasm-bindgen",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2311,7 +2311,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
-    "cpufeatures",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2320,7 +2320,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
-    "spin 0.5.2",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2335,82 +2335,82 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59318e4561e37d83571927c35cdfd1ce52f0fad14d326ee7778309288b73ea2b"
 dependencies = [
-    "async-trait",
-    "btleplug",
-    "clap 4.4.18",
-    "encdec",
-    "futures",
-    "hidapi",
-    "ledger-proto",
-    "once_cell",
-    "strum 0.24.1",
-    "thiserror",
-    "tokio",
-    "tracing",
-    "tracing-subscriber",
-    "uuid",
+ "async-trait",
+ "btleplug",
+ "clap 4.4.18",
+ "encdec",
+ "futures",
+ "hidapi",
+ "ledger-proto",
+ "once_cell",
+ "strum 0.24.1",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
 name = "ledger-mob"
 version = "0.16.0"
 dependencies = [
-    "anyhow",
-    "async-trait",
-    "base64",
-    "clap 4.4.18",
-    "ed25519-dalek",
-    "encdec",
-    "futures",
-    "hex",
-    "lazy_static",
-    "ledger-lib",
-    "ledger-mob-apdu",
-    "ledger-proto",
-    "log",
-    "mc-core",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-crypto-ring-signature-signer",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-transaction-signer",
-    "mc-transaction-summary",
-    "once_cell",
-    "prost 0.11.9",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "serde",
-    "serde_cbor",
-    "serde_json",
-    "simplelog",
-    "strum 0.24.1",
-    "thiserror",
-    "tokio",
-    "zeroize",
+ "anyhow",
+ "async-trait",
+ "base64",
+ "clap 4.4.18",
+ "ed25519-dalek",
+ "encdec",
+ "futures",
+ "hex",
+ "lazy_static",
+ "ledger-lib",
+ "ledger-mob-apdu",
+ "ledger-proto",
+ "log",
+ "mc-core",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-signer",
+ "mc-transaction-summary",
+ "once_cell",
+ "prost 0.11.9",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "simplelog",
+ "strum 0.24.1",
+ "thiserror",
+ "tokio",
+ "zeroize",
 ]
 
 [[package]]
 name = "ledger-mob-apdu"
 version = "0.16.0"
 dependencies = [
-    "bitflags 1.3.2",
-    "byteorder",
-    "curve25519-dalek",
-    "encdec",
-    "heapless 0.7.17",
-    "ledger-proto",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "num_enum",
-    "rand_core 0.6.4",
-    "sha2",
-    "strum 0.24.1",
-    "zeroize",
+ "bitflags 1.3.2",
+ "byteorder",
+ "curve25519-dalek",
+ "encdec",
+ "heapless 0.7.17",
+ "ledger-proto",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "num_enum",
+ "rand_core 0.6.4",
+ "sha2",
+ "strum 0.24.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2419,10 +2419,10 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522849296eded72ceed7a046d84171e04735dd1cff1fdd01a7c9a9691acbadea"
 dependencies = [
-    "bitflags 2.4.2",
-    "displaydoc",
-    "encdec",
-    "thiserror",
+ "bitflags 2.4.2",
+ "displaydoc",
+ "encdec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2437,7 +2437,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
-    "pkg-config",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2446,8 +2446,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
-    "cfg-if",
-    "windows-sys 0.48.0",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2456,9 +2456,9 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
-    "bitflags 2.4.2",
-    "libc",
-    "redox_syscall",
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2467,9 +2467,9 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
-    "cc",
-    "pkg-config",
-    "vcpkg",
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2478,10 +2478,10 @@ version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
-    "cc",
-    "libc",
-    "pkg-config",
-    "vcpkg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2495,10 +2495,10 @@ name = "lmdb-rkv"
 version = "0.14.0"
 source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
-    "bitflags 1.3.2",
-    "byteorder",
-    "libc",
-    "lmdb-rkv-sys",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "lmdb-rkv-sys",
 ]
 
 [[package]]
@@ -2506,9 +2506,9 @@ name = "lmdb-rkv-sys"
 version = "0.11.0"
 source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
-    "cc",
-    "libc",
-    "pkg-config",
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2517,8 +2517,8 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
-    "autocfg",
-    "scopeguard",
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -2533,13 +2533,13 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
-    "cfg-if",
-    "generator",
-    "scoped-tls",
-    "serde",
-    "serde_json",
-    "tracing",
-    "tracing-subscriber",
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -2563,7 +2563,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
-    "regex-automata 0.1.10",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2571,17 +2571,17 @@ name = "mbedtls"
 version = "0.8.1"
 source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=f82523478a1dd813ca381c190175355d249a8123#f82523478a1dd813ca381c190175355d249a8123"
 dependencies = [
-    "bitflags 2.4.2",
-    "byteorder",
-    "cc",
-    "cfg-if",
-    "chrono",
-    "genio",
-    "mbedtls-sys-auto",
-    "rs-libc",
-    "serde",
-    "spin 0.9.8",
-    "yasna",
+ "bitflags 2.4.2",
+ "byteorder",
+ "cc",
+ "cfg-if",
+ "chrono",
+ "genio",
+ "mbedtls-sys-auto",
+ "rs-libc",
+ "serde",
+ "spin 0.9.8",
+ "yasna",
 ]
 
 [[package]]
@@ -2589,220 +2589,220 @@ name = "mbedtls-sys-auto"
 version = "2.26.1"
 source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=f82523478a1dd813ca381c190175355d249a8123#f82523478a1dd813ca381c190175355d249a8123"
 dependencies = [
-    "bindgen 0.64.0",
-    "cc",
-    "cfg-if",
-    "cmake",
-    "lazy_static",
-    "libc",
-    "libz-sys",
-    "quote",
-    "syn 2.0.48",
+ "bindgen 0.64.0",
+ "cc",
+ "cfg-if",
+ "cmake",
+ "lazy_static",
+ "libc",
+ "libz-sys",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "mc-account-keys"
 version = "6.0.0"
 dependencies = [
-    "curve25519-dalek",
-    "displaydoc",
-    "hex_fmt",
-    "hkdf",
-    "mc-account-keys-types",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-fog-sig-authority",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek",
+ "displaydoc",
+ "hex_fmt",
+ "hkdf",
+ "mc-account-keys-types",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-fog-sig-authority",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-account-keys-types"
 version = "6.0.0"
 dependencies = [
-    "mc-crypto-keys",
+ "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
 version = "6.0.0"
 dependencies = [
-    "bs58 0.4.0",
-    "cargo-emit",
-    "crc",
-    "curve25519-dalek",
-    "displaydoc",
-    "mc-account-keys",
-    "mc-attest-verifier-types",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-crypto-keys",
-    "mc-crypto-multisig",
-    "mc-crypto-ring-signature-signer",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-types",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-transaction-summary",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "mc-util-uri",
-    "mc-watcher-api",
-    "protobuf",
+ "bs58 0.4.0",
+ "cargo-emit",
+ "crc",
+ "curve25519-dalek",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-attest-verifier-types",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature-signer",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-types",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-summary",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-uri",
+ "mc-watcher-api",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-attest-ake"
 version = "6.0.0"
 dependencies = [
-    "aead",
-    "cargo-emit",
-    "der",
-    "digest",
-    "displaydoc",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attest-verifier-types",
-    "mc-attestation-verifier",
-    "mc-crypto-keys",
-    "mc-crypto-noise",
-    "mc-sgx-dcap-types",
-    "mc-util-build-script",
-    "mc-util-build-sgx",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
+ "aead",
+ "cargo-emit",
+ "der",
+ "digest",
+ "displaydoc",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attest-verifier-types",
+ "mc-attestation-verifier",
+ "mc-crypto-keys",
+ "mc-crypto-noise",
+ "mc-sgx-dcap-types",
+ "mc-util-build-script",
+ "mc-util-build-sgx",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
 name = "mc-attest-api"
 version = "6.0.0"
 dependencies = [
-    "aead",
-    "cargo-emit",
-    "digest",
-    "futures",
-    "grpcio",
-    "mc-attest-ake",
-    "mc-attest-enclave-api",
-    "mc-attest-verifier-types",
-    "mc-crypto-keys",
-    "mc-crypto-noise",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-types",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-serial",
-    "protobuf",
+ "aead",
+ "cargo-emit",
+ "digest",
+ "futures",
+ "grpcio",
+ "mc-attest-ake",
+ "mc-attest-enclave-api",
+ "mc-attest-verifier-types",
+ "mc-crypto-keys",
+ "mc-crypto-noise",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-types",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-serial",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-attest-core"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "bitflags 2.4.2",
-    "cargo-emit",
-    "chrono",
-    "digest",
-    "displaydoc",
-    "hex",
-    "hex_fmt",
-    "mc-attest-verifier-types",
-    "mc-common",
-    "mc-crypto-digestible",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-types",
-    "mc-sgx-types",
-    "mc-util-build-script",
-    "mc-util-build-sgx",
-    "mc-util-encodings",
-    "mc-util-repr-bytes",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "rjson",
-    "serde",
-    "sha2",
-    "subtle",
+ "base64",
+ "bitflags 2.4.2",
+ "cargo-emit",
+ "chrono",
+ "digest",
+ "displaydoc",
+ "hex",
+ "hex_fmt",
+ "mc-attest-verifier-types",
+ "mc-common",
+ "mc-crypto-digestible",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-types",
+ "mc-sgx-types",
+ "mc-util-build-script",
+ "mc-util-build-sgx",
+ "mc-util-encodings",
+ "mc-util-repr-bytes",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "rjson",
+ "serde",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
 name = "mc-attest-enclave-api"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-attest-ake",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attestation-verifier",
-    "mc-crypto-noise",
-    "mc-sgx-compat",
-    "mc-util-serial",
-    "serde",
+ "displaydoc",
+ "mc-attest-ake",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attestation-verifier",
+ "mc-crypto-noise",
+ "mc-sgx-compat",
+ "mc-util-serial",
+ "serde",
 ]
 
 [[package]]
 name = "mc-attest-verifier"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "cfg-if",
-    "chrono",
-    "der",
-    "displaydoc",
-    "hex",
-    "hex_fmt",
-    "lazy_static",
-    "mbedtls",
-    "mbedtls-sys-auto",
-    "mc-attest-core",
-    "mc-attest-verifier-types",
-    "mc-attestation-verifier",
-    "mc-common",
-    "mc-sgx-core-sys-types 0.10.1",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-css",
-    "mc-sgx-dcap-types",
-    "mc-sgx-types",
-    "mc-util-build-script",
-    "mc-util-build-sgx",
-    "p256",
-    "rand 0.8.5",
-    "rand_hc",
-    "serde",
-    "sha2",
+ "cargo-emit",
+ "cfg-if",
+ "chrono",
+ "der",
+ "displaydoc",
+ "hex",
+ "hex_fmt",
+ "lazy_static",
+ "mbedtls",
+ "mbedtls-sys-auto",
+ "mc-attest-core",
+ "mc-attest-verifier-types",
+ "mc-attestation-verifier",
+ "mc-common",
+ "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-css",
+ "mc-sgx-dcap-types",
+ "mc-sgx-types",
+ "mc-util-build-script",
+ "mc-util-build-sgx",
+ "p256",
+ "rand 0.8.5",
+ "rand_hc",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
 name = "mc-attest-verifier-types"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "displaydoc",
-    "hex",
-    "hex_fmt",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-sys-types",
-    "mc-sgx-dcap-types",
-    "mc-util-encodings",
-    "mc-util-serial",
-    "prost 0.12.3",
-    "prost-build",
-    "serde",
-    "sha2",
-    "x509-cert",
+ "base64",
+ "displaydoc",
+ "hex",
+ "hex_fmt",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-sys-types",
+ "mc-sgx-dcap-types",
+ "mc-util-encodings",
+ "mc-util-serial",
+ "prost 0.12.3",
+ "prost-build",
+ "serde",
+ "sha2",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2811,937 +2811,936 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa489aed434f230862bb92ad3059380203793c30f99c603172f602290edd610"
 dependencies = [
-    "der",
-    "displaydoc",
-    "hex",
-    "mbedtls",
-    "mc-sgx-core-sys-types 0.10.1",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-types",
-    "p256",
-    "serde",
-    "serde_json",
-    "subtle",
-    "x509-cert",
+ "der",
+ "displaydoc",
+ "hex",
+ "mbedtls",
+ "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-types",
+ "p256",
+ "serde",
+ "serde_json",
+ "subtle",
+ "x509-cert",
 ]
 
 [[package]]
 name = "mc-blockchain-test-utils"
 version = "6.0.0"
 dependencies = [
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-consensus-scp-types",
-    "mc-crypto-keys",
-    "mc-transaction-core",
-    "mc-transaction-core-test-utils",
-    "mc-util-from-random",
-    "mc-util-test-helper",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-consensus-scp-types",
+ "mc-crypto-keys",
+ "mc-transaction-core",
+ "mc-transaction-core-test-utils",
+ "mc-util-from-random",
+ "mc-util-test-helper",
 ]
 
 [[package]]
 name = "mc-blockchain-types"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "hex_fmt",
-    "mc-account-keys",
-    "mc-attest-verifier-types",
-    "mc-common",
-    "mc-consensus-scp-types",
-    "mc-crypto-digestible",
-    "mc-crypto-digestible-signature",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-transaction-core",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "prost 0.12.3",
-    "serde",
-    "zeroize",
+ "displaydoc",
+ "hex_fmt",
+ "mc-account-keys",
+ "mc-attest-verifier-types",
+ "mc-common",
+ "mc-consensus-scp-types",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-signature",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-core",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "prost 0.12.3",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-common"
 version = "6.0.0"
 dependencies = [
-    "backtrace",
-    "cfg-if",
-    "chrono",
-    "displaydoc",
-    "hashbrown",
-    "hex",
-    "hex_fmt",
-    "hostname",
-    "lazy_static",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-rand",
-    "mc-util-build-info",
-    "mc-util-logger-macros",
-    "mc-util-serial",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "sentry",
-    "serde",
-    "sha3",
-    "siphasher",
-    "slog",
-    "slog-async",
-    "slog-atomic",
-    "slog-envlogger",
-    "slog-json",
-    "slog-scope",
-    "slog-stdlog",
-    "slog-term",
+ "backtrace",
+ "cfg-if",
+ "chrono",
+ "displaydoc",
+ "hashbrown",
+ "hex",
+ "hex_fmt",
+ "hostname",
+ "lazy_static",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-rand",
+ "mc-util-build-info",
+ "mc-util-logger-macros",
+ "mc-util-serial",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "sentry",
+ "serde",
+ "sha3",
+ "siphasher",
+ "slog",
+ "slog-async",
+ "slog-atomic",
+ "slog-envlogger",
+ "slog-json",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
 ]
 
 [[package]]
 name = "mc-connection"
 version = "6.0.0"
 dependencies = [
-    "aes-gcm",
-    "cookie",
-    "der",
-    "displaydoc",
-    "grpcio",
-    "mc-attest-ake",
-    "mc-attest-api",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attestation-verifier",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-consensus-api",
-    "mc-crypto-keys",
-    "mc-crypto-noise",
-    "mc-rand",
-    "mc-transaction-core",
-    "mc-util-grpc",
-    "mc-util-serial",
-    "mc-util-uri",
-    "retry",
-    "secrecy",
-    "serde",
-    "sha2",
+ "aes-gcm",
+ "cookie",
+ "der",
+ "displaydoc",
+ "grpcio",
+ "mc-attest-ake",
+ "mc-attest-api",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attestation-verifier",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-consensus-api",
+ "mc-crypto-keys",
+ "mc-crypto-noise",
+ "mc-rand",
+ "mc-transaction-core",
+ "mc-util-grpc",
+ "mc-util-serial",
+ "mc-util-uri",
+ "retry",
+ "secrecy",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
 name = "mc-connection-test-utils"
 version = "6.0.0"
 dependencies = [
-    "mc-blockchain-types",
-    "mc-connection",
-    "mc-ledger-db",
-    "mc-transaction-core",
-    "mc-util-uri",
+ "mc-blockchain-types",
+ "mc-connection",
+ "mc-ledger-db",
+ "mc-transaction-core",
+ "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-consensus-api"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-attest-api",
-    "mc-ledger-db",
-    "mc-transaction-core",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "protobuf",
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-attest-api",
+ "mc-ledger-db",
+ "mc-transaction-core",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-api"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "hex",
-    "mc-attest-ake",
-    "mc-attest-core",
-    "mc-attest-enclave-api",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-crypto-message-cipher",
-    "mc-crypto-multisig",
-    "mc-sgx-compat",
-    "mc-sgx-report-cache-api",
-    "mc-transaction-core",
-    "mc-util-serial",
-    "serde",
+ "displaydoc",
+ "hex",
+ "mc-attest-ake",
+ "mc-attest-core",
+ "mc-attest-enclave-api",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-message-cipher",
+ "mc-crypto-multisig",
+ "mc-sgx-compat",
+ "mc-sgx-report-cache-api",
+ "mc-transaction-core",
+ "mc-util-serial",
+ "serde",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "mc-attest-core",
-    "mc-attestation-verifier",
-    "mc-sgx-css",
-    "mc-util-build-enclave",
-    "mc-util-build-script",
-    "mc-util-build-sgx",
+ "cargo-emit",
+ "mc-attest-core",
+ "mc-attestation-verifier",
+ "mc-sgx-css",
+ "mc-util-build-enclave",
+ "mc-util-build-script",
+ "mc-util-build-sgx",
 ]
 
 [[package]]
 name = "mc-consensus-scp"
 version = "6.0.0"
 dependencies = [
-    "mc-common",
-    "mc-consensus-scp-types",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-util-from-random",
-    "mc-util-serial",
-    "mockall",
-    "primitive-types",
-    "rand 0.8.5",
-    "rand_hc",
-    "serde",
-    "serde_json",
+ "mc-common",
+ "mc-consensus-scp-types",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-serial",
+ "mockall",
+ "primitive-types",
+ "rand 0.8.5",
+ "rand_hc",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "mc-consensus-scp-types"
 version = "6.0.0"
 dependencies = [
-    "mc-common",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-util-from-random",
-    "mc-util-test-helper",
-    "prost 0.12.3",
-    "rand 0.8.5",
-    "rand_hc",
-    "serde",
+ "mc-common",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-test-helper",
+ "prost 0.12.3",
+ "rand 0.8.5",
+ "rand_hc",
+ "serde",
 ]
 
 [[package]]
 name = "mc-core"
 version = "6.0.0"
 dependencies = [
-    "curve25519-dalek",
-    "ed25519-dalek",
-    "generic-array",
-    "hkdf",
-    "mc-core-types",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "serde",
-    "sha2",
-    "slip10_ed25519",
-    "tiny-bip39",
-    "zeroize",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "generic-array",
+ "hkdf",
+ "mc-core-types",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "serde",
+ "sha2",
+ "slip10_ed25519",
+ "tiny-bip39",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-core-types"
 version = "6.0.0"
 dependencies = [
-    "curve25519-dalek",
-    "mc-crypto-keys",
-    "serde",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek",
+ "mc-crypto-keys",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-box"
 version = "6.0.0"
 dependencies = [
-    "aead",
-    "digest",
-    "displaydoc",
-    "hkdf",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-oblivious-aes-gcm",
-    "rand_core 0.6.4",
+ "aead",
+ "digest",
+ "displaydoc",
+ "hkdf",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-oblivious-aes-gcm",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-crypto-digestible"
 version = "6.0.0"
 dependencies = [
-    "cfg-if",
-    "curve25519-dalek",
-    "ed25519-dalek",
-    "generic-array",
-    "mc-crypto-digestible-derive",
-    "merlin",
-    "x25519-dalek",
+ "cfg-if",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "generic-array",
+ "mc-crypto-digestible-derive",
+ "merlin",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-derive"
 version = "6.0.0"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-signature"
 version = "6.0.0"
 dependencies = [
-    "mc-crypto-digestible",
-    "signature",
+ "mc-crypto-digestible",
+ "signature",
 ]
 
 [[package]]
 name = "mc-crypto-hashes"
 version = "6.0.0"
 dependencies = [
-    "blake2",
-    "digest",
-    "mc-crypto-digestible",
+ "blake2",
+ "digest",
+ "mc-crypto-digestible",
 ]
 
 [[package]]
 name = "mc-crypto-keys"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "curve25519-dalek",
-    "digest",
-    "displaydoc",
-    "ed25519",
-    "ed25519-dalek",
-    "hex",
-    "hex_fmt",
-    "mc-crypto-digestible",
-    "mc-crypto-digestible-signature",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "rand_core 0.6.4",
-    "rand_hc",
-    "schnorrkel-og",
-    "serde",
-    "sha2",
-    "signature",
-    "static_assertions",
-    "subtle",
-    "x25519-dalek",
-    "zeroize",
+ "base64",
+ "curve25519-dalek",
+ "digest",
+ "displaydoc",
+ "ed25519",
+ "ed25519-dalek",
+ "hex",
+ "hex_fmt",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-signature",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "rand_core 0.6.4",
+ "rand_hc",
+ "schnorrkel-og",
+ "serde",
+ "sha2",
+ "signature",
+ "static_assertions",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-memo-mac"
 version = "6.0.0"
 dependencies = [
-    "hmac",
-    "mc-crypto-keys",
-    "sha2",
+ "hmac",
+ "mc-crypto-keys",
+ "sha2",
 ]
 
 [[package]]
 name = "mc-crypto-message-cipher"
 version = "6.0.0"
 dependencies = [
-    "aes-gcm",
-    "displaydoc",
-    "generic-array",
-    "mc-util-serial",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
+ "aes-gcm",
+ "displaydoc",
+ "generic-array",
+ "mc-util-serial",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
 ]
 
 [[package]]
 name = "mc-crypto-multisig"
 version = "6.0.0"
 dependencies = [
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "prost 0.12.3",
-    "serde",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "prost 0.12.3",
+ "serde",
 ]
 
 [[package]]
 name = "mc-crypto-noise"
 version = "6.0.0"
 dependencies = [
-    "aead",
-    "aes-gcm",
-    "digest",
-    "displaydoc",
-    "generic-array",
-    "hkdf",
-    "mc-crypto-keys",
-    "mc-util-from-random",
-    "rand_core 0.6.4",
-    "secrecy",
-    "serde",
-    "sha2",
-    "subtle",
-    "zeroize",
+ "aead",
+ "aes-gcm",
+ "digest",
+ "displaydoc",
+ "generic-array",
+ "hkdf",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "rand_core 0.6.4",
+ "secrecy",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-ring-signature"
 version = "6.0.0"
 dependencies = [
-    "curve25519-dalek",
-    "displaydoc",
-    "ed25519-dalek",
-    "mc-core-types",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek",
+ "displaydoc",
+ "ed25519-dalek",
+ "mc-core-types",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
 version = "6.0.0"
 dependencies = [
-    "curve25519-dalek",
-    "displaydoc",
-    "generic-array",
-    "hex_fmt",
-    "mc-account-keys",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-transaction-types",
-    "mc-util-serial",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
-    "zeroize",
+ "curve25519-dalek",
+ "displaydoc",
+ "generic-array",
+ "hex_fmt",
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "mc-util-serial",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-x509-utils"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-crypto-keys",
-    "pem",
-    "x509-signature",
+ "displaydoc",
+ "mc-crypto-keys",
+ "pem",
+ "x509-signature",
 ]
 
 [[package]]
 name = "mc-fog-api"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "displaydoc",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-attest-api",
-    "mc-attest-core",
-    "mc-attest-enclave-api",
-    "mc-consensus-api",
-    "mc-crypto-keys",
-    "mc-fog-enclave-connection",
-    "mc-fog-report-api",
-    "mc-fog-report-types",
-    "mc-fog-types",
-    "mc-fog-uri",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-encodings",
-    "mc-util-from-random",
-    "mc-util-grpc",
-    "mc-util-serial",
-    "mc-watcher-api",
-    "prost 0.12.3",
-    "protobuf",
+ "cargo-emit",
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-attest-api",
+ "mc-attest-core",
+ "mc-attest-enclave-api",
+ "mc-consensus-api",
+ "mc-crypto-keys",
+ "mc-fog-enclave-connection",
+ "mc-fog-report-api",
+ "mc-fog-report-types",
+ "mc-fog-types",
+ "mc-fog-uri",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-encodings",
+ "mc-util-from-random",
+ "mc-util-grpc",
+ "mc-util-serial",
+ "mc-watcher-api",
+ "prost 0.12.3",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-fog-enclave-connection"
 version = "6.0.0"
 dependencies = [
-    "aes-gcm",
-    "cookie",
-    "der",
-    "displaydoc",
-    "grpcio",
-    "mc-attest-ake",
-    "mc-attest-api",
-    "mc-attest-core",
-    "mc-attestation-verifier",
-    "mc-common",
-    "mc-connection",
-    "mc-crypto-keys",
-    "mc-crypto-noise",
-    "mc-rand",
-    "mc-util-grpc",
-    "mc-util-serial",
-    "mc-util-uri",
-    "retry",
-    "sha2",
+ "aes-gcm",
+ "cookie",
+ "der",
+ "displaydoc",
+ "grpcio",
+ "mc-attest-ake",
+ "mc-attest-api",
+ "mc-attest-core",
+ "mc-attestation-verifier",
+ "mc-common",
+ "mc-connection",
+ "mc-crypto-keys",
+ "mc-crypto-noise",
+ "mc-rand",
+ "mc-util-grpc",
+ "mc-util-serial",
+ "mc-util-uri",
+ "retry",
+ "sha2",
 ]
 
 [[package]]
 name = "mc-fog-ingest-report"
 version = "6.0.0"
 dependencies = [
-    "der",
-    "displaydoc",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attest-verifier-types",
-    "mc-attestation-verifier",
-    "mc-crypto-keys",
-    "mc-fog-report-types",
-    "mc-util-encodings",
-    "serde",
+ "der",
+ "displaydoc",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attest-verifier-types",
+ "mc-attestation-verifier",
+ "mc-crypto-keys",
+ "mc-fog-report-types",
+ "mc-util-encodings",
+ "serde",
 ]
 
 [[package]]
 name = "mc-fog-kex-rng"
 version = "6.0.0"
 dependencies = [
-    "digest",
-    "displaydoc",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
+ "digest",
+ "displaydoc",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-api"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-attest-api",
-    "mc-attest-verifier-types",
-    "mc-consensus-api",
-    "mc-fog-report-types",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "protobuf",
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-attest-api",
+ "mc-attest-verifier-types",
+ "mc-consensus-api",
+ "mc-fog-report-types",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-fog-report-connection"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "grpcio",
-    "mc-account-keys",
-    "mc-common",
-    "mc-fog-report-api",
-    "mc-fog-report-types",
-    "mc-util-grpc",
-    "mc-util-serial",
-    "mc-util-uri",
+ "displaydoc",
+ "grpcio",
+ "mc-account-keys",
+ "mc-common",
+ "mc-fog-report-api",
+ "mc-fog-report-types",
+ "mc-util-grpc",
+ "mc-util-serial",
+ "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-fog-report-resolver"
 version = "6.0.0"
 dependencies = [
-    "mc-account-keys",
-    "mc-attest-verifier",
-    "mc-attestation-verifier",
-    "mc-fog-ingest-report",
-    "mc-fog-report-types",
-    "mc-fog-report-validation",
-    "mc-fog-sig",
-    "mc-util-uri",
-    "serde",
+ "mc-account-keys",
+ "mc-attest-verifier",
+ "mc-attestation-verifier",
+ "mc-fog-ingest-report",
+ "mc-fog-report-types",
+ "mc-fog-report-validation",
+ "mc-fog-sig",
+ "mc-util-uri",
+ "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-types"
 version = "6.0.0"
 dependencies = [
-    "mc-attest-verifier-types",
-    "mc-crypto-digestible",
-    "prost 0.12.3",
-    "serde",
+ "mc-attest-verifier-types",
+ "mc-crypto-digestible",
+ "prost 0.12.3",
+ "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-validation"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-account-keys",
-    "mc-crypto-keys",
-    "mc-fog-sig",
-    "mc-util-serial",
-    "mc-util-uri",
-    "mockall",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-fog-sig",
+ "mc-util-serial",
+ "mc-util-uri",
+ "mockall",
 ]
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
 version = "6.0.0"
 dependencies = [
-    "mc-account-keys",
-    "mc-fog-report-validation",
+ "mc-account-keys",
+ "mc-fog-report-validation",
 ]
 
 [[package]]
 name = "mc-fog-sig"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-account-keys",
-    "mc-crypto-keys",
-    "mc-crypto-x509-utils",
-    "mc-fog-report-types",
-    "mc-fog-sig-authority",
-    "mc-fog-sig-report",
-    "pem",
-    "signature",
-    "x509-signature",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-crypto-x509-utils",
+ "mc-fog-report-types",
+ "mc-fog-sig-authority",
+ "mc-fog-sig-report",
+ "pem",
+ "signature",
+ "x509-signature",
 ]
 
 [[package]]
 name = "mc-fog-sig-authority"
 version = "6.0.0"
 dependencies = [
-    "mc-crypto-keys",
+ "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-sig-report"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-crypto-digestible-signature",
-    "mc-crypto-keys",
-    "mc-fog-report-types",
-    "signature",
+ "displaydoc",
+ "mc-crypto-digestible-signature",
+ "mc-crypto-keys",
+ "mc-fog-report-types",
+ "signature",
 ]
 
 [[package]]
 name = "mc-fog-types"
 version = "6.0.0"
 dependencies = [
-    "crc",
-    "displaydoc",
-    "mc-attest-enclave-api",
-    "mc-common",
-    "mc-crypto-keys",
-    "mc-fog-kex-rng",
-    "mc-transaction-core",
-    "prost 0.12.3",
-    "serde",
+ "crc",
+ "displaydoc",
+ "mc-attest-enclave-api",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-fog-kex-rng",
+ "mc-transaction-core",
+ "prost 0.12.3",
+ "serde",
 ]
 
 [[package]]
 name = "mc-fog-uri"
 version = "6.0.0"
 dependencies = [
-    "mc-util-uri",
+ "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-full-service"
 version = "2.10.1"
 dependencies = [
-    "anyhow",
-    "async-trait",
-    "base64",
-    "bs58 0.5.0",
-    "chrono",
-    "clap 4.4.18",
-    "crossbeam-channel",
-    "diesel",
-    "diesel-derive-enum",
-    "diesel_migrations",
-    "displaydoc",
-    "dotenv",
-    "ed25519-dalek",
-    "grpcio",
-    "hex",
-    "itertools 0.10.5",
-    "ledger-mob",
-    "libsqlite3-sys",
-    "mc-account-keys",
-    "mc-api",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attestation-verifier",
-    "mc-blockchain-test-utils",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-connection",
-    "mc-connection-test-utils",
-    "mc-consensus-enclave-api",
-    "mc-consensus-enclave-measurement",
-    "mc-consensus-scp",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature-signer",
-    "mc-fog-report-connection",
-    "mc-fog-report-resolver",
-    "mc-fog-report-validation",
-    "mc-fog-report-validation-test-utils",
-    "mc-fog-sig-authority",
-    "mc-ledger-db",
-    "mc-ledger-migration",
-    "mc-ledger-sync",
-    "mc-mobilecoind",
-    "mc-mobilecoind-api",
-    "mc-mobilecoind-json",
-    "mc-rand",
-    "mc-sgx-core-types 0.9.0",
-    "mc-sgx-css",
-    "mc-transaction-builder",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-transaction-signer",
-    "mc-transaction-summary",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "mc-util-grpc",
-    "mc-util-parse",
-    "mc-util-serial",
-    "mc-util-uri",
-    "mc-validator-api",
-    "mc-validator-connection",
-    "mc-watcher",
-    "mc-watcher-api",
-    "num_cpus",
-    "prost 0.11.9",
-    "protobuf",
-    "rand 0.8.5",
-    "rayon",
-    "redact",
-    "reqwest",
-    "retry",
-    "rocket",
-    "rocket_sync_db_pools",
-    "serde",
-    "serde-big-array",
-    "serde_derive",
-    "serde_json",
-    "strum 0.25.0",
-    "strum_macros 0.25.3",
-    "t3-api",
-    "t3-connection",
-    "tempdir",
-    "tiny-bip39",
-    "tokio",
-    "url",
-    "uuid",
-    "vergen",
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bs58 0.5.0",
+ "chrono",
+ "clap 4.4.18",
+ "crossbeam-channel",
+ "diesel",
+ "diesel-derive-enum",
+ "diesel_migrations",
+ "displaydoc",
+ "dotenv",
+ "ed25519-dalek",
+ "grpcio",
+ "hex",
+ "ledger-mob",
+ "libsqlite3-sys",
+ "mc-account-keys",
+ "mc-api",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attestation-verifier",
+ "mc-blockchain-test-utils",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-connection",
+ "mc-connection-test-utils",
+ "mc-consensus-enclave-api",
+ "mc-consensus-enclave-measurement",
+ "mc-consensus-scp",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-connection",
+ "mc-fog-report-resolver",
+ "mc-fog-report-validation",
+ "mc-fog-report-validation-test-utils",
+ "mc-fog-sig-authority",
+ "mc-ledger-db",
+ "mc-ledger-migration",
+ "mc-ledger-sync",
+ "mc-mobilecoind",
+ "mc-mobilecoind-api",
+ "mc-mobilecoind-json",
+ "mc-rand",
+ "mc-sgx-core-types 0.9.0",
+ "mc-sgx-css",
+ "mc-transaction-builder",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-signer",
+ "mc-transaction-summary",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-grpc",
+ "mc-util-parse",
+ "mc-util-serial",
+ "mc-util-uri",
+ "mc-validator-api",
+ "mc-validator-connection",
+ "mc-watcher",
+ "mc-watcher-api",
+ "num_cpus",
+ "prost 0.11.9",
+ "protobuf",
+ "rand 0.8.5",
+ "rayon",
+ "redact",
+ "reqwest",
+ "retry",
+ "rocket",
+ "rocket_sync_db_pools",
+ "serde",
+ "serde-big-array",
+ "serde_derive",
+ "serde_json",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "t3-api",
+ "t3-connection",
+ "tempdir",
+ "tiny-bip39",
+ "tokio",
+ "url",
+ "uuid",
+ "vergen",
 ]
 
 [[package]]
 name = "mc-full-service-mirror"
 version = "2.10.1"
 dependencies = [
-    "boring",
-    "cargo-emit",
-    "futures",
-    "generic-array",
-    "grpcio",
-    "hex",
-    "mc-api",
-    "mc-common",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-grpc",
-    "mc-util-uri",
-    "num_cpus",
-    "protobuf",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "rand_hc",
-    "reqwest",
-    "rocket",
-    "serde",
-    "serde_derive",
-    "serde_json",
-    "structopt",
+ "boring",
+ "cargo-emit",
+ "futures",
+ "generic-array",
+ "grpcio",
+ "hex",
+ "mc-api",
+ "mc-common",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "num_cpus",
+ "protobuf",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_hc",
+ "reqwest",
+ "rocket",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "structopt",
 ]
 
 [[package]]
 name = "mc-ledger-db"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "lazy_static",
-    "lmdb-rkv",
-    "mc-account-keys",
-    "mc-blockchain-test-utils",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-crypto-keys",
-    "mc-transaction-builder",
-    "mc-transaction-core",
-    "mc-transaction-core-test-utils",
-    "mc-util-from-random",
-    "mc-util-lmdb",
-    "mc-util-metrics",
-    "mc-util-serial",
-    "mc-util-telemetry",
-    "mc-util-test-helper",
-    "mockall",
-    "prost 0.12.3",
-    "rand 0.8.5",
-    "tempfile",
+ "displaydoc",
+ "lazy_static",
+ "lmdb-rkv",
+ "mc-account-keys",
+ "mc-blockchain-test-utils",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-transaction-builder",
+ "mc-transaction-core",
+ "mc-transaction-core-test-utils",
+ "mc-util-from-random",
+ "mc-util-lmdb",
+ "mc-util-metrics",
+ "mc-util-serial",
+ "mc-util-telemetry",
+ "mc-util-test-helper",
+ "mockall",
+ "prost 0.12.3",
+ "rand 0.8.5",
+ "tempfile",
 ]
 
 [[package]]
 name = "mc-ledger-migration"
 version = "6.0.0"
 dependencies = [
-    "clap 4.4.18",
-    "lmdb-rkv",
-    "mc-common",
-    "mc-ledger-db",
-    "mc-util-lmdb",
-    "mc-util-serial",
-    "serde",
+ "clap 4.4.18",
+ "lmdb-rkv",
+ "mc-common",
+ "mc-ledger-db",
+ "mc-util-lmdb",
+ "mc-util-serial",
+ "serde",
 ]
 
 [[package]]
 name = "mc-ledger-sync"
 version = "6.0.0"
 dependencies = [
-    "crossbeam-channel",
-    "displaydoc",
-    "grpcio",
-    "mc-account-keys",
-    "mc-api",
-    "mc-attestation-verifier",
-    "mc-blockchain-test-utils",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-connection",
-    "mc-consensus-scp",
-    "mc-ledger-db",
-    "mc-transaction-core",
-    "mc-transaction-core-test-utils",
-    "mc-util-telemetry",
-    "mc-util-uri",
-    "mockall",
-    "protobuf",
-    "rand 0.8.5",
-    "reqwest",
-    "retry",
-    "serde",
-    "tempfile",
-    "url",
+ "crossbeam-channel",
+ "displaydoc",
+ "grpcio",
+ "mc-account-keys",
+ "mc-api",
+ "mc-attestation-verifier",
+ "mc-blockchain-test-utils",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-connection",
+ "mc-consensus-scp",
+ "mc-ledger-db",
+ "mc-transaction-core",
+ "mc-transaction-core-test-utils",
+ "mc-util-telemetry",
+ "mc-util-uri",
+ "mockall",
+ "protobuf",
+ "rand 0.8.5",
+ "reqwest",
+ "retry",
+ "serde",
+ "tempfile",
+ "url",
 ]
 
 [[package]]
 name = "mc-mobilecoind"
 version = "6.0.0"
 dependencies = [
-    "aes-gcm",
-    "clap 4.4.18",
-    "crossbeam-channel",
-    "displaydoc",
-    "grpcio",
-    "hex_fmt",
-    "libz-sys",
-    "lmdb-rkv",
-    "mc-account-keys",
-    "mc-api",
-    "mc-attest-core",
-    "mc-attestation-verifier",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-connection",
-    "mc-consensus-api",
-    "mc-consensus-enclave-api",
-    "mc-consensus-enclave-measurement",
-    "mc-consensus-scp",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature-signer",
-    "mc-fog-report-connection",
-    "mc-fog-report-resolver",
-    "mc-fog-report-validation",
-    "mc-ledger-db",
-    "mc-ledger-migration",
-    "mc-ledger-sync",
-    "mc-mobilecoind-api",
-    "mc-rand",
-    "mc-sgx-css",
-    "mc-transaction-builder",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-util-from-random",
-    "mc-util-grpc",
-    "mc-util-lmdb",
-    "mc-util-parse",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "mc-util-telemetry",
-    "mc-util-uri",
-    "mc-watcher",
-    "mc-watcher-api",
-    "num_cpus",
-    "prost 0.12.3",
-    "protobuf",
-    "rand 0.8.5",
-    "rayon",
-    "reqwest",
-    "retry",
-    "serde_json",
-    "tiny-bip39",
+ "aes-gcm",
+ "clap 4.4.18",
+ "crossbeam-channel",
+ "displaydoc",
+ "grpcio",
+ "hex_fmt",
+ "libz-sys",
+ "lmdb-rkv",
+ "mc-account-keys",
+ "mc-api",
+ "mc-attest-core",
+ "mc-attestation-verifier",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-connection",
+ "mc-consensus-api",
+ "mc-consensus-enclave-api",
+ "mc-consensus-enclave-measurement",
+ "mc-consensus-scp",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-connection",
+ "mc-fog-report-resolver",
+ "mc-fog-report-validation",
+ "mc-ledger-db",
+ "mc-ledger-migration",
+ "mc-ledger-sync",
+ "mc-mobilecoind-api",
+ "mc-rand",
+ "mc-sgx-css",
+ "mc-transaction-builder",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-util-from-random",
+ "mc-util-grpc",
+ "mc-util-lmdb",
+ "mc-util-parse",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-telemetry",
+ "mc-util-uri",
+ "mc-watcher",
+ "mc-watcher-api",
+ "num_cpus",
+ "prost 0.12.3",
+ "protobuf",
+ "rand 0.8.5",
+ "rayon",
+ "reqwest",
+ "retry",
+ "serde_json",
+ "tiny-bip39",
 ]
 
 [[package]]
 name = "mc-mobilecoind-api"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-attest-api",
-    "mc-fog-api",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-uri",
-    "protobuf",
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-attest-api",
+ "mc-fog-api",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-uri",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-mobilecoind-json"
 version = "6.0.0"
 dependencies = [
-    "clap 4.4.18",
-    "grpcio",
-    "hex",
-    "mc-api",
-    "mc-common",
-    "mc-mobilecoind-api",
-    "mc-util-grpc",
-    "mc-util-serial",
-    "protobuf",
-    "rocket",
-    "serde",
-    "serde_derive",
+ "clap 4.4.18",
+ "grpcio",
+ "hex",
+ "mc-api",
+ "mc-common",
+ "mc-mobilecoind-api",
+ "mc-util-grpc",
+ "mc-util-serial",
+ "protobuf",
+ "rocket",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3750,13 +3749,13 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be589d425ac3950edf94eb4185e625b4ca509d8caeab7ab461e107a73c3ebfb"
 dependencies = [
-    "aead",
-    "aes",
-    "cipher",
-    "ctr",
-    "ghash",
-    "subtle",
-    "zeroize",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3765,17 +3764,17 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce58f86dffd114bcefd8bcc6043658feec24b1f29be9972924651fe999ecf4a8"
 dependencies = [
-    "cfg-if",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
+ "cfg-if",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-sgx-compat"
 version = "6.0.0"
 dependencies = [
-    "cfg-if",
-    "mc-sgx-types",
+ "cfg-if",
+ "mc-sgx-types",
 ]
 
 [[package]]
@@ -3784,8 +3783,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a11c52ab87959e701a4cfadef6347598c6177b0de5ddfa4ce4918b71048d569c"
 dependencies = [
-    "bindgen 0.66.1",
-    "cargo-emit",
+ "bindgen 0.66.1",
+ "cargo-emit",
 ]
 
 [[package]]
@@ -3794,8 +3793,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f26e46d3279e257c6a418450332c94d0815486b8dbfdac76387e314e0c1093"
 dependencies = [
-    "bindgen 0.66.1",
-    "cargo-emit",
+ "bindgen 0.66.1",
+ "cargo-emit",
 ]
 
 [[package]]
@@ -3804,11 +3803,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e3737cd325f4fc372d5fe2efea18eeae1e32b08fd170677956e3ba81b46cf0"
 dependencies = [
-    "bindgen 0.66.1",
-    "cargo-emit",
-    "mc-sgx-core-build 0.9.0",
-    "serde",
-    "serde_with",
+ "bindgen 0.66.1",
+ "cargo-emit",
+ "mc-sgx-core-build 0.9.0",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -3817,11 +3816,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b56553b93bd334e1f468394e739f1e404cc54085872da7993cbf85438f25d6c"
 dependencies = [
-    "bindgen 0.66.1",
-    "cargo-emit",
-    "mc-sgx-core-build 0.10.1",
-    "serde",
-    "serde_with",
+ "bindgen 0.66.1",
+ "cargo-emit",
+ "mc-sgx-core-build 0.10.1",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -3830,16 +3829,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d243fa7499d18a9e84cb87c452d727a03c64c841709336d619fb4f9f7e4da892"
 dependencies = [
-    "bitflags 2.4.2",
-    "displaydoc",
-    "getrandom",
-    "hex",
-    "mc-sgx-core-sys-types 0.9.0",
-    "mc-sgx-util 0.9.0",
-    "nom",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
+ "bitflags 2.4.2",
+ "displaydoc",
+ "getrandom",
+ "hex",
+ "mc-sgx-core-sys-types 0.9.0",
+ "mc-sgx-util 0.9.0",
+ "nom",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
 ]
 
 [[package]]
@@ -3848,25 +3847,25 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc4a12a26208d90e08c0eaf85f8318c8f9ab8fd8abd9c505bcf64def220d2ff"
 dependencies = [
-    "bitflags 2.4.2",
-    "displaydoc",
-    "getrandom",
-    "hex",
-    "mc-sgx-core-sys-types 0.10.1",
-    "mc-sgx-util 0.10.1",
-    "nom",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
+ "bitflags 2.4.2",
+ "displaydoc",
+ "getrandom",
+ "hex",
+ "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-util 0.10.1",
+ "nom",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
 ]
 
 [[package]]
 name = "mc-sgx-css"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-sgx-core-types 0.10.1",
-    "sha2",
+ "displaydoc",
+ "mc-sgx-core-types 0.10.1",
+ "sha2",
 ]
 
 [[package]]
@@ -3875,9 +3874,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de6add229c047dc25fa8950ebf8e5fcc21a7f4d2b52c0b85b67b13d2edca08e9"
 dependencies = [
-    "bindgen 0.66.1",
-    "mc-sgx-core-build 0.10.1",
-    "mc-sgx-core-sys-types 0.10.1",
+ "bindgen 0.66.1",
+ "mc-sgx-core-build 0.10.1",
+ "mc-sgx-core-sys-types 0.10.1",
 ]
 
 [[package]]
@@ -3886,38 +3885,38 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8592ab2cf83ec03324dba68e3f24d9dac716d1cefa7db434f8fdf79e2aafcf9f"
 dependencies = [
-    "const-oid",
-    "displaydoc",
-    "hex",
-    "mc-sgx-core-types 0.10.1",
-    "mc-sgx-dcap-sys-types",
-    "mc-sgx-util 0.10.1",
-    "nom",
-    "p256",
-    "serde",
-    "sha2",
-    "static_assertions",
-    "subtle",
-    "x509-cert",
+ "const-oid",
+ "displaydoc",
+ "hex",
+ "mc-sgx-core-types 0.10.1",
+ "mc-sgx-dcap-sys-types",
+ "mc-sgx-util 0.10.1",
+ "nom",
+ "p256",
+ "serde",
+ "sha2",
+ "static_assertions",
+ "subtle",
+ "x509-cert",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-attest-core",
-    "mc-attest-enclave-api",
-    "mc-sgx-dcap-types",
-    "mc-util-serial",
-    "serde",
+ "displaydoc",
+ "mc-attest-core",
+ "mc-attest-enclave-api",
+ "mc-sgx-dcap-types",
+ "mc-util-serial",
+ "serde",
 ]
 
 [[package]]
 name = "mc-sgx-types"
 version = "6.0.0"
 dependencies = [
-    "mc-sgx-core-sys-types 0.10.1",
+ "mc-sgx-core-sys-types 0.10.1",
 ]
 
 [[package]]
@@ -3936,319 +3935,319 @@ checksum = "70a17bdd557d482382794a59232314fe9cfb7a9c4450aec867f737d815e5f5b0"
 name = "mc-signer"
 version = "2.10.1"
 dependencies = [
-    "anyhow",
-    "base64",
-    "clap 4.4.18",
-    "displaydoc",
-    "hex",
-    "log",
-    "mc-account-keys",
-    "mc-common",
-    "mc-core",
-    "mc-core-types",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-crypto-ring-signature-signer",
-    "mc-full-service",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-transaction-signer",
-    "mc-transaction-summary",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "rocket",
-    "serde",
-    "serde_json",
-    "structopt",
-    "strum 0.25.0",
-    "strum_macros 0.25.3",
-    "subtle",
-    "tiny-bip39",
-    "vergen",
-    "zeroize",
+ "anyhow",
+ "base64",
+ "clap 4.4.18",
+ "displaydoc",
+ "hex",
+ "log",
+ "mc-account-keys",
+ "mc-common",
+ "mc-core",
+ "mc-core-types",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-full-service",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-signer",
+ "mc-transaction-summary",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rocket",
+ "serde",
+ "serde_json",
+ "structopt",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "subtle",
+ "tiny-bip39",
+ "vergen",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-builder"
 version = "6.0.0"
 dependencies = [
-    "cfg-if",
-    "curve25519-dalek",
-    "displaydoc",
-    "hmac",
-    "mc-account-keys",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature-signer",
-    "mc-fog-report-validation",
-    "mc-transaction-core",
-    "mc-transaction-extra",
-    "mc-transaction-summary",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "mc-util-serial",
-    "mc-util-u64-ratio",
-    "prost 0.12.3",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "serde",
-    "sha2",
-    "subtle",
-    "zeroize",
+ "cfg-if",
+ "curve25519-dalek",
+ "displaydoc",
+ "hmac",
+ "mc-account-keys",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-summary",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-serial",
+ "mc-util-u64-ratio",
+ "prost 0.12.3",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-core"
 version = "6.0.0"
 dependencies = [
-    "aes",
-    "bulletproofs-og",
-    "crc",
-    "ctr",
-    "curve25519-dalek",
-    "displaydoc",
-    "generic-array",
-    "hex_fmt",
-    "hkdf",
-    "lazy_static",
-    "mc-account-keys",
-    "mc-common",
-    "mc-crypto-box",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-crypto-multisig",
-    "mc-crypto-ring-signature",
-    "mc-crypto-ring-signature-signer",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "mc-util-u64-ratio",
-    "mc-util-zip-exact",
-    "merlin",
-    "prost 0.12.3",
-    "rand_core 0.6.4",
-    "serde",
-    "sha2",
-    "subtle",
-    "zeroize",
+ "aes",
+ "bulletproofs-og",
+ "crc",
+ "ctr",
+ "curve25519-dalek",
+ "displaydoc",
+ "generic-array",
+ "hex_fmt",
+ "hkdf",
+ "lazy_static",
+ "mc-account-keys",
+ "mc-common",
+ "mc-crypto-box",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-u64-ratio",
+ "mc-util-zip-exact",
+ "merlin",
+ "prost 0.12.3",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-core-test-utils"
 version = "6.0.0"
 dependencies = [
-    "mc-account-keys",
-    "mc-crypto-keys",
-    "mc-crypto-multisig",
-    "mc-crypto-ring-signature-signer",
-    "mc-fog-report-validation-test-utils",
-    "mc-rand",
-    "mc-transaction-core",
-    "mc-util-from-random",
-    "mc-util-serial",
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation-test-utils",
+ "mc-rand",
+ "mc-transaction-core",
+ "mc-util-from-random",
+ "mc-util-serial",
 ]
 
 [[package]]
 name = "mc-transaction-extra"
 version = "6.0.0"
 dependencies = [
-    "cfg-if",
-    "curve25519-dalek",
-    "displaydoc",
-    "mc-account-keys",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-crypto-memo-mac",
-    "mc-crypto-ring-signature",
-    "mc-crypto-ring-signature-signer",
-    "mc-transaction-core",
-    "mc-transaction-summary",
-    "mc-transaction-types",
-    "mc-util-from-random",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "mc-util-u64-ratio",
-    "mc-util-vec-map",
-    "mc-util-zip-exact",
-    "prost 0.12.3",
-    "rand 0.8.5",
-    "rand_core 0.6.4",
-    "serde",
-    "subtle",
-    "zeroize",
+ "cfg-if",
+ "curve25519-dalek",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-memo-mac",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-transaction-core",
+ "mc-transaction-summary",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-u64-ratio",
+ "mc-util-vec-map",
+ "mc-util-zip-exact",
+ "prost 0.12.3",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-signer"
 version = "6.0.0"
 dependencies = [
-    "anyhow",
-    "clap 4.4.18",
-    "displaydoc",
-    "hex",
-    "log",
-    "mc-account-keys",
-    "mc-common",
-    "mc-core",
-    "mc-core-types",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-crypto-ring-signature-signer",
-    "mc-transaction-core",
-    "mc-transaction-summary",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "rand_core 0.6.4",
-    "serde",
-    "serde_json",
-    "subtle",
-    "tiny-bip39",
-    "zeroize",
+ "anyhow",
+ "clap 4.4.18",
+ "displaydoc",
+ "hex",
+ "log",
+ "mc-account-keys",
+ "mc-common",
+ "mc-core",
+ "mc-core-types",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-transaction-core",
+ "mc-transaction-summary",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "subtle",
+ "tiny-bip39",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-summary"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "mc-account-keys",
-    "mc-core",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "mc-transaction-types",
-    "mc-util-vec-map",
-    "mc-util-zip-exact",
-    "prost 0.12.3",
-    "serde",
-    "subtle",
-    "zeroize",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-core",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "mc-util-vec-map",
+ "mc-util-zip-exact",
+ "prost 0.12.3",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-types"
 version = "6.0.0"
 dependencies = [
-    "crc",
-    "displaydoc",
-    "hkdf",
-    "mc-crypto-digestible",
-    "mc-crypto-hashes",
-    "mc-crypto-keys",
-    "mc-crypto-ring-signature",
-    "prost 0.12.3",
-    "serde",
-    "sha2",
-    "subtle",
-    "zeroize",
+ "crc",
+ "displaydoc",
+ "hkdf",
+ "mc-crypto-digestible",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "prost 0.12.3",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "mc-util-build-enclave"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "cargo_metadata",
-    "displaydoc",
-    "mbedtls",
-    "mbedtls-sys-auto",
-    "mc-sgx-css",
-    "mc-util-build-script",
-    "mc-util-build-sgx",
-    "pkg-config",
-    "rand 0.8.5",
+ "cargo-emit",
+ "cargo_metadata",
+ "displaydoc",
+ "mbedtls",
+ "mbedtls-sys-auto",
+ "mc-sgx-css",
+ "mc-util-build-script",
+ "mc-util-build-sgx",
+ "pkg-config",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "mc-util-build-grpc"
 version = "6.0.0"
 dependencies = [
-    "mc-util-build-script",
-    "protoc-grpcio",
+ "mc-util-build-script",
+ "protoc-grpcio",
 ]
 
 [[package]]
 name = "mc-util-build-info"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
+ "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "displaydoc",
-    "lazy_static",
-    "url",
-    "walkdir",
+ "cargo-emit",
+ "displaydoc",
+ "lazy_static",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
 name = "mc-util-build-sgx"
 version = "6.0.0"
 dependencies = [
-    "cargo-emit",
-    "cc",
-    "displaydoc",
-    "mc-util-build-script",
-    "pkg-config",
+ "cargo-emit",
+ "cc",
+ "displaydoc",
+ "mc-util-build-script",
+ "pkg-config",
 ]
 
 [[package]]
 name = "mc-util-encodings"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "displaydoc",
-    "hex",
-    "mc-util-repr-bytes",
-    "serde",
+ "base64",
+ "displaydoc",
+ "hex",
+ "mc-util-repr-bytes",
+ "serde",
 ]
 
 [[package]]
 name = "mc-util-from-random"
 version = "6.0.0"
 dependencies = [
-    "rand_core 0.6.4",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-grpc"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "clap 4.4.18",
-    "cookie",
-    "displaydoc",
-    "futures",
-    "grpcio",
-    "hex",
-    "hex_fmt",
-    "hmac",
-    "lazy_static",
-    "mc-common",
-    "mc-util-build-grpc",
-    "mc-util-build-info",
-    "mc-util-metrics",
-    "mc-util-serial",
-    "mc-util-uri",
-    "prometheus",
-    "protobuf",
-    "rand 0.8.5",
-    "retry",
-    "serde",
-    "sha2",
-    "signal-hook",
-    "subtle",
-    "zeroize",
+ "base64",
+ "clap 4.4.18",
+ "cookie",
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "hex",
+ "hex_fmt",
+ "hmac",
+ "lazy_static",
+ "mc-common",
+ "mc-util-build-grpc",
+ "mc-util-build-info",
+ "mc-util-metrics",
+ "mc-util-serial",
+ "mc-util-uri",
+ "prometheus",
+ "protobuf",
+ "rand 0.8.5",
+ "retry",
+ "serde",
+ "sha2",
+ "signal-hook",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4259,85 +4258,85 @@ version = "6.0.0"
 name = "mc-util-lmdb"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "lmdb-rkv",
-    "mc-util-serial",
-    "prost 0.12.3",
+ "displaydoc",
+ "lmdb-rkv",
+ "mc-util-serial",
+ "prost 0.12.3",
 ]
 
 [[package]]
 name = "mc-util-logger-macros"
 version = "6.0.0"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "mc-util-metrics"
 version = "6.0.0"
 dependencies = [
-    "chrono",
-    "grpcio",
-    "lazy_static",
-    "mc-common",
-    "prometheus",
-    "protobuf",
-    "serde_json",
+ "chrono",
+ "grpcio",
+ "lazy_static",
+ "mc-common",
+ "prometheus",
+ "protobuf",
+ "serde_json",
 ]
 
 [[package]]
 name = "mc-util-parse"
 version = "6.0.0"
 dependencies = [
-    "hex",
-    "itertools 0.12.0",
-    "mc-sgx-css",
+ "hex",
+ "itertools 0.12.0",
+ "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
 version = "6.0.0"
 dependencies = [
-    "generic-array",
-    "hex_fmt",
-    "prost 0.12.3",
-    "serde",
+ "generic-array",
+ "hex_fmt",
+ "prost 0.12.3",
+ "serde",
 ]
 
 [[package]]
 name = "mc-util-serial"
 version = "6.0.0"
 dependencies = [
-    "prost 0.12.3",
-    "protobuf",
-    "serde",
-    "serde_cbor",
-    "serde_with",
+ "prost 0.12.3",
+ "protobuf",
+ "serde",
+ "serde_cbor",
+ "serde_with",
 ]
 
 [[package]]
 name = "mc-util-telemetry"
 version = "6.0.0"
 dependencies = [
-    "cfg-if",
-    "displaydoc",
-    "hostname",
-    "opentelemetry",
-    "opentelemetry-jaeger",
-    "opentelemetry_sdk",
+ "cfg-if",
+ "displaydoc",
+ "hostname",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
 name = "mc-util-test-helper"
 version = "6.0.0"
 dependencies = [
-    "clap 4.4.18",
-    "lazy_static",
-    "mc-account-keys",
-    "rand 0.8.5",
-    "rand_hc",
+ "clap 4.4.18",
+ "lazy_static",
+ "mc-account-keys",
+ "rand 0.8.5",
+ "rand_hc",
 ]
 
 [[package]]
@@ -4348,141 +4347,141 @@ version = "6.0.0"
 name = "mc-util-uri"
 version = "6.0.0"
 dependencies = [
-    "base64",
-    "displaydoc",
-    "hex",
-    "mc-common",
-    "mc-crypto-keys",
-    "mc-util-host-cert",
-    "percent-encoding",
-    "serde",
-    "url",
+ "base64",
+ "displaydoc",
+ "hex",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-util-host-cert",
+ "percent-encoding",
+ "serde",
+ "url",
 ]
 
 [[package]]
 name = "mc-util-vec-map"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "heapless 0.8.0",
+ "displaydoc",
+ "heapless 0.8.0",
 ]
 
 [[package]]
 name = "mc-util-zip-exact"
 version = "6.0.0"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
 name = "mc-validator-api"
 version = "2.10.1"
 dependencies = [
-    "cargo-emit",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-consensus-api",
-    "mc-fog-report-api",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-uri",
-    "protobuf",
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-consensus-api",
+ "mc-fog-report-api",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-uri",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-validator-connection"
 version = "2.10.1"
 dependencies = [
-    "displaydoc",
-    "futures",
-    "grpcio",
-    "mc-api",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-connection",
-    "mc-fog-report-types",
-    "mc-transaction-core",
-    "mc-util-grpc",
-    "mc-util-uri",
-    "mc-validator-api",
-    "protobuf",
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "mc-api",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-connection",
+ "mc-fog-report-types",
+ "mc-transaction-core",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "mc-validator-api",
+ "protobuf",
 ]
 
 [[package]]
 name = "mc-validator-service"
 version = "2.10.1"
 dependencies = [
-    "clap 4.4.18",
-    "grpcio",
-    "mc-attest-core",
-    "mc-attest-verifier",
-    "mc-attestation-verifier",
-    "mc-common",
-    "mc-connection",
-    "mc-consensus-enclave-measurement",
-    "mc-fog-report-connection",
-    "mc-full-service",
-    "mc-ledger-db",
-    "mc-ledger-sync",
-    "mc-sgx-core-types 0.9.0",
-    "mc-transaction-core",
-    "mc-util-grpc",
-    "mc-util-parse",
-    "mc-util-uri",
-    "mc-validator-api",
-    "rayon",
+ "clap 4.4.18",
+ "grpcio",
+ "mc-attest-core",
+ "mc-attest-verifier",
+ "mc-attestation-verifier",
+ "mc-common",
+ "mc-connection",
+ "mc-consensus-enclave-measurement",
+ "mc-fog-report-connection",
+ "mc-full-service",
+ "mc-ledger-db",
+ "mc-ledger-sync",
+ "mc-sgx-core-types 0.9.0",
+ "mc-transaction-core",
+ "mc-util-grpc",
+ "mc-util-parse",
+ "mc-util-uri",
+ "mc-validator-api",
+ "rayon",
 ]
 
 [[package]]
 name = "mc-watcher"
 version = "6.0.0"
 dependencies = [
-    "aes-gcm",
-    "clap 4.4.18",
-    "displaydoc",
-    "futures",
-    "grpcio",
-    "hex",
-    "lazy_static",
-    "lmdb-rkv",
-    "mc-api",
-    "mc-attest-ake",
-    "mc-attest-api",
-    "mc-attest-core",
-    "mc-attest-verifier-types",
-    "mc-blockchain-types",
-    "mc-common",
-    "mc-connection",
-    "mc-crypto-digestible",
-    "mc-crypto-keys",
-    "mc-crypto-noise",
-    "mc-ledger-db",
-    "mc-ledger-sync",
-    "mc-rand",
-    "mc-util-from-random",
-    "mc-util-grpc",
-    "mc-util-lmdb",
-    "mc-util-metrics",
-    "mc-util-parse",
-    "mc-util-repr-bytes",
-    "mc-util-serial",
-    "mc-util-uri",
-    "mc-watcher-api",
-    "prost 0.12.3",
-    "rayon",
-    "serde",
-    "sha2",
-    "toml 0.8.8",
-    "url",
+ "aes-gcm",
+ "clap 4.4.18",
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "hex",
+ "lazy_static",
+ "lmdb-rkv",
+ "mc-api",
+ "mc-attest-ake",
+ "mc-attest-api",
+ "mc-attest-core",
+ "mc-attest-verifier-types",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-connection",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-noise",
+ "mc-ledger-db",
+ "mc-ledger-sync",
+ "mc-rand",
+ "mc-util-from-random",
+ "mc-util-grpc",
+ "mc-util-lmdb",
+ "mc-util-metrics",
+ "mc-util-parse",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-uri",
+ "mc-watcher-api",
+ "prost 0.12.3",
+ "rayon",
+ "serde",
+ "sha2",
+ "toml 0.8.8",
+ "url",
 ]
 
 [[package]]
 name = "mc-watcher-api"
 version = "6.0.0"
 dependencies = [
-    "displaydoc",
-    "serde",
+ "displaydoc",
+ "serde",
 ]
 
 [[package]]
@@ -4497,10 +4496,10 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
-    "byteorder",
-    "keccak",
-    "rand_core 0.6.4",
-    "zeroize",
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -4509,8 +4508,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
-    "serde",
-    "toml 0.7.8",
+ "serde",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -4519,9 +4518,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
-    "migrations_internals",
-    "proc-macro2",
-    "quote",
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -4542,7 +4541,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
-    "adler",
+ "adler",
 ]
 
 [[package]]
@@ -4551,9 +4550,9 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
-    "libc",
-    "wasi",
-    "windows-sys 0.48.0",
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4562,13 +4561,13 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
 dependencies = [
-    "cfg-if",
-    "downcast",
-    "fragile",
-    "lazy_static",
-    "mockall_derive",
-    "predicates",
-    "predicates-tree",
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
 ]
 
 [[package]]
@@ -4577,10 +4576,10 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
-    "cfg-if",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4589,18 +4588,18 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
-    "bytes",
-    "encoding_rs",
-    "futures-util",
-    "http",
-    "httparse",
-    "log",
-    "memchr",
-    "mime",
-    "spin 0.9.8",
-    "tokio",
-    "tokio-util",
-    "version_check",
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "tokio",
+ "tokio-util",
+ "version_check",
 ]
 
 [[package]]
@@ -4615,8 +4614,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
-    "memchr",
-    "minimal-lexical",
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -4625,7 +4624,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
-    "winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -4634,8 +4633,8 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
-    "overload",
-    "winapi",
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -4644,9 +4643,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
-    "autocfg",
-    "num-integer",
-    "num-traits",
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4655,8 +4654,8 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
-    "autocfg",
-    "num-traits",
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -4665,7 +4664,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
-    "autocfg",
+ "autocfg",
 ]
 
 [[package]]
@@ -4674,8 +4673,8 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
-    "hermit-abi 0.3.4",
-    "libc",
+ "hermit-abi 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -4684,7 +4683,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
-    "num_enum_derive",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -4693,9 +4692,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4704,7 +4703,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -4713,7 +4712,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
-    "malloc_buf",
+ "malloc_buf",
 ]
 
 [[package]]
@@ -4722,7 +4721,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -4749,14 +4748,14 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
-    "futures-core",
-    "futures-sink",
-    "indexmap",
-    "js-sys",
-    "once_cell",
-    "pin-project-lite",
-    "thiserror",
-    "urlencoding",
+ "futures-core",
+ "futures-sink",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
@@ -4765,11 +4764,11 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
-    "async-trait",
-    "bytes",
-    "http",
-    "opentelemetry",
-    "reqwest",
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
 ]
 
 [[package]]
@@ -4778,17 +4777,17 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e617c66fd588e40e0dbbd66932fdc87393095b125d4459b1a3a10feb1712f8a1"
 dependencies = [
-    "async-trait",
-    "futures-core",
-    "futures-util",
-    "headers",
-    "http",
-    "opentelemetry",
-    "opentelemetry-http",
-    "opentelemetry-semantic-conventions",
-    "opentelemetry_sdk",
-    "reqwest",
-    "thrift",
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "headers",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest",
+ "thrift",
 ]
 
 [[package]]
@@ -4797,7 +4796,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
-    "opentelemetry",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -4806,17 +4805,17 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
-    "async-trait",
-    "crossbeam-channel",
-    "futures-channel",
-    "futures-executor",
-    "futures-util",
-    "once_cell",
-    "opentelemetry",
-    "ordered-float 4.2.0",
-    "percent-encoding",
-    "rand 0.8.5",
-    "thiserror",
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.2.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
 ]
 
 [[package]]
@@ -4825,7 +4824,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -4834,7 +4833,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
-    "num-traits",
+ "num-traits",
 ]
 
 [[package]]
@@ -4843,9 +4842,9 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
-    "log",
-    "serde",
-    "winapi",
+ "log",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -4860,10 +4859,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
-    "ecdsa",
-    "elliptic-curve",
-    "primeorder",
-    "sha2",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -4872,12 +4871,12 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
-    "arrayvec",
-    "bitvec",
-    "byte-slice-cast",
-    "impl-trait-for-tuples",
-    "parity-scale-codec-derive",
-    "serde",
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
 ]
 
 [[package]]
@@ -4886,10 +4885,10 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
-    "proc-macro-crate",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4898,8 +4897,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
-    "lock_api",
-    "parking_lot_core",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4908,11 +4907,11 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
-    "cfg-if",
-    "libc",
-    "redox_syscall",
-    "smallvec",
-    "windows-targets 0.48.5",
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4921,7 +4920,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
-    "digest",
+ "digest",
 ]
 
 [[package]]
@@ -4930,9 +4929,9 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
 dependencies = [
-    "inlinable_string",
-    "pear_codegen",
-    "yansi",
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
 ]
 
 [[package]]
@@ -4941,10 +4940,10 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
 dependencies = [
-    "proc-macro2",
-    "proc-macro2-diagnostics",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4959,8 +4958,8 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
-    "base64",
-    "serde",
+ "base64",
+ "serde",
 ]
 
 [[package]]
@@ -4969,7 +4968,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
-    "base64ct",
+ "base64ct",
 ]
 
 [[package]]
@@ -4984,8 +4983,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
-    "fixedbitset",
-    "indexmap",
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -5006,8 +5005,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
-    "der",
-    "spki",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5028,10 +5027,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "opaque-debug",
-    "universal-hash",
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5052,8 +5051,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
-    "anstyle",
-    "predicates-core",
+ "anstyle",
+ "predicates-core",
 ]
 
 [[package]]
@@ -5068,8 +5067,8 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
-    "predicates-core",
-    "termtree",
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -5078,8 +5077,8 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
-    "proc-macro2",
-    "syn 2.0.48",
+ "proc-macro2",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5088,7 +5087,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
-    "elliptic-curve",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5097,9 +5096,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
-    "fixed-hash",
-    "impl-codec",
-    "uint",
+ "fixed-hash",
+ "impl-codec",
+ "uint",
 ]
 
 [[package]]
@@ -5108,7 +5107,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
-    "toml_edit 0.20.7",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -5117,11 +5116,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
-    "proc-macro-error-attr",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
-    "version_check",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
 ]
 
 [[package]]
@@ -5130,9 +5129,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "version_check",
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -5141,7 +5140,7 @@ version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
-    "unicode-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5150,11 +5149,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
-    "version_check",
-    "yansi",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -5163,13 +5162,13 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
-    "cfg-if",
-    "fnv",
-    "lazy_static",
-    "memchr",
-    "parking_lot",
-    "protobuf",
-    "thiserror",
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
 ]
 
 [[package]]
@@ -5178,8 +5177,8 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
-    "bytes",
-    "prost-derive 0.11.9",
+ "bytes",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -5188,8 +5187,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
-    "bytes",
-    "prost-derive 0.12.3",
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -5198,20 +5197,20 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
-    "bytes",
-    "heck 0.4.1",
-    "itertools 0.10.5",
-    "log",
-    "multimap",
-    "once_cell",
-    "petgraph",
-    "prettyplease",
-    "prost 0.12.3",
-    "prost-types",
-    "regex",
-    "syn 2.0.48",
-    "tempfile",
-    "which",
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.12.3",
+ "prost-types",
+ "regex",
+ "syn 2.0.48",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -5220,11 +5219,11 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
-    "anyhow",
-    "itertools 0.10.5",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5233,11 +5232,11 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
-    "anyhow",
-    "itertools 0.10.5",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5246,7 +5245,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
-    "prost 0.12.3",
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -5261,7 +5260,7 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
 dependencies = [
-    "protobuf",
+ "protobuf",
 ]
 
 [[package]]
@@ -5270,8 +5269,8 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
 dependencies = [
-    "log",
-    "which",
+ "log",
+ "which",
 ]
 
 [[package]]
@@ -5280,12 +5279,12 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d0ed845138df84f72beb72faf6d726c70c99d0debb2b5e1e7dee61f853df7"
 dependencies = [
-    "failure",
-    "grpcio-compiler",
-    "protobuf",
-    "protobuf-codegen",
-    "protoc",
-    "tempfile",
+ "failure",
+ "grpcio-compiler",
+ "protobuf",
+ "protobuf-codegen",
+ "protoc",
+ "tempfile",
 ]
 
 [[package]]
@@ -5294,7 +5293,7 @@ version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
-    "proc-macro2",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -5303,9 +5302,9 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
-    "log",
-    "parking_lot",
-    "scheduled-thread-pool",
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -5320,11 +5319,11 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
-    "fuchsia-cprng",
-    "libc",
-    "rand_core 0.3.1",
-    "rdrand",
-    "winapi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
 ]
 
 [[package]]
@@ -5333,9 +5332,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
-    "libc",
-    "rand_chacha",
-    "rand_core 0.6.4",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5344,8 +5343,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
-    "ppv-lite86",
-    "rand_core 0.6.4",
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5354,7 +5353,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
-    "rand_core 0.4.2",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -5369,7 +5368,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
-    "getrandom",
+ "getrandom",
 ]
 
 [[package]]
@@ -5378,7 +5377,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
 dependencies = [
-    "rand_core 0.6.4",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5387,8 +5386,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
-    "either",
-    "rayon-core",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
@@ -5397,8 +5396,8 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
-    "crossbeam-deque",
-    "crossbeam-utils",
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -5407,7 +5406,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
-    "rand_core 0.3.1",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5416,7 +5415,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09525bbb69b77802609e9c714e28dbf2db3a8c88bf0e82c9c69c4ade77a949bd"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -5425,7 +5424,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
-    "bitflags 1.3.2",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5434,9 +5433,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
-    "getrandom",
-    "libredox",
-    "thiserror",
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -5445,7 +5444,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4846d4c50d1721b1a3bef8af76924eef20d5e723647333798c1b519b3a9473f"
 dependencies = [
-    "ref-cast-impl",
+ "ref-cast-impl",
 ]
 
 [[package]]
@@ -5454,9 +5453,9 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5465,10 +5464,10 @@ version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-automata 0.4.4",
-    "regex-syntax 0.8.2",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.4",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5477,7 +5476,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
-    "regex-syntax 0.6.29",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5486,9 +5485,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
-    "aho-corasick",
-    "memchr",
-    "regex-syntax 0.8.2",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5509,7 +5508,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
-    "winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -5518,41 +5517,41 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
-    "async-compression",
-    "base64",
-    "bytes",
-    "encoding_rs",
-    "futures-core",
-    "futures-util",
-    "h2",
-    "http",
-    "http-body",
-    "hyper",
-    "hyper-rustls",
-    "ipnet",
-    "js-sys",
-    "log",
-    "mime",
-    "once_cell",
-    "percent-encoding",
-    "pin-project-lite",
-    "rustls",
-    "rustls-native-certs",
-    "rustls-pemfile",
-    "serde",
-    "serde_json",
-    "serde_urlencoded",
-    "system-configuration",
-    "tokio",
-    "tokio-rustls",
-    "tokio-util",
-    "tower-service",
-    "url",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
-    "web-sys",
-    "webpki-roots",
-    "winreg",
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -5561,7 +5560,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
 dependencies = [
-    "rand 0.8.5",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5570,8 +5569,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
-    "hmac",
-    "subtle",
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -5580,13 +5579,13 @@ version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
-    "cc",
-    "libc",
-    "once_cell",
-    "spin 0.5.2",
-    "untrusted 0.7.1",
-    "web-sys",
-    "winapi",
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -5595,12 +5594,12 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
-    "cc",
-    "getrandom",
-    "libc",
-    "spin 0.9.8",
-    "untrusted 0.9.0",
-    "windows-sys 0.48.0",
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5615,36 +5614,36 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e7bb57ccb26670d73b6a47396c83139447b9e7878cab627fdfe9ea8da489150"
 dependencies = [
-    "async-stream",
-    "async-trait",
-    "atomic 0.5.3",
-    "binascii",
-    "bytes",
-    "either",
-    "figment",
-    "futures",
-    "indexmap",
-    "log",
-    "memchr",
-    "multer",
-    "num_cpus",
-    "parking_lot",
-    "pin-project-lite",
-    "rand 0.8.5",
-    "ref-cast",
-    "rocket_codegen",
-    "rocket_http",
-    "serde",
-    "serde_json",
-    "state",
-    "tempfile",
-    "time",
-    "tokio",
-    "tokio-stream",
-    "tokio-util",
-    "ubyte",
-    "version_check",
-    "yansi",
+ "async-stream",
+ "async-trait",
+ "atomic 0.5.3",
+ "binascii",
+ "bytes",
+ "either",
+ "figment",
+ "futures",
+ "indexmap",
+ "log",
+ "memchr",
+ "multer",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "ref-cast",
+ "rocket_codegen",
+ "rocket_http",
+ "serde",
+ "serde_json",
+ "state",
+ "tempfile",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ubyte",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -5653,15 +5652,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2238066abf75f21be6cd7dc1a09d5414a671f4246e384e49fe3f8a4936bd04c"
 dependencies = [
-    "devise",
-    "glob",
-    "indexmap",
-    "proc-macro2",
-    "quote",
-    "rocket_http",
-    "syn 2.0.48",
-    "unicode-xid",
-    "version_check",
+ "devise",
+ "glob",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "rocket_http",
+ "syn 2.0.48",
+ "unicode-xid",
+ "version_check",
 ]
 
 [[package]]
@@ -5670,28 +5669,28 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a1663694d059fe5f943ea5481363e48050acedd241d46deb2e27f71110389e"
 dependencies = [
-    "cookie",
-    "either",
-    "futures",
-    "http",
-    "hyper",
-    "indexmap",
-    "log",
-    "memchr",
-    "pear",
-    "percent-encoding",
-    "pin-project-lite",
-    "ref-cast",
-    "rustls",
-    "rustls-pemfile",
-    "serde",
-    "smallvec",
-    "stable-pattern",
-    "state",
-    "time",
-    "tokio",
-    "tokio-rustls",
-    "uncased",
+ "cookie",
+ "either",
+ "futures",
+ "http",
+ "hyper",
+ "indexmap",
+ "log",
+ "memchr",
+ "pear",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "smallvec",
+ "stable-pattern",
+ "state",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "uncased",
 ]
 
 [[package]]
@@ -5700,13 +5699,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f32721ed79509adac4328e97f817a8f55a47c4b64799f6fd6cc3adb6e42ff"
 dependencies = [
-    "diesel",
-    "r2d2",
-    "rocket",
-    "rocket_sync_db_pools_codegen",
-    "serde",
-    "tokio",
-    "version_check",
+ "diesel",
+ "r2d2",
+ "rocket",
+ "rocket_sync_db_pools_codegen",
+ "serde",
+ "tokio",
+ "version_check",
 ]
 
 [[package]]
@@ -5715,8 +5714,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc890925dc79370c28eb15c9957677093fdb7e8c44966d189f38cedb995ee68"
 dependencies = [
-    "devise",
-    "quote",
+ "devise",
+ "quote",
 ]
 
 [[package]]
@@ -5725,8 +5724,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683e8c8e8aac6ffa4b2287bac3c69575d5346accac4f218ae1e084303bb174ca"
 dependencies = [
-    "cc",
-    "zeroize",
+ "cc",
+ "zeroize",
 ]
 
 [[package]]
@@ -5753,7 +5752,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
-    "semver",
+ "semver",
 ]
 
 [[package]]
@@ -5762,11 +5761,11 @@ version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
-    "bitflags 2.4.2",
-    "errno",
-    "libc",
-    "linux-raw-sys",
-    "windows-sys 0.52.0",
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5775,10 +5774,10 @@ version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
-    "log",
-    "ring 0.17.7",
-    "rustls-webpki",
-    "sct",
+ "log",
+ "ring 0.17.7",
+ "rustls-webpki",
+ "sct",
 ]
 
 [[package]]
@@ -5787,10 +5786,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
-    "openssl-probe",
-    "rustls-pemfile",
-    "schannel",
-    "security-framework",
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5799,7 +5798,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
-    "base64",
+ "base64",
 ]
 
 [[package]]
@@ -5808,8 +5807,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
-    "ring 0.17.7",
-    "untrusted 0.9.0",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5830,7 +5829,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
-    "winapi-util",
+ "winapi-util",
 ]
 
 [[package]]
@@ -5839,7 +5838,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
-    "windows-sys 0.52.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5848,7 +5847,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
-    "parking_lot",
+ "parking_lot",
 ]
 
 [[package]]
@@ -5856,15 +5855,15 @@ name = "schnorrkel-og"
 version = "0.11.0-pre.0"
 source = "git+https://github.com/mobilecoinfoundation/schnorrkel.git?rev=049bf9d30f3bbe072e2ad1b5eefdf0f3c851215e#049bf9d30f3bbe072e2ad1b5eefdf0f3c851215e"
 dependencies = [
-    "arrayref",
-    "arrayvec",
-    "cfg-if",
-    "curve25519-dalek",
-    "merlin",
-    "rand_core 0.6.4",
-    "sha2",
-    "subtle",
-    "zeroize",
+ "arrayref",
+ "arrayvec",
+ "cfg-if",
+ "curve25519-dalek",
+ "merlin",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5885,8 +5884,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
-    "ring 0.17.7",
-    "untrusted 0.9.0",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5895,12 +5894,12 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
-    "base16ct",
-    "der",
-    "generic-array",
-    "pkcs8",
-    "subtle",
-    "zeroize",
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5909,7 +5908,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
-    "zeroize",
+ "zeroize",
 ]
 
 [[package]]
@@ -5918,11 +5917,11 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
-    "bitflags 1.3.2",
-    "core-foundation",
-    "core-foundation-sys",
-    "libc",
-    "security-framework-sys",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -5931,8 +5930,8 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5941,7 +5940,7 @@ version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -5950,20 +5949,20 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab18211f62fb890f27c9bb04861f76e4be35e4c2fcbfc2d98afa37aadebb16f1"
 dependencies = [
-    "httpdate",
-    "reqwest",
-    "rustls",
-    "sentry-backtrace",
-    "sentry-contexts",
-    "sentry-core",
-    "sentry-log",
-    "sentry-panic",
-    "sentry-slog",
-    "sentry-tracing",
-    "serde_json",
-    "tokio",
-    "ureq",
-    "webpki-roots",
+ "httpdate",
+ "reqwest",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-log",
+ "sentry-panic",
+ "sentry-slog",
+ "sentry-tracing",
+ "serde_json",
+ "tokio",
+ "ureq",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5972,10 +5971,10 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf018ff7d5ce5b23165a9cbfee60b270a55ae219bc9eebef2a3b6039356dd7e5"
 dependencies = [
-    "backtrace",
-    "once_cell",
-    "regex",
-    "sentry-core",
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
 ]
 
 [[package]]
@@ -5984,12 +5983,12 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d934df6f9a17b8c15b829860d9d6d39e78126b5b970b365ccbd817bc0fe82c9"
 dependencies = [
-    "hostname",
-    "libc",
-    "os_info",
-    "rustc_version",
-    "sentry-core",
-    "uname",
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
 ]
 
 [[package]]
@@ -5998,11 +5997,11 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e362d3fb1c5de5124bf1681086eaca7adf6a8c4283a7e1545359c729f9128ff"
 dependencies = [
-    "once_cell",
-    "rand 0.8.5",
-    "sentry-types",
-    "serde",
-    "serde_json",
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6011,8 +6010,8 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7574422f662fe062a2ef7d027659ad8745e05fb815770887aeb08e2fb92cf6"
 dependencies = [
-    "log",
-    "sentry-core",
+ "log",
+ "sentry-core",
 ]
 
 [[package]]
@@ -6021,8 +6020,8 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0224e7a8e2bd8a32d96804acb8243d6d6e073fed55618afbdabae8249a964d8"
 dependencies = [
-    "sentry-backtrace",
-    "sentry-core",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]
@@ -6031,9 +6030,9 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16adbbf6ec1e248d92b481e159eda295ea1d863c9ecaf12c88d3fb8de86f12a"
 dependencies = [
-    "sentry-core",
-    "serde_json",
-    "slog",
+ "sentry-core",
+ "serde_json",
+ "slog",
 ]
 
 [[package]]
@@ -6042,10 +6041,10 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087bed8c616d176a9c6b662a8155e5f23b40dc9e1fa96d0bd5fb56e8636a9275"
 dependencies = [
-    "sentry-backtrace",
-    "sentry-core",
-    "tracing-core",
-    "tracing-subscriber",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6054,15 +6053,15 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4f0e37945b7a8ce7faebc310af92442e2d7c5aa7ef5b42fe6daa98ee133f65"
 dependencies = [
-    "debugid",
-    "hex",
-    "rand 0.8.5",
-    "serde",
-    "serde_json",
-    "thiserror",
-    "time",
-    "url",
-    "uuid",
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -6071,7 +6070,7 @@ version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
-    "serde_derive",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6080,7 +6079,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -6089,10 +6088,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
 dependencies = [
-    "log",
-    "serde",
-    "thiserror",
-    "xml-rs",
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
@@ -6101,8 +6100,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
-    "half",
-    "serde",
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -6111,9 +6110,9 @@ version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6122,10 +6121,10 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
-    "indexmap",
-    "itoa",
-    "ryu",
-    "serde",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -6134,7 +6133,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -6143,10 +6142,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
-    "form_urlencoded",
-    "itoa",
-    "ryu",
-    "serde",
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -6155,8 +6154,8 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
-    "serde",
-    "serde_with_macros",
+ "serde",
+ "serde_with_macros",
 ]
 
 [[package]]
@@ -6165,10 +6164,10 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
-    "darling 0.20.3",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6177,9 +6176,9 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -6188,9 +6187,9 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
-    "cfg-if",
-    "cpufeatures",
-    "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -6199,8 +6198,8 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
-    "digest",
-    "keccak",
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -6209,7 +6208,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
-    "lazy_static",
+ "lazy_static",
 ]
 
 [[package]]
@@ -6224,8 +6223,8 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
-    "libc",
-    "signal-hook-registry",
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]
@@ -6234,7 +6233,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -6243,8 +6242,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
-    "digest",
-    "rand_core 0.6.4",
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6253,9 +6252,9 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
-    "log",
-    "termcolor",
-    "time",
+ "log",
+ "termcolor",
+ "time",
 ]
 
 [[package]]
@@ -6270,7 +6269,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
-    "autocfg",
+ "autocfg",
 ]
 
 [[package]]
@@ -6279,7 +6278,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be0ff28bf14f9610a342169084e87a4f435ad798ec528dc7579a3678fa9dc9a"
 dependencies = [
-    "hmac-sha512",
+ "hmac-sha512",
 ]
 
 [[package]]
@@ -6288,7 +6287,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
-    "erased-serde",
+ "erased-serde",
 ]
 
 [[package]]
@@ -6297,10 +6296,10 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
 dependencies = [
-    "crossbeam-channel",
-    "slog",
-    "take_mut",
-    "thread_local",
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
 ]
 
 [[package]]
@@ -6309,8 +6308,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b517f2dda9e1458733eb8350bad1a3632ffed8141be4c0f3d6def899a9b066"
 dependencies = [
-    "arc-swap",
-    "slog",
+ "arc-swap",
+ "slog",
 ]
 
 [[package]]
@@ -6319,13 +6318,13 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
 dependencies = [
-    "log",
-    "regex",
-    "slog",
-    "slog-async",
-    "slog-scope",
-    "slog-stdlog",
-    "slog-term",
+ "log",
+ "regex",
+ "slog",
+ "slog-async",
+ "slog-scope",
+ "slog-stdlog",
+ "slog-term",
 ]
 
 [[package]]
@@ -6334,10 +6333,10 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
 dependencies = [
-    "serde",
-    "serde_json",
-    "slog",
-    "time",
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
 ]
 
 [[package]]
@@ -6346,9 +6345,9 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
-    "arc-swap",
-    "lazy_static",
-    "slog",
+ "arc-swap",
+ "lazy_static",
+ "slog",
 ]
 
 [[package]]
@@ -6357,9 +6356,9 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
 dependencies = [
-    "log",
-    "slog",
-    "slog-scope",
+ "log",
+ "slog",
+ "slog-scope",
 ]
 
 [[package]]
@@ -6368,11 +6367,11 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
-    "atty",
-    "slog",
-    "term",
-    "thread_local",
-    "time",
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -6387,8 +6386,8 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
-    "libc",
-    "windows-sys 0.48.0",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6403,7 +6402,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
-    "lock_api",
+ "lock_api",
 ]
 
 [[package]]
@@ -6412,8 +6411,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
-    "base64ct",
-    "der",
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -6422,7 +6421,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -6437,7 +6436,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
-    "loom",
+ "loom",
 ]
 
 [[package]]
@@ -6464,9 +6463,9 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
-    "clap 2.34.0",
-    "lazy_static",
-    "structopt-derive",
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
 ]
 
 [[package]]
@@ -6475,11 +6474,11 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
-    "heck 0.3.3",
-    "proc-macro-error",
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6488,7 +6487,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
-    "strum_macros 0.24.3",
+ "strum_macros 0.24.3",
 ]
 
 [[package]]
@@ -6497,7 +6496,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
-    "strum_macros 0.25.3",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -6506,11 +6505,11 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
-    "heck 0.4.1",
-    "proc-macro2",
-    "quote",
-    "rustversion",
-    "syn 1.0.109",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6519,11 +6518,11 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
-    "heck 0.4.1",
-    "proc-macro2",
-    "quote",
-    "rustversion",
-    "syn 2.0.48",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6538,9 +6537,9 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "unicode-ident",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -6549,9 +6548,9 @@ version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "unicode-ident",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -6560,10 +6559,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 1.0.109",
-    "unicode-xid",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -6572,12 +6571,12 @@ version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
 dependencies = [
-    "cfg-if",
-    "core-foundation-sys",
-    "libc",
-    "ntapi",
-    "once_cell",
-    "windows 0.52.0",
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -6586,9 +6585,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
-    "bitflags 1.3.2",
-    "core-foundation",
-    "system-configuration-sys",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -6597,36 +6596,36 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
-    "core-foundation-sys",
-    "libc",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "t3-api"
 version = "2.10.1"
 dependencies = [
-    "cargo-emit",
-    "futures",
-    "grpcio",
-    "mc-util-build-grpc",
-    "mc-util-build-script",
-    "mc-util-uri",
-    "protobuf",
+ "cargo-emit",
+ "futures",
+ "grpcio",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-uri",
+ "protobuf",
 ]
 
 [[package]]
 name = "t3-connection"
 version = "2.10.1"
 dependencies = [
-    "displaydoc",
-    "futures",
-    "grpcio",
-    "mc-common",
-    "mc-connection",
-    "mc-util-grpc",
-    "mc-util-uri",
-    "protobuf",
-    "t3-api",
+ "displaydoc",
+ "futures",
+ "grpcio",
+ "mc-common",
+ "mc-connection",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "protobuf",
+ "t3-api",
 ]
 
 [[package]]
@@ -6647,8 +6646,8 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
-    "rand 0.4.6",
-    "remove_dir_all",
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -6657,11 +6656,11 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
-    "cfg-if",
-    "fastrand",
-    "redox_syscall",
-    "rustix",
-    "windows-sys 0.52.0",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6670,9 +6669,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
-    "dirs-next",
-    "rustversion",
-    "winapi",
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -6681,7 +6680,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
-    "winapi-util",
+ "winapi-util",
 ]
 
 [[package]]
@@ -6696,7 +6695,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
-    "unicode-width",
+ "unicode-width",
 ]
 
 [[package]]
@@ -6705,7 +6704,7 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
-    "thiserror-impl",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -6714,9 +6713,9 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6725,8 +6724,8 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
-    "cfg-if",
-    "once_cell",
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -6735,7 +6734,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
-    "num_cpus",
+ "num_cpus",
 ]
 
 [[package]]
@@ -6744,11 +6743,11 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
-    "byteorder",
-    "integer-encoding",
-    "log",
-    "ordered-float 2.10.1",
-    "threadpool",
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float 2.10.1",
+ "threadpool",
 ]
 
 [[package]]
@@ -6757,14 +6756,14 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
-    "deranged",
-    "itoa",
-    "libc",
-    "num_threads",
-    "powerfmt",
-    "serde",
-    "time-core",
-    "time-macros",
+ "deranged",
+ "itoa",
+ "libc",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -6779,7 +6778,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
-    "time-core",
+ "time-core",
 ]
 
 [[package]]
@@ -6788,17 +6787,17 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
-    "anyhow",
-    "hmac",
-    "once_cell",
-    "pbkdf2",
-    "rand 0.8.5",
-    "rustc-hash",
-    "sha2",
-    "thiserror",
-    "unicode-normalization",
-    "wasm-bindgen",
-    "zeroize",
+ "anyhow",
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand 0.8.5",
+ "rustc-hash",
+ "sha2",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -6807,7 +6806,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
-    "tinyvec_macros",
+ "tinyvec_macros",
 ]
 
 [[package]]
@@ -6822,17 +6821,17 @@ version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
-    "backtrace",
-    "bytes",
-    "libc",
-    "mio",
-    "num_cpus",
-    "parking_lot",
-    "pin-project-lite",
-    "signal-hook-registry",
-    "socket2",
-    "tokio-macros",
-    "windows-sys 0.48.0",
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6841,9 +6840,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6852,8 +6851,8 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
-    "rustls",
-    "tokio",
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -6862,10 +6861,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
-    "futures-core",
-    "pin-project-lite",
-    "tokio",
-    "tokio-util",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6874,12 +6873,12 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
-    "bytes",
-    "futures-core",
-    "futures-sink",
-    "pin-project-lite",
-    "tokio",
-    "tracing",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6888,10 +6887,10 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
-    "serde",
-    "serde_spanned",
-    "toml_datetime",
-    "toml_edit 0.19.15",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -6900,10 +6899,10 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
-    "serde",
-    "serde_spanned",
-    "toml_datetime",
-    "toml_edit 0.21.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -6912,7 +6911,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -6921,11 +6920,11 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
-    "indexmap",
-    "serde",
-    "serde_spanned",
-    "toml_datetime",
-    "winnow",
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -6934,9 +6933,9 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
-    "indexmap",
-    "toml_datetime",
-    "winnow",
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -6945,11 +6944,11 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
-    "indexmap",
-    "serde",
-    "serde_spanned",
-    "toml_datetime",
-    "winnow",
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -6964,9 +6963,9 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
-    "pin-project-lite",
-    "tracing-attributes",
-    "tracing-core",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
 ]
 
 [[package]]
@@ -6975,9 +6974,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6986,8 +6985,8 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
-    "once_cell",
-    "valuable",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -6996,9 +6995,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
-    "log",
-    "once_cell",
-    "tracing-core",
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7007,16 +7006,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
-    "matchers",
-    "nu-ansi-term",
-    "once_cell",
-    "regex",
-    "sharded-slab",
-    "smallvec",
-    "thread_local",
-    "tracing",
-    "tracing-core",
-    "tracing-log",
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7037,7 +7036,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 dependencies = [
-    "serde",
+ "serde",
 ]
 
 [[package]]
@@ -7046,10 +7045,10 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
-    "byteorder",
-    "crunchy",
-    "hex",
-    "static_assertions",
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7058,7 +7057,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
-    "libc",
+ "libc",
 ]
 
 [[package]]
@@ -7067,8 +7066,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
-    "serde",
-    "version_check",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -7089,7 +7088,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
-    "tinyvec",
+ "tinyvec",
 ]
 
 [[package]]
@@ -7116,8 +7115,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
-    "crypto-common",
-    "subtle",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -7138,13 +7137,13 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
-    "base64",
-    "log",
-    "once_cell",
-    "rustls",
-    "rustls-webpki",
-    "url",
-    "webpki-roots",
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7153,10 +7152,10 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
-    "form_urlencoded",
-    "idna",
-    "percent-encoding",
-    "serde",
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -7177,8 +7176,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
-    "getrandom",
-    "serde",
+ "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -7205,14 +7204,14 @@ version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
-    "anyhow",
-    "cargo_metadata",
-    "cfg-if",
-    "regex",
-    "rustc_version",
-    "rustversion",
-    "sysinfo",
-    "time",
+ "anyhow",
+ "cargo_metadata",
+ "cfg-if",
+ "regex",
+ "rustc_version",
+ "rustversion",
+ "sysinfo",
+ "time",
 ]
 
 [[package]]
@@ -7233,8 +7232,8 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
-    "same-file",
-    "winapi-util",
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -7243,7 +7242,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
-    "try-lock",
+ "try-lock",
 ]
 
 [[package]]
@@ -7258,8 +7257,8 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
-    "cfg-if",
-    "wasm-bindgen-macro",
+ "cfg-if",
+ "wasm-bindgen-macro",
 ]
 
 [[package]]
@@ -7268,13 +7267,13 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
-    "bumpalo",
-    "log",
-    "once_cell",
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
-    "wasm-bindgen-shared",
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -7283,10 +7282,10 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
-    "cfg-if",
-    "js-sys",
-    "wasm-bindgen",
-    "web-sys",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -7295,8 +7294,8 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
-    "quote",
-    "wasm-bindgen-macro-support",
+ "quote",
+ "wasm-bindgen-macro-support",
 ]
 
 [[package]]
@@ -7305,11 +7304,11 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
-    "wasm-bindgen-backend",
-    "wasm-bindgen-shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -7324,8 +7323,8 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
-    "js-sys",
-    "wasm-bindgen",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7340,10 +7339,10 @@ version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
-    "either",
-    "home",
-    "once_cell",
-    "rustix",
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -7352,8 +7351,8 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
-    "winapi-i686-pc-windows-gnu",
-    "winapi-x86_64-pc-windows-gnu",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
@@ -7368,7 +7367,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
-    "winapi",
+ "winapi",
 ]
 
 [[package]]
@@ -7383,7 +7382,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
-    "windows-targets 0.48.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7392,8 +7391,8 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
-    "windows-core",
-    "windows-targets 0.52.0",
+ "windows-core",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7402,7 +7401,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
-    "windows-targets 0.52.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7411,7 +7410,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
-    "windows-targets 0.48.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7420,7 +7419,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
-    "windows-targets 0.52.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7429,13 +7428,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
-    "windows_aarch64_gnullvm 0.48.5",
-    "windows_aarch64_msvc 0.48.5",
-    "windows_i686_gnu 0.48.5",
-    "windows_i686_msvc 0.48.5",
-    "windows_x86_64_gnu 0.48.5",
-    "windows_x86_64_gnullvm 0.48.5",
-    "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7444,13 +7443,13 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
-    "windows_aarch64_gnullvm 0.52.0",
-    "windows_aarch64_msvc 0.52.0",
-    "windows_i686_gnu 0.52.0",
-    "windows_i686_msvc 0.52.0",
-    "windows_x86_64_gnu 0.52.0",
-    "windows_x86_64_gnullvm 0.52.0",
-    "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -7543,7 +7542,7 @@ version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
-    "memchr",
+ "memchr",
 ]
 
 [[package]]
@@ -7552,8 +7551,8 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
-    "cfg-if",
-    "windows-sys 0.48.0",
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7562,7 +7561,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
-    "tap",
+ "tap",
 ]
 
 [[package]]
@@ -7571,8 +7570,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
-    "curve25519-dalek",
-    "rand_core 0.6.4",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7581,9 +7580,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
-    "const-oid",
-    "der",
-    "spki",
+ "const-oid",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -7592,8 +7591,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb2bc2a902d992cd5f471ee3ab0ffd6603047a4207384562755b9d6de977518"
 dependencies = [
-    "ring 0.16.20",
-    "untrusted 0.7.1",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -7608,7 +7607,7 @@ version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 dependencies = [
-    "is-terminal",
+ "is-terminal",
 ]
 
 [[package]]
@@ -7617,8 +7616,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
-    "bit-vec",
-    "num-bigint",
+ "bit-vec",
+ "num-bigint",
 ]
 
 [[package]]
@@ -7627,7 +7626,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
-    "zeroize_derive",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -7636,7 +7635,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
-    "proc-macro2",
-    "quote",
-    "syn 2.0.48",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "ed25519-dalek",
  "grpcio",
  "hex",
+ "itertools 0.10.5",
  "ledger-mob",
  "libsqlite3-sys",
  "mc-account-keys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli",
+    "gimli",
 ]
 
 [[package]]
@@ -23,8 +23,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
- "generic-array",
+    "crypto-common",
+    "generic-array",
 ]
 
 [[package]]
@@ -33,9 +33,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
+    "cfg-if",
+    "cipher",
+    "cpufeatures",
 ]
 
 [[package]]
@@ -44,12 +44,12 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
+    "aead",
+    "aes",
+    "cipher",
+    "ctr",
+    "ghash",
+    "subtle",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+    "winapi",
 ]
 
 [[package]]
@@ -97,12 +97,12 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
+    "anstyle",
+    "anstyle-parse",
+    "anstyle-query",
+    "anstyle-wincon",
+    "colorchoice",
+    "utf8parse",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
- "utf8parse",
+    "utf8parse",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.52.0",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -135,8 +135,8 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
+    "anstyle",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -169,11 +169,11 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
+    "flate2",
+    "futures-core",
+    "memchr",
+    "pin-project-lite",
+    "tokio",
 ]
 
 [[package]]
@@ -182,9 +182,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
+    "async-stream-impl",
+    "futures-core",
+    "pin-project-lite",
 ]
 
 [[package]]
@@ -193,9 +193,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -204,9 +204,9 @@ version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
- "critical-section",
+    "critical-section",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+    "hermit-abi 0.1.19",
+    "libc",
+    "winapi",
 ]
 
 [[package]]
@@ -256,13 +256,13 @@ version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
+    "addr2line",
+    "cc",
+    "cfg-if",
+    "libc",
+    "miniz_oxide",
+    "object",
+    "rustc-demangle",
 ]
 
 [[package]]
@@ -295,21 +295,21 @@ version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "clap 2.34.0",
- "env_logger",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
+    "bitflags 1.3.2",
+    "cexpr",
+    "clang-sys",
+    "clap 2.34.0",
+    "env_logger",
+    "lazy_static",
+    "lazycell",
+    "log",
+    "peeking_take_while",
+    "proc-macro2",
+    "quote",
+    "regex",
+    "rustc-hash",
+    "shlex",
+    "which",
 ]
 
 [[package]]
@@ -318,20 +318,20 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 1.0.109",
- "which",
+    "bitflags 1.3.2",
+    "cexpr",
+    "clang-sys",
+    "lazy_static",
+    "lazycell",
+    "log",
+    "peeking_take_while",
+    "proc-macro2",
+    "quote",
+    "regex",
+    "rustc-hash",
+    "shlex",
+    "syn 1.0.109",
+    "which",
 ]
 
 [[package]]
@@ -340,21 +340,21 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.4.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.48",
- "which",
+    "bitflags 2.4.2",
+    "cexpr",
+    "clang-sys",
+    "lazy_static",
+    "lazycell",
+    "log",
+    "peeking_take_while",
+    "prettyplease",
+    "proc-macro2",
+    "quote",
+    "regex",
+    "rustc-hash",
+    "shlex",
+    "syn 2.0.48",
+    "which",
 ]
 
 [[package]]
@@ -363,18 +363,18 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.4.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.48",
+    "bitflags 2.4.2",
+    "cexpr",
+    "clang-sys",
+    "lazy_static",
+    "lazycell",
+    "peeking_take_while",
+    "proc-macro2",
+    "quote",
+    "regex",
+    "rustc-hash",
+    "shlex",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -404,10 +404,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
+    "funty",
+    "radium",
+    "tap",
+    "wyz",
 ]
 
 [[package]]
@@ -416,7 +416,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+    "digest",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+    "generic-array",
 ]
 
 [[package]]
@@ -440,19 +440,19 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce7d4413c940e8e3cb6afc122d3f4a07096aca259d286781128683fc9f39d9b"
 dependencies = [
- "async-trait",
- "bitflags 2.4.2",
- "bluez-generated",
- "dbus",
- "dbus-tokio",
- "futures",
- "itertools 0.10.5",
- "log",
- "serde",
- "serde-xml-rs",
- "thiserror",
- "tokio",
- "uuid",
+    "async-trait",
+    "bitflags 2.4.2",
+    "bluez-generated",
+    "dbus",
+    "dbus-tokio",
+    "futures",
+    "itertools 0.10.5",
+    "log",
+    "serde",
+    "serde-xml-rs",
+    "thiserror",
+    "tokio",
+    "uuid",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d1c659dbc82f0b8ca75606c91a371e763589b7f6acf36858eeed0c705afe367"
 dependencies = [
- "dbus",
+    "dbus",
 ]
 
 [[package]]
@@ -470,11 +470,11 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15fabc62c27039b971303b808e3d2683863cc4bbcffbf1615f18d6190b20eaa6"
 dependencies = [
- "bitflags 2.4.2",
- "boring-sys",
- "foreign-types 0.5.0",
- "libc",
- "once_cell",
+    "bitflags 2.4.2",
+    "boring-sys",
+    "foreign-types 0.5.0",
+    "libc",
+    "once_cell",
 ]
 
 [[package]]
@@ -483,10 +483,10 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007c69b35cbe5c5963eecfc50f224d60199c95b2bfbeb957eedba5988e57f91c"
 dependencies = [
- "bindgen 0.68.1",
- "cmake",
- "fs_extra",
- "fslock",
+    "bindgen 0.68.1",
+    "cmake",
+    "fs_extra",
+    "fslock",
 ]
 
 [[package]]
@@ -495,7 +495,7 @@ version = "0.6.0+e46383f"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5edec42197c014d84ea2396589f0da14b2257f63f319442b5e8475a077b90457"
 dependencies = [
- "cmake",
+    "cmake",
 ]
 
 [[package]]
@@ -510,7 +510,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "tinyvec",
+    "tinyvec",
 ]
 
 [[package]]
@@ -519,25 +519,25 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790e133b9d27f6dbd1289e046e735cef97fb0b4c840f18db52c959521dfb8145"
 dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bluez-async",
- "cocoa",
- "dashmap",
- "dbus",
- "futures",
- "jni",
- "jni-utils",
- "libc",
- "log",
- "objc",
- "once_cell",
- "static_assertions",
- "thiserror",
- "tokio",
- "tokio-stream",
- "uuid",
- "windows 0.48.0",
+    "async-trait",
+    "bitflags 1.3.2",
+    "bluez-async",
+    "cocoa",
+    "dashmap",
+    "dbus",
+    "futures",
+    "jni",
+    "jni-utils",
+    "libc",
+    "log",
+    "objc",
+    "once_cell",
+    "static_assertions",
+    "thiserror",
+    "tokio",
+    "tokio-stream",
+    "uuid",
+    "windows 0.48.0",
 ]
 
 [[package]]
@@ -545,15 +545,15 @@ name = "bulletproofs-og"
 version = "3.0.0-pre.1"
 source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=9abfdc054d9ba65f1e185ea1e6eff3947ce879dc#9abfdc054d9ba65f1e185ea1e6eff3947ce879dc"
 dependencies = [
- "byteorder",
- "clear_on_drop",
- "curve25519-dalek",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "serde_derive",
- "sha3",
- "subtle",
+    "byteorder",
+    "clear_on_drop",
+    "curve25519-dalek",
+    "merlin",
+    "rand_core 0.6.4",
+    "serde",
+    "serde_derive",
+    "sha3",
+    "subtle",
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -616,12 +616,12 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
+    "camino",
+    "cargo-platform",
+    "semver",
+    "serde",
+    "serde_json",
+    "thiserror",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+    "nom",
 ]
 
 [[package]]
@@ -660,12 +660,12 @@ version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets 0.52.0",
+    "android-tzdata",
+    "iana-time-zone",
+    "js-sys",
+    "num-traits",
+    "wasm-bindgen",
+    "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -674,8 +674,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+    "crypto-common",
+    "inout",
 ]
 
 [[package]]
@@ -684,9 +684,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
- "glob",
- "libc",
- "libloading",
+    "glob",
+    "libc",
+    "libloading",
 ]
 
 [[package]]
@@ -695,13 +695,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+    "ansi_term",
+    "atty",
+    "bitflags 1.3.2",
+    "strsim 0.8.0",
+    "textwrap",
+    "unicode-width",
+    "vec_map",
 ]
 
 [[package]]
@@ -710,8 +710,8 @@ version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
- "clap_builder",
- "clap_derive",
+    "clap_builder",
+    "clap_derive",
 ]
 
 [[package]]
@@ -720,10 +720,10 @@ version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.10.0",
+    "anstream",
+    "anstyle",
+    "clap_lex",
+    "strsim 0.10.0",
 ]
 
 [[package]]
@@ -732,10 +732,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "heck 0.4.1",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
 dependencies = [
- "cc",
+    "cc",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
- "cc",
+    "cc",
 ]
 
 [[package]]
@@ -768,14 +768,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags 1.3.2",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics",
- "foreign-types 0.3.2",
- "libc",
- "objc",
+    "bitflags 1.3.2",
+    "block",
+    "cocoa-foundation",
+    "core-foundation",
+    "core-graphics",
+    "foreign-types 0.3.2",
+    "libc",
+    "objc",
 ]
 
 [[package]]
@@ -784,12 +784,12 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-foundation",
- "core-graphics-types",
- "libc",
- "objc",
+    "bitflags 1.3.2",
+    "block",
+    "core-foundation",
+    "core-graphics-types",
+    "libc",
+    "objc",
 ]
 
 [[package]]
@@ -804,8 +804,8 @@ version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
- "bytes",
- "memchr",
+    "bytes",
+    "memchr",
 ]
 
 [[package]]
@@ -820,9 +820,9 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
 dependencies = [
- "percent-encoding",
- "time",
- "version_check",
+    "percent-encoding",
+    "time",
+    "version_check",
 ]
 
 [[package]]
@@ -831,8 +831,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
- "libc",
+    "core-foundation-sys",
+    "libc",
 ]
 
 [[package]]
@@ -847,11 +847,11 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "libc",
+    "bitflags 1.3.2",
+    "core-foundation",
+    "core-graphics-types",
+    "foreign-types 0.3.2",
+    "libc",
 ]
 
 [[package]]
@@ -860,9 +860,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
+    "bitflags 1.3.2",
+    "core-foundation",
+    "libc",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -880,7 +880,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
- "crc-catalog",
+    "crc-catalog",
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+    "cfg-if",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "crossbeam-utils",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -919,8 +919,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+    "crossbeam-epoch",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "crossbeam-utils",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -950,10 +950,10 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
+    "generic-array",
+    "rand_core 0.6.4",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -962,9 +962,9 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "typenum",
+    "generic-array",
+    "rand_core 0.6.4",
+    "typenum",
 ]
 
 [[package]]
@@ -973,7 +973,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+    "cipher",
 ]
 
 [[package]]
@@ -982,17 +982,17 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "platforms",
- "rand_core 0.6.4",
- "rustc_version",
- "serde",
- "subtle",
- "zeroize",
+    "cfg-if",
+    "cpufeatures",
+    "curve25519-dalek-derive",
+    "digest",
+    "fiat-crypto",
+    "platforms",
+    "rand_core 0.6.4",
+    "rustc_version",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -1001,9 +1001,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1012,8 +1012,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
+    "darling_core 0.14.4",
+    "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1022,8 +1022,8 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+    "darling_core 0.20.3",
+    "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1032,12 +1032,12 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+    "fnv",
+    "ident_case",
+    "proc-macro2",
+    "quote",
+    "strsim 0.10.0",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -1046,12 +1046,12 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 2.0.48",
+    "fnv",
+    "ident_case",
+    "proc-macro2",
+    "quote",
+    "strsim 0.10.0",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1060,9 +1060,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
+    "darling_core 0.14.4",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -1071,9 +1071,9 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.3",
- "quote",
- "syn 2.0.48",
+    "darling_core 0.20.3",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1082,11 +1082,11 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
+    "cfg-if",
+    "hashbrown",
+    "lock_api",
+    "once_cell",
+    "parking_lot_core",
 ]
 
 [[package]]
@@ -1095,11 +1095,11 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
 dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "libdbus-sys",
- "winapi",
+    "futures-channel",
+    "futures-util",
+    "libc",
+    "libdbus-sys",
+    "winapi",
 ]
 
 [[package]]
@@ -1108,9 +1108,9 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
 dependencies = [
- "dbus",
- "libc",
- "tokio",
+    "dbus",
+    "libc",
+    "tokio",
 ]
 
 [[package]]
@@ -1119,8 +1119,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "serde",
- "uuid",
+    "serde",
+    "uuid",
 ]
 
 [[package]]
@@ -1129,11 +1129,11 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
- "const-oid",
- "der_derive",
- "flagset",
- "pem-rfc7468",
- "zeroize",
+    "const-oid",
+    "der_derive",
+    "flagset",
+    "pem-rfc7468",
+    "zeroize",
 ]
 
 [[package]]
@@ -1142,9 +1142,9 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
- "powerfmt",
+    "powerfmt",
 ]
 
 [[package]]
@@ -1162,8 +1162,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6eacefd3f541c66fc61433d65e54e0e46e0a029a819a7dbbc7a7b489e8a85f8"
 dependencies = [
- "devise_codegen",
- "devise_core",
+    "devise_codegen",
+    "devise_core",
 ]
 
 [[package]]
@@ -1172,8 +1172,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8cf4b8dd484ede80fd5c547592c46c3745a617c8af278e2b72bea86b2dfed6"
 dependencies = [
- "devise_core",
- "quote",
+    "devise_core",
+    "quote",
 ]
 
 [[package]]
@@ -1182,11 +1182,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
 dependencies = [
- "bitflags 2.4.2",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.48",
+    "bitflags 2.4.2",
+    "proc-macro2",
+    "proc-macro2-diagnostics",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1195,11 +1195,11 @@ version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
 dependencies = [
- "chrono",
- "diesel_derives",
- "libsqlite3-sys",
- "r2d2",
- "time",
+    "chrono",
+    "diesel_derives",
+    "libsqlite3-sys",
+    "r2d2",
+    "time",
 ]
 
 [[package]]
@@ -1208,10 +1208,10 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81c5131a2895ef64741dad1d483f358c2a229a3a2d1b256778cdc5e146db64d4"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "heck 0.4.1",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1220,10 +1220,10 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
- "diesel_table_macro_syntax",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "diesel_table_macro_syntax",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1232,9 +1232,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
- "diesel",
- "migrations_internals",
- "migrations_macros",
+    "diesel",
+    "migrations_internals",
+    "migrations_macros",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.48",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1252,10 +1252,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
- "subtle",
+    "block-buffer",
+    "const-oid",
+    "crypto-common",
+    "subtle",
 ]
 
 [[package]]
@@ -1264,8 +1264,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+    "cfg-if",
+    "dirs-sys-next",
 ]
 
 [[package]]
@@ -1274,9 +1274,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc",
- "redox_users",
- "winapi",
+    "libc",
+    "redox_users",
+    "winapi",
 ]
 
 [[package]]
@@ -1285,9 +1285,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1308,11 +1308,11 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
+    "der",
+    "digest",
+    "elliptic-curve",
+    "rfc6979",
+    "signature",
 ]
 
 [[package]]
@@ -1321,9 +1321,9 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "serde",
- "signature",
+    "pkcs8",
+    "serde",
+    "signature",
 ]
 
 [[package]]
@@ -1332,14 +1332,14 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2",
- "signature",
- "subtle",
- "zeroize",
+    "curve25519-dalek",
+    "ed25519",
+    "rand_core 0.6.4",
+    "serde",
+    "sha2",
+    "signature",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -1354,18 +1354,18 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
+    "base16ct",
+    "crypto-bigint",
+    "digest",
+    "ff",
+    "generic-array",
+    "group",
+    "pem-rfc7468",
+    "pkcs8",
+    "rand_core 0.6.4",
+    "sec1",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -1374,8 +1374,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25de94e10baa85551f7c65730423239370ed5bed60bf8d2a9cbf2683327ba421"
 dependencies = [
- "encdec-base 0.9.0",
- "encdec-macros",
+    "encdec-base 0.9.0",
+    "encdec-macros",
 ]
 
 [[package]]
@@ -1384,8 +1384,8 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8542ff2a35da7fc94ffcf280f35dc759219c4b48fa930e0a0f268220d7fb6a"
 dependencies = [
- "byteorder",
- "num-traits",
+    "byteorder",
+    "num-traits",
 ]
 
 [[package]]
@@ -1394,10 +1394,10 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516ae3c7d00515548bf26a6531883335ceac2e9cde4938e70feea7456569be09"
 dependencies = [
- "byteorder",
- "heapless 0.7.17",
- "num-traits",
- "thiserror",
+    "byteorder",
+    "heapless 0.7.17",
+    "num-traits",
+    "thiserror",
 ]
 
 [[package]]
@@ -1406,11 +1406,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15497932aae6b53bf8548cc63c65929b4fab6be54e28709c80fc72f5707eeed"
 dependencies = [
- "darling 0.14.4",
- "encdec-base 0.8.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "darling 0.14.4",
+    "encdec-base 0.8.3",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if",
+    "cfg-if",
 ]
 
 [[package]]
@@ -1428,11 +1428,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
+    "atty",
+    "humantime",
+    "log",
+    "regex",
+    "termcolor",
 ]
 
 [[package]]
@@ -1447,7 +1447,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -1456,8 +1456,8 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "libc",
- "windows-sys 0.52.0",
+    "libc",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1466,8 +1466,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
- "backtrace",
- "failure_derive",
+    "backtrace",
+    "failure_derive",
 ]
 
 [[package]]
@@ -1476,10 +1476,10 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
+    "synstructure",
 ]
 
 [[package]]
@@ -1494,8 +1494,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
- "subtle",
+    "rand_core 0.6.4",
+    "subtle",
 ]
 
 [[package]]
@@ -1510,12 +1510,12 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
 dependencies = [
- "atomic 0.6.0",
- "pear",
- "serde",
- "toml 0.8.8",
- "uncased",
- "version_check",
+    "atomic 0.6.0",
+    "pear",
+    "serde",
+    "toml 0.8.8",
+    "uncased",
+    "version_check",
 ]
 
 [[package]]
@@ -1524,10 +1524,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
+    "byteorder",
+    "rand 0.8.5",
+    "rustc-hex",
+    "static_assertions",
 ]
 
 [[package]]
@@ -1548,8 +1548,8 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
- "crc32fast",
- "miniz_oxide",
+    "crc32fast",
+    "miniz_oxide",
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
+    "foreign-types-shared 0.1.1",
 ]
 
 [[package]]
@@ -1573,8 +1573,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+    "foreign-types-macros",
+    "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1583,9 +1583,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1606,7 +1606,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+    "percent-encoding",
 ]
 
 [[package]]
@@ -1627,8 +1627,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
- "libc",
- "winapi",
+    "libc",
+    "winapi",
 ]
 
 [[package]]
@@ -1649,13 +1649,13 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
+    "futures-channel",
+    "futures-core",
+    "futures-executor",
+    "futures-io",
+    "futures-sink",
+    "futures-task",
+    "futures-util",
 ]
 
 [[package]]
@@ -1664,8 +1664,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
- "futures-core",
- "futures-sink",
+    "futures-core",
+    "futures-sink",
 ]
 
 [[package]]
@@ -1680,9 +1680,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
+    "futures-core",
+    "futures-task",
+    "futures-util",
 ]
 
 [[package]]
@@ -1697,9 +1697,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -1720,16 +1720,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
+    "futures-channel",
+    "futures-core",
+    "futures-io",
+    "futures-macro",
+    "futures-sink",
+    "futures-task",
+    "memchr",
+    "pin-project-lite",
+    "pin-utils",
+    "slab",
 ]
 
 [[package]]
@@ -1738,11 +1738,11 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
 dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows 0.48.0",
+    "cc",
+    "libc",
+    "log",
+    "rustversion",
+    "windows 0.48.0",
 ]
 
 [[package]]
@@ -1751,10 +1751,10 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
- "typenum",
- "version_check",
- "zeroize",
+    "serde",
+    "typenum",
+    "version_check",
+    "zeroize",
 ]
 
 [[package]]
@@ -1763,7 +1763,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e26859a808ffa83a83f20c7e3c9366afea91edae637a6ac203051885882dc8"
 dependencies = [
- "void",
+    "void",
 ]
 
 [[package]]
@@ -1772,9 +1772,9 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+    "cfg-if",
+    "libc",
+    "wasi",
 ]
 
 [[package]]
@@ -1783,8 +1783,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
 dependencies = [
- "opaque-debug",
- "polyval",
+    "opaque-debug",
+    "polyval",
 ]
 
 [[package]]
@@ -1805,9 +1805,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
+    "ff",
+    "rand_core 0.6.4",
+    "subtle",
 ]
 
 [[package]]
@@ -1816,13 +1816,13 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e398946b5721d72478eb647260a1b7c1d5f70f0de35399846c3913bd369a33e"
 dependencies = [
- "futures-executor",
- "futures-util",
- "grpcio-sys",
- "libc",
- "log",
- "parking_lot",
- "protobuf",
+    "futures-executor",
+    "futures-util",
+    "grpcio-sys",
+    "libc",
+    "log",
+    "parking_lot",
+    "protobuf",
 ]
 
 [[package]]
@@ -1831,7 +1831,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f1abac9f330ac9ee0950220c10eea84d66479cede4836f0b924407fecf093c"
 dependencies = [
- "protobuf",
+    "protobuf",
 ]
 
 [[package]]
@@ -1840,14 +1840,14 @@ version = "0.13.0+1.56.2-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3dae9132320ae1b03ea55b5ddc88ca72a31fb85fa631a241a40157f5feffe43"
 dependencies = [
- "bindgen 0.59.2",
- "boringssl-src",
- "cc",
- "cmake",
- "libc",
- "libz-sys",
- "pkg-config",
- "walkdir",
+    "bindgen 0.59.2",
+    "boringssl-src",
+    "cc",
+    "cmake",
+    "libc",
+    "libz-sys",
+    "pkg-config",
+    "walkdir",
 ]
 
 [[package]]
@@ -1856,17 +1856,17 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+    "bytes",
+    "fnv",
+    "futures-core",
+    "futures-sink",
+    "futures-util",
+    "http",
+    "indexmap",
+    "slab",
+    "tokio",
+    "tokio-util",
+    "tracing",
 ]
 
 [[package]]
@@ -1881,7 +1881,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
- "byteorder",
+    "byteorder",
 ]
 
 [[package]]
@@ -1890,7 +1890,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
- "byteorder",
+    "byteorder",
 ]
 
 [[package]]
@@ -1899,8 +1899,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "allocator-api2",
- "serde",
+    "allocator-api2",
+    "serde",
 ]
 
 [[package]]
@@ -1909,13 +1909,13 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
+    "base64",
+    "bytes",
+    "headers-core",
+    "http",
+    "httpdate",
+    "mime",
+    "sha1",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+    "http",
 ]
 
 [[package]]
@@ -1933,11 +1933,11 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "spin 0.9.8",
- "stable_deref_trait",
+    "atomic-polyfill",
+    "hash32 0.2.1",
+    "rustc_version",
+    "spin 0.9.8",
+    "stable_deref_trait",
 ]
 
 [[package]]
@@ -1946,8 +1946,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32 0.3.1",
- "stable_deref_trait",
+    "hash32 0.3.1",
+    "stable_deref_trait",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
- "unicode-segmentation",
+    "unicode-segmentation",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -1986,7 +1986,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -2001,10 +2001,10 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723777263b0dcc5730aec947496bd8c3940ba63c15f5633b288cc615f4f6af79"
 dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "winapi",
+    "cc",
+    "libc",
+    "pkg-config",
+    "winapi",
 ]
 
 [[package]]
@@ -2013,7 +2013,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+    "hmac",
 ]
 
 [[package]]
@@ -2022,7 +2022,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+    "digest",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.52.0",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2046,9 +2046,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
- "libc",
- "match_cfg",
- "winapi",
+    "libc",
+    "match_cfg",
+    "winapi",
 ]
 
 [[package]]
@@ -2057,9 +2057,9 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
- "bytes",
- "fnv",
- "itoa",
+    "bytes",
+    "fnv",
+    "itoa",
 ]
 
 [[package]]
@@ -2068,9 +2068,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
+    "bytes",
+    "http",
+    "pin-project-lite",
 ]
 
 [[package]]
@@ -2097,22 +2097,22 @@ version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+    "bytes",
+    "futures-channel",
+    "futures-core",
+    "futures-util",
+    "h2",
+    "http",
+    "http-body",
+    "httparse",
+    "httpdate",
+    "itoa",
+    "pin-project-lite",
+    "socket2",
+    "tokio",
+    "tower-service",
+    "tracing",
+    "want",
 ]
 
 [[package]]
@@ -2121,12 +2121,12 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "futures-util",
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
+    "futures-util",
+    "http",
+    "hyper",
+    "rustls",
+    "tokio",
+    "tokio-rustls",
 ]
 
 [[package]]
@@ -2135,12 +2135,12 @@ version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
+    "android_system_properties",
+    "core-foundation-sys",
+    "iana-time-zone-haiku",
+    "js-sys",
+    "wasm-bindgen",
+    "windows-core",
 ]
 
 [[package]]
@@ -2149,7 +2149,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cc",
+    "cc",
 ]
 
 [[package]]
@@ -2164,8 +2164,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+    "unicode-bidi",
+    "unicode-normalization",
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec",
+    "parity-scale-codec",
 ]
 
 [[package]]
@@ -2183,9 +2183,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -2194,9 +2194,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
- "equivalent",
- "hashbrown",
- "serde",
+    "equivalent",
+    "hashbrown",
+    "serde",
 ]
 
 [[package]]
@@ -2211,7 +2211,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array",
+    "generic-array",
 ]
 
 [[package]]
@@ -2232,9 +2232,9 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.4",
- "rustix",
- "windows-sys 0.52.0",
+    "hermit-abi 0.3.4",
+    "rustix",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2243,7 +2243,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
- "either",
+    "either",
 ]
 
 [[package]]
@@ -2252,7 +2252,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
- "either",
+    "either",
 ]
 
 [[package]]
@@ -2267,12 +2267,12 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
 dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
+    "cesu8",
+    "combine",
+    "jni-sys",
+    "log",
+    "thiserror",
+    "walkdir",
 ]
 
 [[package]]
@@ -2287,13 +2287,13 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
 dependencies = [
- "dashmap",
- "futures",
- "jni",
- "log",
- "once_cell",
- "static_assertions",
- "uuid",
+    "dashmap",
+    "futures",
+    "jni",
+    "log",
+    "once_cell",
+    "static_assertions",
+    "uuid",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
- "wasm-bindgen",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -2311,7 +2311,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+    "cpufeatures",
 ]
 
 [[package]]
@@ -2320,7 +2320,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+    "spin 0.5.2",
 ]
 
 [[package]]
@@ -2335,82 +2335,82 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59318e4561e37d83571927c35cdfd1ce52f0fad14d326ee7778309288b73ea2b"
 dependencies = [
- "async-trait",
- "btleplug",
- "clap 4.4.18",
- "encdec",
- "futures",
- "hidapi",
- "ledger-proto",
- "once_cell",
- "strum 0.24.1",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
+    "async-trait",
+    "btleplug",
+    "clap 4.4.18",
+    "encdec",
+    "futures",
+    "hidapi",
+    "ledger-proto",
+    "once_cell",
+    "strum 0.24.1",
+    "thiserror",
+    "tokio",
+    "tracing",
+    "tracing-subscriber",
+    "uuid",
 ]
 
 [[package]]
 name = "ledger-mob"
 version = "0.16.0"
 dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "clap 4.4.18",
- "ed25519-dalek",
- "encdec",
- "futures",
- "hex",
- "lazy_static",
- "ledger-lib",
- "ledger-mob-apdu",
- "ledger-proto",
- "log",
- "mc-core",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-signer",
- "mc-transaction-summary",
- "once_cell",
- "prost 0.11.9",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "serde_cbor",
- "serde_json",
- "simplelog",
- "strum 0.24.1",
- "thiserror",
- "tokio",
- "zeroize",
+    "anyhow",
+    "async-trait",
+    "base64",
+    "clap 4.4.18",
+    "ed25519-dalek",
+    "encdec",
+    "futures",
+    "hex",
+    "lazy_static",
+    "ledger-lib",
+    "ledger-mob-apdu",
+    "ledger-proto",
+    "log",
+    "mc-core",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-crypto-ring-signature-signer",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-transaction-signer",
+    "mc-transaction-summary",
+    "once_cell",
+    "prost 0.11.9",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
+    "serde",
+    "serde_cbor",
+    "serde_json",
+    "simplelog",
+    "strum 0.24.1",
+    "thiserror",
+    "tokio",
+    "zeroize",
 ]
 
 [[package]]
 name = "ledger-mob-apdu"
 version = "0.16.0"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "curve25519-dalek",
- "encdec",
- "heapless 0.7.17",
- "ledger-proto",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-transaction-types",
- "mc-util-from-random",
- "num_enum",
- "rand_core 0.6.4",
- "sha2",
- "strum 0.24.1",
- "zeroize",
+    "bitflags 1.3.2",
+    "byteorder",
+    "curve25519-dalek",
+    "encdec",
+    "heapless 0.7.17",
+    "ledger-proto",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "num_enum",
+    "rand_core 0.6.4",
+    "sha2",
+    "strum 0.24.1",
+    "zeroize",
 ]
 
 [[package]]
@@ -2419,10 +2419,10 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522849296eded72ceed7a046d84171e04735dd1cff1fdd01a7c9a9691acbadea"
 dependencies = [
- "bitflags 2.4.2",
- "displaydoc",
- "encdec",
- "thiserror",
+    "bitflags 2.4.2",
+    "displaydoc",
+    "encdec",
+    "thiserror",
 ]
 
 [[package]]
@@ -2437,7 +2437,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
- "pkg-config",
+    "pkg-config",
 ]
 
 [[package]]
@@ -2446,8 +2446,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+    "cfg-if",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2456,9 +2456,9 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall",
+    "bitflags 2.4.2",
+    "libc",
+    "redox_syscall",
 ]
 
 [[package]]
@@ -2467,9 +2467,9 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
+    "cc",
+    "pkg-config",
+    "vcpkg",
 ]
 
 [[package]]
@@ -2478,10 +2478,10 @@ version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
+    "cc",
+    "libc",
+    "pkg-config",
+    "vcpkg",
 ]
 
 [[package]]
@@ -2495,10 +2495,10 @@ name = "lmdb-rkv"
 version = "0.14.0"
 source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "lmdb-rkv-sys",
+    "bitflags 1.3.2",
+    "byteorder",
+    "libc",
+    "lmdb-rkv-sys",
 ]
 
 [[package]]
@@ -2506,9 +2506,9 @@ name = "lmdb-rkv-sys"
 version = "0.11.0"
 source = "git+https://github.com/mozilla/lmdb-rs?rev=df1c2f5#df1c2f56e3088f097c719c57b9925ab51e26f3f4"
 dependencies = [
- "cc",
- "libc",
- "pkg-config",
+    "cc",
+    "libc",
+    "pkg-config",
 ]
 
 [[package]]
@@ -2517,8 +2517,8 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
- "autocfg",
- "scopeguard",
+    "autocfg",
+    "scopeguard",
 ]
 
 [[package]]
@@ -2533,13 +2533,13 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber",
+    "cfg-if",
+    "generator",
+    "scoped-tls",
+    "serde",
+    "serde_json",
+    "tracing",
+    "tracing-subscriber",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -2563,7 +2563,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata 0.1.10",
+    "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2571,17 +2571,17 @@ name = "mbedtls"
 version = "0.8.1"
 source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=f82523478a1dd813ca381c190175355d249a8123#f82523478a1dd813ca381c190175355d249a8123"
 dependencies = [
- "bitflags 2.4.2",
- "byteorder",
- "cc",
- "cfg-if",
- "chrono",
- "genio",
- "mbedtls-sys-auto",
- "rs-libc",
- "serde",
- "spin 0.9.8",
- "yasna",
+    "bitflags 2.4.2",
+    "byteorder",
+    "cc",
+    "cfg-if",
+    "chrono",
+    "genio",
+    "mbedtls-sys-auto",
+    "rs-libc",
+    "serde",
+    "spin 0.9.8",
+    "yasna",
 ]
 
 [[package]]
@@ -2589,220 +2589,220 @@ name = "mbedtls-sys-auto"
 version = "2.26.1"
 source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=f82523478a1dd813ca381c190175355d249a8123#f82523478a1dd813ca381c190175355d249a8123"
 dependencies = [
- "bindgen 0.64.0",
- "cc",
- "cfg-if",
- "cmake",
- "lazy_static",
- "libc",
- "libz-sys",
- "quote",
- "syn 2.0.48",
+    "bindgen 0.64.0",
+    "cc",
+    "cfg-if",
+    "cmake",
+    "lazy_static",
+    "libc",
+    "libz-sys",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
 name = "mc-account-keys"
 version = "6.0.0"
 dependencies = [
- "curve25519-dalek",
- "displaydoc",
- "hex_fmt",
- "hkdf",
- "mc-account-keys-types",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-fog-sig-authority",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
- "subtle",
- "zeroize",
+    "curve25519-dalek",
+    "displaydoc",
+    "hex_fmt",
+    "hkdf",
+    "mc-account-keys-types",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-fog-sig-authority",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-account-keys-types"
 version = "6.0.0"
 dependencies = [
- "mc-crypto-keys",
+    "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
 version = "6.0.0"
 dependencies = [
- "bs58 0.4.0",
- "cargo-emit",
- "crc",
- "curve25519-dalek",
- "displaydoc",
- "mc-account-keys",
- "mc-attest-verifier-types",
- "mc-blockchain-types",
- "mc-common",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-ring-signature-signer",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-types",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-summary",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-uri",
- "mc-watcher-api",
- "protobuf",
+    "bs58 0.4.0",
+    "cargo-emit",
+    "crc",
+    "curve25519-dalek",
+    "displaydoc",
+    "mc-account-keys",
+    "mc-attest-verifier-types",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-crypto-keys",
+    "mc-crypto-multisig",
+    "mc-crypto-ring-signature-signer",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-types",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-transaction-summary",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "mc-util-uri",
+    "mc-watcher-api",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-attest-ake"
 version = "6.0.0"
 dependencies = [
- "aead",
- "cargo-emit",
- "der",
- "digest",
- "displaydoc",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attest-verifier-types",
- "mc-attestation-verifier",
- "mc-crypto-keys",
- "mc-crypto-noise",
- "mc-sgx-dcap-types",
- "mc-util-build-script",
- "mc-util-build-sgx",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
+    "aead",
+    "cargo-emit",
+    "der",
+    "digest",
+    "displaydoc",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attest-verifier-types",
+    "mc-attestation-verifier",
+    "mc-crypto-keys",
+    "mc-crypto-noise",
+    "mc-sgx-dcap-types",
+    "mc-util-build-script",
+    "mc-util-build-sgx",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
 ]
 
 [[package]]
 name = "mc-attest-api"
 version = "6.0.0"
 dependencies = [
- "aead",
- "cargo-emit",
- "digest",
- "futures",
- "grpcio",
- "mc-attest-ake",
- "mc-attest-enclave-api",
- "mc-attest-verifier-types",
- "mc-crypto-keys",
- "mc-crypto-noise",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-types",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-serial",
- "protobuf",
+    "aead",
+    "cargo-emit",
+    "digest",
+    "futures",
+    "grpcio",
+    "mc-attest-ake",
+    "mc-attest-enclave-api",
+    "mc-attest-verifier-types",
+    "mc-crypto-keys",
+    "mc-crypto-noise",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-types",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-serial",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-attest-core"
 version = "6.0.0"
 dependencies = [
- "base64",
- "bitflags 2.4.2",
- "cargo-emit",
- "chrono",
- "digest",
- "displaydoc",
- "hex",
- "hex_fmt",
- "mc-attest-verifier-types",
- "mc-common",
- "mc-crypto-digestible",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-types",
- "mc-sgx-types",
- "mc-util-build-script",
- "mc-util-build-sgx",
- "mc-util-encodings",
- "mc-util-repr-bytes",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "rjson",
- "serde",
- "sha2",
- "subtle",
+    "base64",
+    "bitflags 2.4.2",
+    "cargo-emit",
+    "chrono",
+    "digest",
+    "displaydoc",
+    "hex",
+    "hex_fmt",
+    "mc-attest-verifier-types",
+    "mc-common",
+    "mc-crypto-digestible",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-types",
+    "mc-sgx-types",
+    "mc-util-build-script",
+    "mc-util-build-sgx",
+    "mc-util-encodings",
+    "mc-util-repr-bytes",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "rjson",
+    "serde",
+    "sha2",
+    "subtle",
 ]
 
 [[package]]
 name = "mc-attest-enclave-api"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-attest-ake",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attestation-verifier",
- "mc-crypto-noise",
- "mc-sgx-compat",
- "mc-util-serial",
- "serde",
+    "displaydoc",
+    "mc-attest-ake",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attestation-verifier",
+    "mc-crypto-noise",
+    "mc-sgx-compat",
+    "mc-util-serial",
+    "serde",
 ]
 
 [[package]]
 name = "mc-attest-verifier"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "cfg-if",
- "chrono",
- "der",
- "displaydoc",
- "hex",
- "hex_fmt",
- "lazy_static",
- "mbedtls",
- "mbedtls-sys-auto",
- "mc-attest-core",
- "mc-attest-verifier-types",
- "mc-attestation-verifier",
- "mc-common",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-css",
- "mc-sgx-dcap-types",
- "mc-sgx-types",
- "mc-util-build-script",
- "mc-util-build-sgx",
- "p256",
- "rand 0.8.5",
- "rand_hc",
- "serde",
- "sha2",
+    "cargo-emit",
+    "cfg-if",
+    "chrono",
+    "der",
+    "displaydoc",
+    "hex",
+    "hex_fmt",
+    "lazy_static",
+    "mbedtls",
+    "mbedtls-sys-auto",
+    "mc-attest-core",
+    "mc-attest-verifier-types",
+    "mc-attestation-verifier",
+    "mc-common",
+    "mc-sgx-core-sys-types 0.10.1",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-css",
+    "mc-sgx-dcap-types",
+    "mc-sgx-types",
+    "mc-util-build-script",
+    "mc-util-build-sgx",
+    "p256",
+    "rand 0.8.5",
+    "rand_hc",
+    "serde",
+    "sha2",
 ]
 
 [[package]]
 name = "mc-attest-verifier-types"
 version = "6.0.0"
 dependencies = [
- "base64",
- "displaydoc",
- "hex",
- "hex_fmt",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-sys-types",
- "mc-sgx-dcap-types",
- "mc-util-encodings",
- "mc-util-serial",
- "prost 0.12.3",
- "prost-build",
- "serde",
- "sha2",
- "x509-cert",
+    "base64",
+    "displaydoc",
+    "hex",
+    "hex_fmt",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-sys-types",
+    "mc-sgx-dcap-types",
+    "mc-util-encodings",
+    "mc-util-serial",
+    "prost 0.12.3",
+    "prost-build",
+    "serde",
+    "sha2",
+    "x509-cert",
 ]
 
 [[package]]
@@ -2811,936 +2811,937 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa489aed434f230862bb92ad3059380203793c30f99c603172f602290edd610"
 dependencies = [
- "der",
- "displaydoc",
- "hex",
- "mbedtls",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-types",
- "p256",
- "serde",
- "serde_json",
- "subtle",
- "x509-cert",
+    "der",
+    "displaydoc",
+    "hex",
+    "mbedtls",
+    "mc-sgx-core-sys-types 0.10.1",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-types",
+    "p256",
+    "serde",
+    "serde_json",
+    "subtle",
+    "x509-cert",
 ]
 
 [[package]]
 name = "mc-blockchain-test-utils"
 version = "6.0.0"
 dependencies = [
- "mc-blockchain-types",
- "mc-common",
- "mc-consensus-scp-types",
- "mc-crypto-keys",
- "mc-transaction-core",
- "mc-transaction-core-test-utils",
- "mc-util-from-random",
- "mc-util-test-helper",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-consensus-scp-types",
+    "mc-crypto-keys",
+    "mc-transaction-core",
+    "mc-transaction-core-test-utils",
+    "mc-util-from-random",
+    "mc-util-test-helper",
 ]
 
 [[package]]
 name = "mc-blockchain-types"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "hex_fmt",
- "mc-account-keys",
- "mc-attest-verifier-types",
- "mc-common",
- "mc-consensus-scp-types",
- "mc-crypto-digestible",
- "mc-crypto-digestible-signature",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-transaction-core",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "prost 0.12.3",
- "serde",
- "zeroize",
+    "displaydoc",
+    "hex_fmt",
+    "mc-account-keys",
+    "mc-attest-verifier-types",
+    "mc-common",
+    "mc-consensus-scp-types",
+    "mc-crypto-digestible",
+    "mc-crypto-digestible-signature",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-transaction-core",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "prost 0.12.3",
+    "serde",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-common"
 version = "6.0.0"
 dependencies = [
- "backtrace",
- "cfg-if",
- "chrono",
- "displaydoc",
- "hashbrown",
- "hex",
- "hex_fmt",
- "hostname",
- "lazy_static",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-rand",
- "mc-util-build-info",
- "mc-util-logger-macros",
- "mc-util-serial",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "sentry",
- "serde",
- "sha3",
- "siphasher",
- "slog",
- "slog-async",
- "slog-atomic",
- "slog-envlogger",
- "slog-json",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
+    "backtrace",
+    "cfg-if",
+    "chrono",
+    "displaydoc",
+    "hashbrown",
+    "hex",
+    "hex_fmt",
+    "hostname",
+    "lazy_static",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-rand",
+    "mc-util-build-info",
+    "mc-util-logger-macros",
+    "mc-util-serial",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "sentry",
+    "serde",
+    "sha3",
+    "siphasher",
+    "slog",
+    "slog-async",
+    "slog-atomic",
+    "slog-envlogger",
+    "slog-json",
+    "slog-scope",
+    "slog-stdlog",
+    "slog-term",
 ]
 
 [[package]]
 name = "mc-connection"
 version = "6.0.0"
 dependencies = [
- "aes-gcm",
- "cookie",
- "der",
- "displaydoc",
- "grpcio",
- "mc-attest-ake",
- "mc-attest-api",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attestation-verifier",
- "mc-blockchain-types",
- "mc-common",
- "mc-consensus-api",
- "mc-crypto-keys",
- "mc-crypto-noise",
- "mc-rand",
- "mc-transaction-core",
- "mc-util-grpc",
- "mc-util-serial",
- "mc-util-uri",
- "retry",
- "secrecy",
- "serde",
- "sha2",
+    "aes-gcm",
+    "cookie",
+    "der",
+    "displaydoc",
+    "grpcio",
+    "mc-attest-ake",
+    "mc-attest-api",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attestation-verifier",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-consensus-api",
+    "mc-crypto-keys",
+    "mc-crypto-noise",
+    "mc-rand",
+    "mc-transaction-core",
+    "mc-util-grpc",
+    "mc-util-serial",
+    "mc-util-uri",
+    "retry",
+    "secrecy",
+    "serde",
+    "sha2",
 ]
 
 [[package]]
 name = "mc-connection-test-utils"
 version = "6.0.0"
 dependencies = [
- "mc-blockchain-types",
- "mc-connection",
- "mc-ledger-db",
- "mc-transaction-core",
- "mc-util-uri",
+    "mc-blockchain-types",
+    "mc-connection",
+    "mc-ledger-db",
+    "mc-transaction-core",
+    "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-consensus-api"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "mc-api",
- "mc-attest-api",
- "mc-ledger-db",
- "mc-transaction-core",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "protobuf",
+    "cargo-emit",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-attest-api",
+    "mc-ledger-db",
+    "mc-transaction-core",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-api"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "hex",
- "mc-attest-ake",
- "mc-attest-core",
- "mc-attest-enclave-api",
- "mc-blockchain-types",
- "mc-common",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-crypto-message-cipher",
- "mc-crypto-multisig",
- "mc-sgx-compat",
- "mc-sgx-report-cache-api",
- "mc-transaction-core",
- "mc-util-serial",
- "serde",
+    "displaydoc",
+    "hex",
+    "mc-attest-ake",
+    "mc-attest-core",
+    "mc-attest-enclave-api",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-crypto-message-cipher",
+    "mc-crypto-multisig",
+    "mc-sgx-compat",
+    "mc-sgx-report-cache-api",
+    "mc-transaction-core",
+    "mc-util-serial",
+    "serde",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "mc-attest-core",
- "mc-attestation-verifier",
- "mc-sgx-css",
- "mc-util-build-enclave",
- "mc-util-build-script",
- "mc-util-build-sgx",
+    "cargo-emit",
+    "mc-attest-core",
+    "mc-attestation-verifier",
+    "mc-sgx-css",
+    "mc-util-build-enclave",
+    "mc-util-build-script",
+    "mc-util-build-sgx",
 ]
 
 [[package]]
 name = "mc-consensus-scp"
 version = "6.0.0"
 dependencies = [
- "mc-common",
- "mc-consensus-scp-types",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-util-from-random",
- "mc-util-serial",
- "mockall",
- "primitive-types",
- "rand 0.8.5",
- "rand_hc",
- "serde",
- "serde_json",
+    "mc-common",
+    "mc-consensus-scp-types",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-util-from-random",
+    "mc-util-serial",
+    "mockall",
+    "primitive-types",
+    "rand 0.8.5",
+    "rand_hc",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
 name = "mc-consensus-scp-types"
 version = "6.0.0"
 dependencies = [
- "mc-common",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-util-from-random",
- "mc-util-test-helper",
- "prost 0.12.3",
- "rand 0.8.5",
- "rand_hc",
- "serde",
+    "mc-common",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-util-from-random",
+    "mc-util-test-helper",
+    "prost 0.12.3",
+    "rand 0.8.5",
+    "rand_hc",
+    "serde",
 ]
 
 [[package]]
 name = "mc-core"
 version = "6.0.0"
 dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "generic-array",
- "hkdf",
- "mc-core-types",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "serde",
- "sha2",
- "slip10_ed25519",
- "tiny-bip39",
- "zeroize",
+    "curve25519-dalek",
+    "ed25519-dalek",
+    "generic-array",
+    "hkdf",
+    "mc-core-types",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "serde",
+    "sha2",
+    "slip10_ed25519",
+    "tiny-bip39",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-core-types"
 version = "6.0.0"
 dependencies = [
- "curve25519-dalek",
- "mc-crypto-keys",
- "serde",
- "subtle",
- "zeroize",
+    "curve25519-dalek",
+    "mc-crypto-keys",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-box"
 version = "6.0.0"
 dependencies = [
- "aead",
- "digest",
- "displaydoc",
- "hkdf",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-oblivious-aes-gcm",
- "rand_core 0.6.4",
+    "aead",
+    "digest",
+    "displaydoc",
+    "hkdf",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-oblivious-aes-gcm",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-crypto-digestible"
 version = "6.0.0"
 dependencies = [
- "cfg-if",
- "curve25519-dalek",
- "ed25519-dalek",
- "generic-array",
- "mc-crypto-digestible-derive",
- "merlin",
- "x25519-dalek",
+    "cfg-if",
+    "curve25519-dalek",
+    "ed25519-dalek",
+    "generic-array",
+    "mc-crypto-digestible-derive",
+    "merlin",
+    "x25519-dalek",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-derive"
 version = "6.0.0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-signature"
 version = "6.0.0"
 dependencies = [
- "mc-crypto-digestible",
- "signature",
+    "mc-crypto-digestible",
+    "signature",
 ]
 
 [[package]]
 name = "mc-crypto-hashes"
 version = "6.0.0"
 dependencies = [
- "blake2",
- "digest",
- "mc-crypto-digestible",
+    "blake2",
+    "digest",
+    "mc-crypto-digestible",
 ]
 
 [[package]]
 name = "mc-crypto-keys"
 version = "6.0.0"
 dependencies = [
- "base64",
- "curve25519-dalek",
- "digest",
- "displaydoc",
- "ed25519",
- "ed25519-dalek",
- "hex",
- "hex_fmt",
- "mc-crypto-digestible",
- "mc-crypto-digestible-signature",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "rand_core 0.6.4",
- "rand_hc",
- "schnorrkel-og",
- "serde",
- "sha2",
- "signature",
- "static_assertions",
- "subtle",
- "x25519-dalek",
- "zeroize",
+    "base64",
+    "curve25519-dalek",
+    "digest",
+    "displaydoc",
+    "ed25519",
+    "ed25519-dalek",
+    "hex",
+    "hex_fmt",
+    "mc-crypto-digestible",
+    "mc-crypto-digestible-signature",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "rand_core 0.6.4",
+    "rand_hc",
+    "schnorrkel-og",
+    "serde",
+    "sha2",
+    "signature",
+    "static_assertions",
+    "subtle",
+    "x25519-dalek",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-memo-mac"
 version = "6.0.0"
 dependencies = [
- "hmac",
- "mc-crypto-keys",
- "sha2",
+    "hmac",
+    "mc-crypto-keys",
+    "sha2",
 ]
 
 [[package]]
 name = "mc-crypto-message-cipher"
 version = "6.0.0"
 dependencies = [
- "aes-gcm",
- "displaydoc",
- "generic-array",
- "mc-util-serial",
- "rand_core 0.6.4",
- "serde",
- "subtle",
+    "aes-gcm",
+    "displaydoc",
+    "generic-array",
+    "mc-util-serial",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
 ]
 
 [[package]]
 name = "mc-crypto-multisig"
 version = "6.0.0"
 dependencies = [
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "prost 0.12.3",
- "serde",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "prost 0.12.3",
+    "serde",
 ]
 
 [[package]]
 name = "mc-crypto-noise"
 version = "6.0.0"
 dependencies = [
- "aead",
- "aes-gcm",
- "digest",
- "displaydoc",
- "generic-array",
- "hkdf",
- "mc-crypto-keys",
- "mc-util-from-random",
- "rand_core 0.6.4",
- "secrecy",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
+    "aead",
+    "aes-gcm",
+    "digest",
+    "displaydoc",
+    "generic-array",
+    "hkdf",
+    "mc-crypto-keys",
+    "mc-util-from-random",
+    "rand_core 0.6.4",
+    "secrecy",
+    "serde",
+    "sha2",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-ring-signature"
 version = "6.0.0"
 dependencies = [
- "curve25519-dalek",
- "displaydoc",
- "ed25519-dalek",
- "mc-core-types",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
- "subtle",
- "zeroize",
+    "curve25519-dalek",
+    "displaydoc",
+    "ed25519-dalek",
+    "mc-core-types",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
 version = "6.0.0"
 dependencies = [
- "curve25519-dalek",
- "displaydoc",
- "generic-array",
- "hex_fmt",
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-transaction-types",
- "mc-util-serial",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
- "subtle",
- "zeroize",
+    "curve25519-dalek",
+    "displaydoc",
+    "generic-array",
+    "hex_fmt",
+    "mc-account-keys",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-transaction-types",
+    "mc-util-serial",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-x509-utils"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-crypto-keys",
- "pem",
- "x509-signature",
+    "displaydoc",
+    "mc-crypto-keys",
+    "pem",
+    "x509-signature",
 ]
 
 [[package]]
 name = "mc-fog-api"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "displaydoc",
- "futures",
- "grpcio",
- "mc-api",
- "mc-attest-api",
- "mc-attest-core",
- "mc-attest-enclave-api",
- "mc-consensus-api",
- "mc-crypto-keys",
- "mc-fog-enclave-connection",
- "mc-fog-report-api",
- "mc-fog-report-types",
- "mc-fog-types",
- "mc-fog-uri",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-encodings",
- "mc-util-from-random",
- "mc-util-grpc",
- "mc-util-serial",
- "mc-watcher-api",
- "prost 0.12.3",
- "protobuf",
+    "cargo-emit",
+    "displaydoc",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-attest-api",
+    "mc-attest-core",
+    "mc-attest-enclave-api",
+    "mc-consensus-api",
+    "mc-crypto-keys",
+    "mc-fog-enclave-connection",
+    "mc-fog-report-api",
+    "mc-fog-report-types",
+    "mc-fog-types",
+    "mc-fog-uri",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-encodings",
+    "mc-util-from-random",
+    "mc-util-grpc",
+    "mc-util-serial",
+    "mc-watcher-api",
+    "prost 0.12.3",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-fog-enclave-connection"
 version = "6.0.0"
 dependencies = [
- "aes-gcm",
- "cookie",
- "der",
- "displaydoc",
- "grpcio",
- "mc-attest-ake",
- "mc-attest-api",
- "mc-attest-core",
- "mc-attestation-verifier",
- "mc-common",
- "mc-connection",
- "mc-crypto-keys",
- "mc-crypto-noise",
- "mc-rand",
- "mc-util-grpc",
- "mc-util-serial",
- "mc-util-uri",
- "retry",
- "sha2",
+    "aes-gcm",
+    "cookie",
+    "der",
+    "displaydoc",
+    "grpcio",
+    "mc-attest-ake",
+    "mc-attest-api",
+    "mc-attest-core",
+    "mc-attestation-verifier",
+    "mc-common",
+    "mc-connection",
+    "mc-crypto-keys",
+    "mc-crypto-noise",
+    "mc-rand",
+    "mc-util-grpc",
+    "mc-util-serial",
+    "mc-util-uri",
+    "retry",
+    "sha2",
 ]
 
 [[package]]
 name = "mc-fog-ingest-report"
 version = "6.0.0"
 dependencies = [
- "der",
- "displaydoc",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attest-verifier-types",
- "mc-attestation-verifier",
- "mc-crypto-keys",
- "mc-fog-report-types",
- "mc-util-encodings",
- "serde",
+    "der",
+    "displaydoc",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attest-verifier-types",
+    "mc-attestation-verifier",
+    "mc-crypto-keys",
+    "mc-fog-report-types",
+    "mc-util-encodings",
+    "serde",
 ]
 
 [[package]]
 name = "mc-fog-kex-rng"
 version = "6.0.0"
 dependencies = [
- "digest",
- "displaydoc",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
+    "digest",
+    "displaydoc",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-api"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "mc-api",
- "mc-attest-api",
- "mc-attest-verifier-types",
- "mc-consensus-api",
- "mc-fog-report-types",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "protobuf",
+    "cargo-emit",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-attest-api",
+    "mc-attest-verifier-types",
+    "mc-consensus-api",
+    "mc-fog-report-types",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-fog-report-connection"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "grpcio",
- "mc-account-keys",
- "mc-common",
- "mc-fog-report-api",
- "mc-fog-report-types",
- "mc-util-grpc",
- "mc-util-serial",
- "mc-util-uri",
+    "displaydoc",
+    "grpcio",
+    "mc-account-keys",
+    "mc-common",
+    "mc-fog-report-api",
+    "mc-fog-report-types",
+    "mc-util-grpc",
+    "mc-util-serial",
+    "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-fog-report-resolver"
 version = "6.0.0"
 dependencies = [
- "mc-account-keys",
- "mc-attest-verifier",
- "mc-attestation-verifier",
- "mc-fog-ingest-report",
- "mc-fog-report-types",
- "mc-fog-report-validation",
- "mc-fog-sig",
- "mc-util-uri",
- "serde",
+    "mc-account-keys",
+    "mc-attest-verifier",
+    "mc-attestation-verifier",
+    "mc-fog-ingest-report",
+    "mc-fog-report-types",
+    "mc-fog-report-validation",
+    "mc-fog-sig",
+    "mc-util-uri",
+    "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-types"
 version = "6.0.0"
 dependencies = [
- "mc-attest-verifier-types",
- "mc-crypto-digestible",
- "prost 0.12.3",
- "serde",
+    "mc-attest-verifier-types",
+    "mc-crypto-digestible",
+    "prost 0.12.3",
+    "serde",
 ]
 
 [[package]]
 name = "mc-fog-report-validation"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-fog-sig",
- "mc-util-serial",
- "mc-util-uri",
- "mockall",
+    "displaydoc",
+    "mc-account-keys",
+    "mc-crypto-keys",
+    "mc-fog-sig",
+    "mc-util-serial",
+    "mc-util-uri",
+    "mockall",
 ]
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
 version = "6.0.0"
 dependencies = [
- "mc-account-keys",
- "mc-fog-report-validation",
+    "mc-account-keys",
+    "mc-fog-report-validation",
 ]
 
 [[package]]
 name = "mc-fog-sig"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-crypto-x509-utils",
- "mc-fog-report-types",
- "mc-fog-sig-authority",
- "mc-fog-sig-report",
- "pem",
- "signature",
- "x509-signature",
+    "displaydoc",
+    "mc-account-keys",
+    "mc-crypto-keys",
+    "mc-crypto-x509-utils",
+    "mc-fog-report-types",
+    "mc-fog-sig-authority",
+    "mc-fog-sig-report",
+    "pem",
+    "signature",
+    "x509-signature",
 ]
 
 [[package]]
 name = "mc-fog-sig-authority"
 version = "6.0.0"
 dependencies = [
- "mc-crypto-keys",
+    "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-sig-report"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-crypto-digestible-signature",
- "mc-crypto-keys",
- "mc-fog-report-types",
- "signature",
+    "displaydoc",
+    "mc-crypto-digestible-signature",
+    "mc-crypto-keys",
+    "mc-fog-report-types",
+    "signature",
 ]
 
 [[package]]
 name = "mc-fog-types"
 version = "6.0.0"
 dependencies = [
- "crc",
- "displaydoc",
- "mc-attest-enclave-api",
- "mc-common",
- "mc-crypto-keys",
- "mc-fog-kex-rng",
- "mc-transaction-core",
- "prost 0.12.3",
- "serde",
+    "crc",
+    "displaydoc",
+    "mc-attest-enclave-api",
+    "mc-common",
+    "mc-crypto-keys",
+    "mc-fog-kex-rng",
+    "mc-transaction-core",
+    "prost 0.12.3",
+    "serde",
 ]
 
 [[package]]
 name = "mc-fog-uri"
 version = "6.0.0"
 dependencies = [
- "mc-util-uri",
+    "mc-util-uri",
 ]
 
 [[package]]
 name = "mc-full-service"
 version = "2.10.1"
 dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "bs58 0.5.0",
- "chrono",
- "clap 4.4.18",
- "crossbeam-channel",
- "diesel",
- "diesel-derive-enum",
- "diesel_migrations",
- "displaydoc",
- "dotenv",
- "ed25519-dalek",
- "grpcio",
- "hex",
- "ledger-mob",
- "libsqlite3-sys",
- "mc-account-keys",
- "mc-api",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attestation-verifier",
- "mc-blockchain-test-utils",
- "mc-blockchain-types",
- "mc-common",
- "mc-connection",
- "mc-connection-test-utils",
- "mc-consensus-enclave-api",
- "mc-consensus-enclave-measurement",
- "mc-consensus-scp",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-connection",
- "mc-fog-report-resolver",
- "mc-fog-report-validation",
- "mc-fog-report-validation-test-utils",
- "mc-fog-sig-authority",
- "mc-ledger-db",
- "mc-ledger-migration",
- "mc-ledger-sync",
- "mc-mobilecoind",
- "mc-mobilecoind-api",
- "mc-mobilecoind-json",
- "mc-rand",
- "mc-sgx-core-types 0.9.0",
- "mc-sgx-css",
- "mc-transaction-builder",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-signer",
- "mc-transaction-summary",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-grpc",
- "mc-util-parse",
- "mc-util-serial",
- "mc-util-uri",
- "mc-validator-api",
- "mc-validator-connection",
- "mc-watcher",
- "mc-watcher-api",
- "num_cpus",
- "prost 0.11.9",
- "protobuf",
- "rand 0.8.5",
- "rayon",
- "redact",
- "reqwest",
- "retry",
- "rocket",
- "rocket_sync_db_pools",
- "serde",
- "serde-big-array",
- "serde_derive",
- "serde_json",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "t3-api",
- "t3-connection",
- "tempdir",
- "tiny-bip39",
- "tokio",
- "url",
- "uuid",
- "vergen",
+    "anyhow",
+    "async-trait",
+    "base64",
+    "bs58 0.5.0",
+    "chrono",
+    "clap 4.4.18",
+    "crossbeam-channel",
+    "diesel",
+    "diesel-derive-enum",
+    "diesel_migrations",
+    "displaydoc",
+    "dotenv",
+    "ed25519-dalek",
+    "grpcio",
+    "hex",
+    "itertools 0.10.5",
+    "ledger-mob",
+    "libsqlite3-sys",
+    "mc-account-keys",
+    "mc-api",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attestation-verifier",
+    "mc-blockchain-test-utils",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-connection",
+    "mc-connection-test-utils",
+    "mc-consensus-enclave-api",
+    "mc-consensus-enclave-measurement",
+    "mc-consensus-scp",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature-signer",
+    "mc-fog-report-connection",
+    "mc-fog-report-resolver",
+    "mc-fog-report-validation",
+    "mc-fog-report-validation-test-utils",
+    "mc-fog-sig-authority",
+    "mc-ledger-db",
+    "mc-ledger-migration",
+    "mc-ledger-sync",
+    "mc-mobilecoind",
+    "mc-mobilecoind-api",
+    "mc-mobilecoind-json",
+    "mc-rand",
+    "mc-sgx-core-types 0.9.0",
+    "mc-sgx-css",
+    "mc-transaction-builder",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-transaction-signer",
+    "mc-transaction-summary",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "mc-util-grpc",
+    "mc-util-parse",
+    "mc-util-serial",
+    "mc-util-uri",
+    "mc-validator-api",
+    "mc-validator-connection",
+    "mc-watcher",
+    "mc-watcher-api",
+    "num_cpus",
+    "prost 0.11.9",
+    "protobuf",
+    "rand 0.8.5",
+    "rayon",
+    "redact",
+    "reqwest",
+    "retry",
+    "rocket",
+    "rocket_sync_db_pools",
+    "serde",
+    "serde-big-array",
+    "serde_derive",
+    "serde_json",
+    "strum 0.25.0",
+    "strum_macros 0.25.3",
+    "t3-api",
+    "t3-connection",
+    "tempdir",
+    "tiny-bip39",
+    "tokio",
+    "url",
+    "uuid",
+    "vergen",
 ]
 
 [[package]]
 name = "mc-full-service-mirror"
 version = "2.10.1"
 dependencies = [
- "boring",
- "cargo-emit",
- "futures",
- "generic-array",
- "grpcio",
- "hex",
- "mc-api",
- "mc-common",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-grpc",
- "mc-util-uri",
- "num_cpus",
- "protobuf",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rand_hc",
- "reqwest",
- "rocket",
- "serde",
- "serde_derive",
- "serde_json",
- "structopt",
+    "boring",
+    "cargo-emit",
+    "futures",
+    "generic-array",
+    "grpcio",
+    "hex",
+    "mc-api",
+    "mc-common",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-grpc",
+    "mc-util-uri",
+    "num_cpus",
+    "protobuf",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
+    "rand_hc",
+    "reqwest",
+    "rocket",
+    "serde",
+    "serde_derive",
+    "serde_json",
+    "structopt",
 ]
 
 [[package]]
 name = "mc-ledger-db"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "lazy_static",
- "lmdb-rkv",
- "mc-account-keys",
- "mc-blockchain-test-utils",
- "mc-blockchain-types",
- "mc-common",
- "mc-crypto-keys",
- "mc-transaction-builder",
- "mc-transaction-core",
- "mc-transaction-core-test-utils",
- "mc-util-from-random",
- "mc-util-lmdb",
- "mc-util-metrics",
- "mc-util-serial",
- "mc-util-telemetry",
- "mc-util-test-helper",
- "mockall",
- "prost 0.12.3",
- "rand 0.8.5",
- "tempfile",
+    "displaydoc",
+    "lazy_static",
+    "lmdb-rkv",
+    "mc-account-keys",
+    "mc-blockchain-test-utils",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-crypto-keys",
+    "mc-transaction-builder",
+    "mc-transaction-core",
+    "mc-transaction-core-test-utils",
+    "mc-util-from-random",
+    "mc-util-lmdb",
+    "mc-util-metrics",
+    "mc-util-serial",
+    "mc-util-telemetry",
+    "mc-util-test-helper",
+    "mockall",
+    "prost 0.12.3",
+    "rand 0.8.5",
+    "tempfile",
 ]
 
 [[package]]
 name = "mc-ledger-migration"
 version = "6.0.0"
 dependencies = [
- "clap 4.4.18",
- "lmdb-rkv",
- "mc-common",
- "mc-ledger-db",
- "mc-util-lmdb",
- "mc-util-serial",
- "serde",
+    "clap 4.4.18",
+    "lmdb-rkv",
+    "mc-common",
+    "mc-ledger-db",
+    "mc-util-lmdb",
+    "mc-util-serial",
+    "serde",
 ]
 
 [[package]]
 name = "mc-ledger-sync"
 version = "6.0.0"
 dependencies = [
- "crossbeam-channel",
- "displaydoc",
- "grpcio",
- "mc-account-keys",
- "mc-api",
- "mc-attestation-verifier",
- "mc-blockchain-test-utils",
- "mc-blockchain-types",
- "mc-common",
- "mc-connection",
- "mc-consensus-scp",
- "mc-ledger-db",
- "mc-transaction-core",
- "mc-transaction-core-test-utils",
- "mc-util-telemetry",
- "mc-util-uri",
- "mockall",
- "protobuf",
- "rand 0.8.5",
- "reqwest",
- "retry",
- "serde",
- "tempfile",
- "url",
+    "crossbeam-channel",
+    "displaydoc",
+    "grpcio",
+    "mc-account-keys",
+    "mc-api",
+    "mc-attestation-verifier",
+    "mc-blockchain-test-utils",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-connection",
+    "mc-consensus-scp",
+    "mc-ledger-db",
+    "mc-transaction-core",
+    "mc-transaction-core-test-utils",
+    "mc-util-telemetry",
+    "mc-util-uri",
+    "mockall",
+    "protobuf",
+    "rand 0.8.5",
+    "reqwest",
+    "retry",
+    "serde",
+    "tempfile",
+    "url",
 ]
 
 [[package]]
 name = "mc-mobilecoind"
 version = "6.0.0"
 dependencies = [
- "aes-gcm",
- "clap 4.4.18",
- "crossbeam-channel",
- "displaydoc",
- "grpcio",
- "hex_fmt",
- "libz-sys",
- "lmdb-rkv",
- "mc-account-keys",
- "mc-api",
- "mc-attest-core",
- "mc-attestation-verifier",
- "mc-blockchain-types",
- "mc-common",
- "mc-connection",
- "mc-consensus-api",
- "mc-consensus-enclave-api",
- "mc-consensus-enclave-measurement",
- "mc-consensus-scp",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-connection",
- "mc-fog-report-resolver",
- "mc-fog-report-validation",
- "mc-ledger-db",
- "mc-ledger-migration",
- "mc-ledger-sync",
- "mc-mobilecoind-api",
- "mc-rand",
- "mc-sgx-css",
- "mc-transaction-builder",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-util-from-random",
- "mc-util-grpc",
- "mc-util-lmdb",
- "mc-util-parse",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-telemetry",
- "mc-util-uri",
- "mc-watcher",
- "mc-watcher-api",
- "num_cpus",
- "prost 0.12.3",
- "protobuf",
- "rand 0.8.5",
- "rayon",
- "reqwest",
- "retry",
- "serde_json",
- "tiny-bip39",
+    "aes-gcm",
+    "clap 4.4.18",
+    "crossbeam-channel",
+    "displaydoc",
+    "grpcio",
+    "hex_fmt",
+    "libz-sys",
+    "lmdb-rkv",
+    "mc-account-keys",
+    "mc-api",
+    "mc-attest-core",
+    "mc-attestation-verifier",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-connection",
+    "mc-consensus-api",
+    "mc-consensus-enclave-api",
+    "mc-consensus-enclave-measurement",
+    "mc-consensus-scp",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature-signer",
+    "mc-fog-report-connection",
+    "mc-fog-report-resolver",
+    "mc-fog-report-validation",
+    "mc-ledger-db",
+    "mc-ledger-migration",
+    "mc-ledger-sync",
+    "mc-mobilecoind-api",
+    "mc-rand",
+    "mc-sgx-css",
+    "mc-transaction-builder",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-util-from-random",
+    "mc-util-grpc",
+    "mc-util-lmdb",
+    "mc-util-parse",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "mc-util-telemetry",
+    "mc-util-uri",
+    "mc-watcher",
+    "mc-watcher-api",
+    "num_cpus",
+    "prost 0.12.3",
+    "protobuf",
+    "rand 0.8.5",
+    "rayon",
+    "reqwest",
+    "retry",
+    "serde_json",
+    "tiny-bip39",
 ]
 
 [[package]]
 name = "mc-mobilecoind-api"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "mc-api",
- "mc-attest-api",
- "mc-fog-api",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-uri",
- "protobuf",
+    "cargo-emit",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-attest-api",
+    "mc-fog-api",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-uri",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-mobilecoind-json"
 version = "6.0.0"
 dependencies = [
- "clap 4.4.18",
- "grpcio",
- "hex",
- "mc-api",
- "mc-common",
- "mc-mobilecoind-api",
- "mc-util-grpc",
- "mc-util-serial",
- "protobuf",
- "rocket",
- "serde",
- "serde_derive",
+    "clap 4.4.18",
+    "grpcio",
+    "hex",
+    "mc-api",
+    "mc-common",
+    "mc-mobilecoind-api",
+    "mc-util-grpc",
+    "mc-util-serial",
+    "protobuf",
+    "rocket",
+    "serde",
+    "serde_derive",
 ]
 
 [[package]]
@@ -3749,13 +3750,13 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be589d425ac3950edf94eb4185e625b4ca509d8caeab7ab461e107a73c3ebfb"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
- "zeroize",
+    "aead",
+    "aes",
+    "cipher",
+    "ctr",
+    "ghash",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -3764,17 +3765,17 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce58f86dffd114bcefd8bcc6043658feec24b1f29be9972924651fe999ecf4a8"
 dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "rand_core 0.6.4",
+    "cfg-if",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-sgx-compat"
 version = "6.0.0"
 dependencies = [
- "cfg-if",
- "mc-sgx-types",
+    "cfg-if",
+    "mc-sgx-types",
 ]
 
 [[package]]
@@ -3783,8 +3784,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a11c52ab87959e701a4cfadef6347598c6177b0de5ddfa4ce4918b71048d569c"
 dependencies = [
- "bindgen 0.66.1",
- "cargo-emit",
+    "bindgen 0.66.1",
+    "cargo-emit",
 ]
 
 [[package]]
@@ -3793,8 +3794,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f26e46d3279e257c6a418450332c94d0815486b8dbfdac76387e314e0c1093"
 dependencies = [
- "bindgen 0.66.1",
- "cargo-emit",
+    "bindgen 0.66.1",
+    "cargo-emit",
 ]
 
 [[package]]
@@ -3803,11 +3804,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e3737cd325f4fc372d5fe2efea18eeae1e32b08fd170677956e3ba81b46cf0"
 dependencies = [
- "bindgen 0.66.1",
- "cargo-emit",
- "mc-sgx-core-build 0.9.0",
- "serde",
- "serde_with",
+    "bindgen 0.66.1",
+    "cargo-emit",
+    "mc-sgx-core-build 0.9.0",
+    "serde",
+    "serde_with",
 ]
 
 [[package]]
@@ -3816,11 +3817,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b56553b93bd334e1f468394e739f1e404cc54085872da7993cbf85438f25d6c"
 dependencies = [
- "bindgen 0.66.1",
- "cargo-emit",
- "mc-sgx-core-build 0.10.1",
- "serde",
- "serde_with",
+    "bindgen 0.66.1",
+    "cargo-emit",
+    "mc-sgx-core-build 0.10.1",
+    "serde",
+    "serde_with",
 ]
 
 [[package]]
@@ -3829,16 +3830,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d243fa7499d18a9e84cb87c452d727a03c64c841709336d619fb4f9f7e4da892"
 dependencies = [
- "bitflags 2.4.2",
- "displaydoc",
- "getrandom",
- "hex",
- "mc-sgx-core-sys-types 0.9.0",
- "mc-sgx-util 0.9.0",
- "nom",
- "rand_core 0.6.4",
- "serde",
- "subtle",
+    "bitflags 2.4.2",
+    "displaydoc",
+    "getrandom",
+    "hex",
+    "mc-sgx-core-sys-types 0.9.0",
+    "mc-sgx-util 0.9.0",
+    "nom",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
 ]
 
 [[package]]
@@ -3847,25 +3848,25 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc4a12a26208d90e08c0eaf85f8318c8f9ab8fd8abd9c505bcf64def220d2ff"
 dependencies = [
- "bitflags 2.4.2",
- "displaydoc",
- "getrandom",
- "hex",
- "mc-sgx-core-sys-types 0.10.1",
- "mc-sgx-util 0.10.1",
- "nom",
- "rand_core 0.6.4",
- "serde",
- "subtle",
+    "bitflags 2.4.2",
+    "displaydoc",
+    "getrandom",
+    "hex",
+    "mc-sgx-core-sys-types 0.10.1",
+    "mc-sgx-util 0.10.1",
+    "nom",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
 ]
 
 [[package]]
 name = "mc-sgx-css"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-sgx-core-types 0.10.1",
- "sha2",
+    "displaydoc",
+    "mc-sgx-core-types 0.10.1",
+    "sha2",
 ]
 
 [[package]]
@@ -3874,9 +3875,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de6add229c047dc25fa8950ebf8e5fcc21a7f4d2b52c0b85b67b13d2edca08e9"
 dependencies = [
- "bindgen 0.66.1",
- "mc-sgx-core-build 0.10.1",
- "mc-sgx-core-sys-types 0.10.1",
+    "bindgen 0.66.1",
+    "mc-sgx-core-build 0.10.1",
+    "mc-sgx-core-sys-types 0.10.1",
 ]
 
 [[package]]
@@ -3885,38 +3886,38 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8592ab2cf83ec03324dba68e3f24d9dac716d1cefa7db434f8fdf79e2aafcf9f"
 dependencies = [
- "const-oid",
- "displaydoc",
- "hex",
- "mc-sgx-core-types 0.10.1",
- "mc-sgx-dcap-sys-types",
- "mc-sgx-util 0.10.1",
- "nom",
- "p256",
- "serde",
- "sha2",
- "static_assertions",
- "subtle",
- "x509-cert",
+    "const-oid",
+    "displaydoc",
+    "hex",
+    "mc-sgx-core-types 0.10.1",
+    "mc-sgx-dcap-sys-types",
+    "mc-sgx-util 0.10.1",
+    "nom",
+    "p256",
+    "serde",
+    "sha2",
+    "static_assertions",
+    "subtle",
+    "x509-cert",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-attest-core",
- "mc-attest-enclave-api",
- "mc-sgx-dcap-types",
- "mc-util-serial",
- "serde",
+    "displaydoc",
+    "mc-attest-core",
+    "mc-attest-enclave-api",
+    "mc-sgx-dcap-types",
+    "mc-util-serial",
+    "serde",
 ]
 
 [[package]]
 name = "mc-sgx-types"
 version = "6.0.0"
 dependencies = [
- "mc-sgx-core-sys-types 0.10.1",
+    "mc-sgx-core-sys-types 0.10.1",
 ]
 
 [[package]]
@@ -3935,319 +3936,319 @@ checksum = "70a17bdd557d482382794a59232314fe9cfb7a9c4450aec867f737d815e5f5b0"
 name = "mc-signer"
 version = "2.10.1"
 dependencies = [
- "anyhow",
- "base64",
- "clap 4.4.18",
- "displaydoc",
- "hex",
- "log",
- "mc-account-keys",
- "mc-common",
- "mc-core",
- "mc-core-types",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-full-service",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-signer",
- "mc-transaction-summary",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rocket",
- "serde",
- "serde_json",
- "structopt",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "subtle",
- "tiny-bip39",
- "vergen",
- "zeroize",
+    "anyhow",
+    "base64",
+    "clap 4.4.18",
+    "displaydoc",
+    "hex",
+    "log",
+    "mc-account-keys",
+    "mc-common",
+    "mc-core",
+    "mc-core-types",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-crypto-ring-signature-signer",
+    "mc-full-service",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-transaction-signer",
+    "mc-transaction-summary",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
+    "rocket",
+    "serde",
+    "serde_json",
+    "structopt",
+    "strum 0.25.0",
+    "strum_macros 0.25.3",
+    "subtle",
+    "tiny-bip39",
+    "vergen",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-builder"
 version = "6.0.0"
 dependencies = [
- "cfg-if",
- "curve25519-dalek",
- "displaydoc",
- "hmac",
- "mc-account-keys",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-summary",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-serial",
- "mc-util-u64-ratio",
- "prost 0.12.3",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
+    "cfg-if",
+    "curve25519-dalek",
+    "displaydoc",
+    "hmac",
+    "mc-account-keys",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature-signer",
+    "mc-fog-report-validation",
+    "mc-transaction-core",
+    "mc-transaction-extra",
+    "mc-transaction-summary",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "mc-util-serial",
+    "mc-util-u64-ratio",
+    "prost 0.12.3",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
+    "serde",
+    "sha2",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-core"
 version = "6.0.0"
 dependencies = [
- "aes",
- "bulletproofs-og",
- "crc",
- "ctr",
- "curve25519-dalek",
- "displaydoc",
- "generic-array",
- "hex_fmt",
- "hkdf",
- "lazy_static",
- "mc-account-keys",
- "mc-common",
- "mc-crypto-box",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-u64-ratio",
- "mc-util-zip-exact",
- "merlin",
- "prost 0.12.3",
- "rand_core 0.6.4",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
+    "aes",
+    "bulletproofs-og",
+    "crc",
+    "ctr",
+    "curve25519-dalek",
+    "displaydoc",
+    "generic-array",
+    "hex_fmt",
+    "hkdf",
+    "lazy_static",
+    "mc-account-keys",
+    "mc-common",
+    "mc-crypto-box",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-crypto-multisig",
+    "mc-crypto-ring-signature",
+    "mc-crypto-ring-signature-signer",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "mc-util-u64-ratio",
+    "mc-util-zip-exact",
+    "merlin",
+    "prost 0.12.3",
+    "rand_core 0.6.4",
+    "serde",
+    "sha2",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-core-test-utils"
 version = "6.0.0"
 dependencies = [
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation-test-utils",
- "mc-rand",
- "mc-transaction-core",
- "mc-util-from-random",
- "mc-util-serial",
+    "mc-account-keys",
+    "mc-crypto-keys",
+    "mc-crypto-multisig",
+    "mc-crypto-ring-signature-signer",
+    "mc-fog-report-validation-test-utils",
+    "mc-rand",
+    "mc-transaction-core",
+    "mc-util-from-random",
+    "mc-util-serial",
 ]
 
 [[package]]
 name = "mc-transaction-extra"
 version = "6.0.0"
 dependencies = [
- "cfg-if",
- "curve25519-dalek",
- "displaydoc",
- "mc-account-keys",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-memo-mac",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-transaction-core",
- "mc-transaction-summary",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-u64-ratio",
- "mc-util-vec-map",
- "mc-util-zip-exact",
- "prost 0.12.3",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "subtle",
- "zeroize",
+    "cfg-if",
+    "curve25519-dalek",
+    "displaydoc",
+    "mc-account-keys",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-crypto-memo-mac",
+    "mc-crypto-ring-signature",
+    "mc-crypto-ring-signature-signer",
+    "mc-transaction-core",
+    "mc-transaction-summary",
+    "mc-transaction-types",
+    "mc-util-from-random",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "mc-util-u64-ratio",
+    "mc-util-vec-map",
+    "mc-util-zip-exact",
+    "prost 0.12.3",
+    "rand 0.8.5",
+    "rand_core 0.6.4",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-signer"
 version = "6.0.0"
 dependencies = [
- "anyhow",
- "clap 4.4.18",
- "displaydoc",
- "hex",
- "log",
- "mc-account-keys",
- "mc-common",
- "mc-core",
- "mc-core-types",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-transaction-core",
- "mc-transaction-summary",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
- "subtle",
- "tiny-bip39",
- "zeroize",
+    "anyhow",
+    "clap 4.4.18",
+    "displaydoc",
+    "hex",
+    "log",
+    "mc-account-keys",
+    "mc-common",
+    "mc-core",
+    "mc-core-types",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-crypto-ring-signature-signer",
+    "mc-transaction-core",
+    "mc-transaction-summary",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "rand_core 0.6.4",
+    "serde",
+    "serde_json",
+    "subtle",
+    "tiny-bip39",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-summary"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "mc-account-keys",
- "mc-core",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "mc-transaction-types",
- "mc-util-vec-map",
- "mc-util-zip-exact",
- "prost 0.12.3",
- "serde",
- "subtle",
- "zeroize",
+    "displaydoc",
+    "mc-account-keys",
+    "mc-core",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "mc-transaction-types",
+    "mc-util-vec-map",
+    "mc-util-zip-exact",
+    "prost 0.12.3",
+    "serde",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-transaction-types"
 version = "6.0.0"
 dependencies = [
- "crc",
- "displaydoc",
- "hkdf",
- "mc-crypto-digestible",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-ring-signature",
- "prost 0.12.3",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
+    "crc",
+    "displaydoc",
+    "hkdf",
+    "mc-crypto-digestible",
+    "mc-crypto-hashes",
+    "mc-crypto-keys",
+    "mc-crypto-ring-signature",
+    "prost 0.12.3",
+    "serde",
+    "sha2",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
 name = "mc-util-build-enclave"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "cargo_metadata",
- "displaydoc",
- "mbedtls",
- "mbedtls-sys-auto",
- "mc-sgx-css",
- "mc-util-build-script",
- "mc-util-build-sgx",
- "pkg-config",
- "rand 0.8.5",
+    "cargo-emit",
+    "cargo_metadata",
+    "displaydoc",
+    "mbedtls",
+    "mbedtls-sys-auto",
+    "mc-sgx-css",
+    "mc-util-build-script",
+    "mc-util-build-sgx",
+    "pkg-config",
+    "rand 0.8.5",
 ]
 
 [[package]]
 name = "mc-util-build-grpc"
 version = "6.0.0"
 dependencies = [
- "mc-util-build-script",
- "protoc-grpcio",
+    "mc-util-build-script",
+    "protoc-grpcio",
 ]
 
 [[package]]
 name = "mc-util-build-info"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
+    "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "displaydoc",
- "lazy_static",
- "url",
- "walkdir",
+    "cargo-emit",
+    "displaydoc",
+    "lazy_static",
+    "url",
+    "walkdir",
 ]
 
 [[package]]
 name = "mc-util-build-sgx"
 version = "6.0.0"
 dependencies = [
- "cargo-emit",
- "cc",
- "displaydoc",
- "mc-util-build-script",
- "pkg-config",
+    "cargo-emit",
+    "cc",
+    "displaydoc",
+    "mc-util-build-script",
+    "pkg-config",
 ]
 
 [[package]]
 name = "mc-util-encodings"
 version = "6.0.0"
 dependencies = [
- "base64",
- "displaydoc",
- "hex",
- "mc-util-repr-bytes",
- "serde",
+    "base64",
+    "displaydoc",
+    "hex",
+    "mc-util-repr-bytes",
+    "serde",
 ]
 
 [[package]]
 name = "mc-util-from-random"
 version = "6.0.0"
 dependencies = [
- "rand_core 0.6.4",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-grpc"
 version = "6.0.0"
 dependencies = [
- "base64",
- "clap 4.4.18",
- "cookie",
- "displaydoc",
- "futures",
- "grpcio",
- "hex",
- "hex_fmt",
- "hmac",
- "lazy_static",
- "mc-common",
- "mc-util-build-grpc",
- "mc-util-build-info",
- "mc-util-metrics",
- "mc-util-serial",
- "mc-util-uri",
- "prometheus",
- "protobuf",
- "rand 0.8.5",
- "retry",
- "serde",
- "sha2",
- "signal-hook",
- "subtle",
- "zeroize",
+    "base64",
+    "clap 4.4.18",
+    "cookie",
+    "displaydoc",
+    "futures",
+    "grpcio",
+    "hex",
+    "hex_fmt",
+    "hmac",
+    "lazy_static",
+    "mc-common",
+    "mc-util-build-grpc",
+    "mc-util-build-info",
+    "mc-util-metrics",
+    "mc-util-serial",
+    "mc-util-uri",
+    "prometheus",
+    "protobuf",
+    "rand 0.8.5",
+    "retry",
+    "serde",
+    "sha2",
+    "signal-hook",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -4258,85 +4259,85 @@ version = "6.0.0"
 name = "mc-util-lmdb"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "lmdb-rkv",
- "mc-util-serial",
- "prost 0.12.3",
+    "displaydoc",
+    "lmdb-rkv",
+    "mc-util-serial",
+    "prost 0.12.3",
 ]
 
 [[package]]
 name = "mc-util-logger-macros"
 version = "6.0.0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
 name = "mc-util-metrics"
 version = "6.0.0"
 dependencies = [
- "chrono",
- "grpcio",
- "lazy_static",
- "mc-common",
- "prometheus",
- "protobuf",
- "serde_json",
+    "chrono",
+    "grpcio",
+    "lazy_static",
+    "mc-common",
+    "prometheus",
+    "protobuf",
+    "serde_json",
 ]
 
 [[package]]
 name = "mc-util-parse"
 version = "6.0.0"
 dependencies = [
- "hex",
- "itertools 0.12.0",
- "mc-sgx-css",
+    "hex",
+    "itertools 0.12.0",
+    "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
 version = "6.0.0"
 dependencies = [
- "generic-array",
- "hex_fmt",
- "prost 0.12.3",
- "serde",
+    "generic-array",
+    "hex_fmt",
+    "prost 0.12.3",
+    "serde",
 ]
 
 [[package]]
 name = "mc-util-serial"
 version = "6.0.0"
 dependencies = [
- "prost 0.12.3",
- "protobuf",
- "serde",
- "serde_cbor",
- "serde_with",
+    "prost 0.12.3",
+    "protobuf",
+    "serde",
+    "serde_cbor",
+    "serde_with",
 ]
 
 [[package]]
 name = "mc-util-telemetry"
 version = "6.0.0"
 dependencies = [
- "cfg-if",
- "displaydoc",
- "hostname",
- "opentelemetry",
- "opentelemetry-jaeger",
- "opentelemetry_sdk",
+    "cfg-if",
+    "displaydoc",
+    "hostname",
+    "opentelemetry",
+    "opentelemetry-jaeger",
+    "opentelemetry_sdk",
 ]
 
 [[package]]
 name = "mc-util-test-helper"
 version = "6.0.0"
 dependencies = [
- "clap 4.4.18",
- "lazy_static",
- "mc-account-keys",
- "rand 0.8.5",
- "rand_hc",
+    "clap 4.4.18",
+    "lazy_static",
+    "mc-account-keys",
+    "rand 0.8.5",
+    "rand_hc",
 ]
 
 [[package]]
@@ -4347,141 +4348,141 @@ version = "6.0.0"
 name = "mc-util-uri"
 version = "6.0.0"
 dependencies = [
- "base64",
- "displaydoc",
- "hex",
- "mc-common",
- "mc-crypto-keys",
- "mc-util-host-cert",
- "percent-encoding",
- "serde",
- "url",
+    "base64",
+    "displaydoc",
+    "hex",
+    "mc-common",
+    "mc-crypto-keys",
+    "mc-util-host-cert",
+    "percent-encoding",
+    "serde",
+    "url",
 ]
 
 [[package]]
 name = "mc-util-vec-map"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "heapless 0.8.0",
+    "displaydoc",
+    "heapless 0.8.0",
 ]
 
 [[package]]
 name = "mc-util-zip-exact"
 version = "6.0.0"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
 name = "mc-validator-api"
 version = "2.10.1"
 dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "mc-api",
- "mc-consensus-api",
- "mc-fog-report-api",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-uri",
- "protobuf",
+    "cargo-emit",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-consensus-api",
+    "mc-fog-report-api",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-uri",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-validator-connection"
 version = "2.10.1"
 dependencies = [
- "displaydoc",
- "futures",
- "grpcio",
- "mc-api",
- "mc-blockchain-types",
- "mc-common",
- "mc-connection",
- "mc-fog-report-types",
- "mc-transaction-core",
- "mc-util-grpc",
- "mc-util-uri",
- "mc-validator-api",
- "protobuf",
+    "displaydoc",
+    "futures",
+    "grpcio",
+    "mc-api",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-connection",
+    "mc-fog-report-types",
+    "mc-transaction-core",
+    "mc-util-grpc",
+    "mc-util-uri",
+    "mc-validator-api",
+    "protobuf",
 ]
 
 [[package]]
 name = "mc-validator-service"
 version = "2.10.1"
 dependencies = [
- "clap 4.4.18",
- "grpcio",
- "mc-attest-core",
- "mc-attest-verifier",
- "mc-attestation-verifier",
- "mc-common",
- "mc-connection",
- "mc-consensus-enclave-measurement",
- "mc-fog-report-connection",
- "mc-full-service",
- "mc-ledger-db",
- "mc-ledger-sync",
- "mc-sgx-core-types 0.9.0",
- "mc-transaction-core",
- "mc-util-grpc",
- "mc-util-parse",
- "mc-util-uri",
- "mc-validator-api",
- "rayon",
+    "clap 4.4.18",
+    "grpcio",
+    "mc-attest-core",
+    "mc-attest-verifier",
+    "mc-attestation-verifier",
+    "mc-common",
+    "mc-connection",
+    "mc-consensus-enclave-measurement",
+    "mc-fog-report-connection",
+    "mc-full-service",
+    "mc-ledger-db",
+    "mc-ledger-sync",
+    "mc-sgx-core-types 0.9.0",
+    "mc-transaction-core",
+    "mc-util-grpc",
+    "mc-util-parse",
+    "mc-util-uri",
+    "mc-validator-api",
+    "rayon",
 ]
 
 [[package]]
 name = "mc-watcher"
 version = "6.0.0"
 dependencies = [
- "aes-gcm",
- "clap 4.4.18",
- "displaydoc",
- "futures",
- "grpcio",
- "hex",
- "lazy_static",
- "lmdb-rkv",
- "mc-api",
- "mc-attest-ake",
- "mc-attest-api",
- "mc-attest-core",
- "mc-attest-verifier-types",
- "mc-blockchain-types",
- "mc-common",
- "mc-connection",
- "mc-crypto-digestible",
- "mc-crypto-keys",
- "mc-crypto-noise",
- "mc-ledger-db",
- "mc-ledger-sync",
- "mc-rand",
- "mc-util-from-random",
- "mc-util-grpc",
- "mc-util-lmdb",
- "mc-util-metrics",
- "mc-util-parse",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-uri",
- "mc-watcher-api",
- "prost 0.12.3",
- "rayon",
- "serde",
- "sha2",
- "toml 0.8.8",
- "url",
+    "aes-gcm",
+    "clap 4.4.18",
+    "displaydoc",
+    "futures",
+    "grpcio",
+    "hex",
+    "lazy_static",
+    "lmdb-rkv",
+    "mc-api",
+    "mc-attest-ake",
+    "mc-attest-api",
+    "mc-attest-core",
+    "mc-attest-verifier-types",
+    "mc-blockchain-types",
+    "mc-common",
+    "mc-connection",
+    "mc-crypto-digestible",
+    "mc-crypto-keys",
+    "mc-crypto-noise",
+    "mc-ledger-db",
+    "mc-ledger-sync",
+    "mc-rand",
+    "mc-util-from-random",
+    "mc-util-grpc",
+    "mc-util-lmdb",
+    "mc-util-metrics",
+    "mc-util-parse",
+    "mc-util-repr-bytes",
+    "mc-util-serial",
+    "mc-util-uri",
+    "mc-watcher-api",
+    "prost 0.12.3",
+    "rayon",
+    "serde",
+    "sha2",
+    "toml 0.8.8",
+    "url",
 ]
 
 [[package]]
 name = "mc-watcher-api"
 version = "6.0.0"
 dependencies = [
- "displaydoc",
- "serde",
+    "displaydoc",
+    "serde",
 ]
 
 [[package]]
@@ -4496,10 +4497,10 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
+    "byteorder",
+    "keccak",
+    "rand_core 0.6.4",
+    "zeroize",
 ]
 
 [[package]]
@@ -4508,8 +4509,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
- "serde",
- "toml 0.7.8",
+    "serde",
+    "toml 0.7.8",
 ]
 
 [[package]]
@@ -4518,9 +4519,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
- "migrations_internals",
- "proc-macro2",
- "quote",
+    "migrations_internals",
+    "proc-macro2",
+    "quote",
 ]
 
 [[package]]
@@ -4541,7 +4542,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
- "adler",
+    "adler",
 ]
 
 [[package]]
@@ -4550,9 +4551,9 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
+    "libc",
+    "wasi",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4561,13 +4562,13 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
 dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
+    "cfg-if",
+    "downcast",
+    "fragile",
+    "lazy_static",
+    "mockall_derive",
+    "predicates",
+    "predicates-tree",
 ]
 
 [[package]]
@@ -4576,10 +4577,10 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "cfg-if",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -4588,18 +4589,18 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin 0.9.8",
- "tokio",
- "tokio-util",
- "version_check",
+    "bytes",
+    "encoding_rs",
+    "futures-util",
+    "http",
+    "httparse",
+    "log",
+    "memchr",
+    "mime",
+    "spin 0.9.8",
+    "tokio",
+    "tokio-util",
+    "version_check",
 ]
 
 [[package]]
@@ -4614,8 +4615,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "memchr",
- "minimal-lexical",
+    "memchr",
+    "minimal-lexical",
 ]
 
 [[package]]
@@ -4624,7 +4625,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
- "winapi",
+    "winapi",
 ]
 
 [[package]]
@@ -4633,8 +4634,8 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "overload",
- "winapi",
+    "overload",
+    "winapi",
 ]
 
 [[package]]
@@ -4643,9 +4644,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
+    "autocfg",
+    "num-integer",
+    "num-traits",
 ]
 
 [[package]]
@@ -4654,8 +4655,8 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
- "num-traits",
+    "autocfg",
+    "num-traits",
 ]
 
 [[package]]
@@ -4664,7 +4665,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
- "autocfg",
+    "autocfg",
 ]
 
 [[package]]
@@ -4673,8 +4674,8 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
- "libc",
+    "hermit-abi 0.3.4",
+    "libc",
 ]
 
 [[package]]
@@ -4683,7 +4684,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+    "num_enum_derive",
 ]
 
 [[package]]
@@ -4692,9 +4693,9 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -4703,7 +4704,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -4712,7 +4713,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
- "malloc_buf",
+    "malloc_buf",
 ]
 
 [[package]]
@@ -4721,7 +4722,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -4748,14 +4749,14 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "futures-core",
- "futures-sink",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
+    "futures-core",
+    "futures-sink",
+    "indexmap",
+    "js-sys",
+    "once_cell",
+    "pin-project-lite",
+    "thiserror",
+    "urlencoding",
 ]
 
 [[package]]
@@ -4764,11 +4765,11 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest",
+    "async-trait",
+    "bytes",
+    "http",
+    "opentelemetry",
+    "reqwest",
 ]
 
 [[package]]
@@ -4777,17 +4778,17 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e617c66fd588e40e0dbbd66932fdc87393095b125d4459b1a3a10feb1712f8a1"
 dependencies = [
- "async-trait",
- "futures-core",
- "futures-util",
- "headers",
- "http",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "reqwest",
- "thrift",
+    "async-trait",
+    "futures-core",
+    "futures-util",
+    "headers",
+    "http",
+    "opentelemetry",
+    "opentelemetry-http",
+    "opentelemetry-semantic-conventions",
+    "opentelemetry_sdk",
+    "reqwest",
+    "thrift",
 ]
 
 [[package]]
@@ -4796,7 +4797,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry",
+    "opentelemetry",
 ]
 
 [[package]]
@@ -4805,17 +4806,17 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry",
- "ordered-float 4.2.0",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror",
+    "async-trait",
+    "crossbeam-channel",
+    "futures-channel",
+    "futures-executor",
+    "futures-util",
+    "once_cell",
+    "opentelemetry",
+    "ordered-float 4.2.0",
+    "percent-encoding",
+    "rand 0.8.5",
+    "thiserror",
 ]
 
 [[package]]
@@ -4824,7 +4825,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -4833,7 +4834,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -4842,9 +4843,9 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
- "log",
- "serde",
- "winapi",
+    "log",
+    "serde",
+    "winapi",
 ]
 
 [[package]]
@@ -4859,10 +4860,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+    "ecdsa",
+    "elliptic-curve",
+    "primeorder",
+    "sha2",
 ]
 
 [[package]]
@@ -4871,12 +4872,12 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
+    "arrayvec",
+    "bitvec",
+    "byte-slice-cast",
+    "impl-trait-for-tuples",
+    "parity-scale-codec-derive",
+    "serde",
 ]
 
 [[package]]
@@ -4885,10 +4886,10 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "proc-macro-crate",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -4897,8 +4898,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+    "lock_api",
+    "parking_lot_core",
 ]
 
 [[package]]
@@ -4907,11 +4908,11 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
+    "cfg-if",
+    "libc",
+    "redox_syscall",
+    "smallvec",
+    "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4920,7 +4921,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+    "digest",
 ]
 
 [[package]]
@@ -4929,9 +4930,9 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccca0f6c17acc81df8e242ed473ec144cbf5c98037e69aa6d144780aad103c8"
 dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
+    "inlinable_string",
+    "pear_codegen",
+    "yansi",
 ]
 
 [[package]]
@@ -4940,10 +4941,10 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e22670e8eb757cff11d6c199ca7b987f352f0346e0be4dd23869ec72cb53c77"
 dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "proc-macro2-diagnostics",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -4958,8 +4959,8 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
- "serde",
+    "base64",
+    "serde",
 ]
 
 [[package]]
@@ -4968,7 +4969,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
- "base64ct",
+    "base64ct",
 ]
 
 [[package]]
@@ -4983,8 +4984,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "fixedbitset",
- "indexmap",
+    "fixedbitset",
+    "indexmap",
 ]
 
 [[package]]
@@ -5005,8 +5006,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+    "der",
+    "spki",
 ]
 
 [[package]]
@@ -5027,10 +5028,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
+    "cfg-if",
+    "cpufeatures",
+    "opaque-debug",
+    "universal-hash",
 ]
 
 [[package]]
@@ -5051,8 +5052,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
- "anstyle",
- "predicates-core",
+    "anstyle",
+    "predicates-core",
 ]
 
 [[package]]
@@ -5067,8 +5068,8 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
- "predicates-core",
- "termtree",
+    "predicates-core",
+    "termtree",
 ]
 
 [[package]]
@@ -5077,8 +5078,8 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
- "proc-macro2",
- "syn 2.0.48",
+    "proc-macro2",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -5087,7 +5088,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+    "elliptic-curve",
 ]
 
 [[package]]
@@ -5096,9 +5097,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash",
- "impl-codec",
- "uint",
+    "fixed-hash",
+    "impl-codec",
+    "uint",
 ]
 
 [[package]]
@@ -5107,7 +5108,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_edit 0.20.7",
+    "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -5116,11 +5117,11 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
+    "proc-macro-error-attr",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
+    "version_check",
 ]
 
 [[package]]
@@ -5129,9 +5130,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+    "proc-macro2",
+    "quote",
+    "version_check",
 ]
 
 [[package]]
@@ -5140,7 +5141,7 @@ version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
- "unicode-ident",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -5149,11 +5150,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "version_check",
- "yansi",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
+    "version_check",
+    "yansi",
 ]
 
 [[package]]
@@ -5162,13 +5163,13 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
+    "cfg-if",
+    "fnv",
+    "lazy_static",
+    "memchr",
+    "parking_lot",
+    "protobuf",
+    "thiserror",
 ]
 
 [[package]]
@@ -5177,8 +5178,8 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
- "bytes",
- "prost-derive 0.11.9",
+    "bytes",
+    "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -5187,8 +5188,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
- "bytes",
- "prost-derive 0.12.3",
+    "bytes",
+    "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -5197,20 +5198,20 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.3",
- "prost-types",
- "regex",
- "syn 2.0.48",
- "tempfile",
- "which",
+    "bytes",
+    "heck 0.4.1",
+    "itertools 0.10.5",
+    "log",
+    "multimap",
+    "once_cell",
+    "petgraph",
+    "prettyplease",
+    "prost 0.12.3",
+    "prost-types",
+    "regex",
+    "syn 2.0.48",
+    "tempfile",
+    "which",
 ]
 
 [[package]]
@@ -5219,11 +5220,11 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "anyhow",
+    "itertools 0.10.5",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -5232,11 +5233,11 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "anyhow",
+    "itertools 0.10.5",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -5245,7 +5246,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
+    "prost 0.12.3",
 ]
 
 [[package]]
@@ -5260,7 +5261,7 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
 dependencies = [
- "protobuf",
+    "protobuf",
 ]
 
 [[package]]
@@ -5269,8 +5270,8 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
 dependencies = [
- "log",
- "which",
+    "log",
+    "which",
 ]
 
 [[package]]
@@ -5279,12 +5280,12 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d0ed845138df84f72beb72faf6d726c70c99d0debb2b5e1e7dee61f853df7"
 dependencies = [
- "failure",
- "grpcio-compiler",
- "protobuf",
- "protobuf-codegen",
- "protoc",
- "tempfile",
+    "failure",
+    "grpcio-compiler",
+    "protobuf",
+    "protobuf-codegen",
+    "protoc",
+    "tempfile",
 ]
 
 [[package]]
@@ -5293,7 +5294,7 @@ version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2",
+    "proc-macro2",
 ]
 
 [[package]]
@@ -5302,9 +5303,9 @@ version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
+    "log",
+    "parking_lot",
+    "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -5319,11 +5320,11 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
+    "fuchsia-cprng",
+    "libc",
+    "rand_core 0.3.1",
+    "rdrand",
+    "winapi",
 ]
 
 [[package]]
@@ -5332,9 +5333,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
+    "libc",
+    "rand_chacha",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5343,8 +5344,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+    "ppv-lite86",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5353,7 +5354,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 dependencies = [
- "rand_core 0.4.2",
+    "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -5368,7 +5369,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+    "getrandom",
 ]
 
 [[package]]
@@ -5377,7 +5378,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b363d4f6370f88d62bf586c80405657bde0f0e1b8945d47d2ad59b906cb4f54"
 dependencies = [
- "rand_core 0.6.4",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5386,8 +5387,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
- "either",
- "rayon-core",
+    "either",
+    "rayon-core",
 ]
 
 [[package]]
@@ -5396,8 +5397,8 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
+    "crossbeam-deque",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -5406,7 +5407,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
- "rand_core 0.3.1",
+    "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5415,7 +5416,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09525bbb69b77802609e9c714e28dbf2db3a8c88bf0e82c9c69c4ade77a949bd"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -5424,7 +5425,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.3.2",
+    "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5433,9 +5434,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
+    "getrandom",
+    "libredox",
+    "thiserror",
 ]
 
 [[package]]
@@ -5444,7 +5445,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4846d4c50d1721b1a3bef8af76924eef20d5e723647333798c1b519b3a9473f"
 dependencies = [
- "ref-cast-impl",
+    "ref-cast-impl",
 ]
 
 [[package]]
@@ -5453,9 +5454,9 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -5464,10 +5465,10 @@ version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.4",
- "regex-syntax 0.8.2",
+    "aho-corasick",
+    "memchr",
+    "regex-automata 0.4.4",
+    "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5476,7 +5477,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax 0.6.29",
+    "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5485,9 +5486,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.2",
+    "aho-corasick",
+    "memchr",
+    "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5508,7 +5509,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+    "winapi",
 ]
 
 [[package]]
@@ -5517,41 +5518,41 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "async-compression",
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "system-configuration",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
+    "async-compression",
+    "base64",
+    "bytes",
+    "encoding_rs",
+    "futures-core",
+    "futures-util",
+    "h2",
+    "http",
+    "http-body",
+    "hyper",
+    "hyper-rustls",
+    "ipnet",
+    "js-sys",
+    "log",
+    "mime",
+    "once_cell",
+    "percent-encoding",
+    "pin-project-lite",
+    "rustls",
+    "rustls-native-certs",
+    "rustls-pemfile",
+    "serde",
+    "serde_json",
+    "serde_urlencoded",
+    "system-configuration",
+    "tokio",
+    "tokio-rustls",
+    "tokio-util",
+    "tower-service",
+    "url",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "web-sys",
+    "webpki-roots",
+    "winreg",
 ]
 
 [[package]]
@@ -5560,7 +5561,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
 dependencies = [
- "rand 0.8.5",
+    "rand 0.8.5",
 ]
 
 [[package]]
@@ -5569,8 +5570,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
- "subtle",
+    "hmac",
+    "subtle",
 ]
 
 [[package]]
@@ -5579,13 +5580,13 @@ version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
+    "cc",
+    "libc",
+    "once_cell",
+    "spin 0.5.2",
+    "untrusted 0.7.1",
+    "web-sys",
+    "winapi",
 ]
 
 [[package]]
@@ -5594,12 +5595,12 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
- "windows-sys 0.48.0",
+    "cc",
+    "getrandom",
+    "libc",
+    "spin 0.9.8",
+    "untrusted 0.9.0",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5614,36 +5615,36 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e7bb57ccb26670d73b6a47396c83139447b9e7878cab627fdfe9ea8da489150"
 dependencies = [
- "async-stream",
- "async-trait",
- "atomic 0.5.3",
- "binascii",
- "bytes",
- "either",
- "figment",
- "futures",
- "indexmap",
- "log",
- "memchr",
- "multer",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "rand 0.8.5",
- "ref-cast",
- "rocket_codegen",
- "rocket_http",
- "serde",
- "serde_json",
- "state",
- "tempfile",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "ubyte",
- "version_check",
- "yansi",
+    "async-stream",
+    "async-trait",
+    "atomic 0.5.3",
+    "binascii",
+    "bytes",
+    "either",
+    "figment",
+    "futures",
+    "indexmap",
+    "log",
+    "memchr",
+    "multer",
+    "num_cpus",
+    "parking_lot",
+    "pin-project-lite",
+    "rand 0.8.5",
+    "ref-cast",
+    "rocket_codegen",
+    "rocket_http",
+    "serde",
+    "serde_json",
+    "state",
+    "tempfile",
+    "time",
+    "tokio",
+    "tokio-stream",
+    "tokio-util",
+    "ubyte",
+    "version_check",
+    "yansi",
 ]
 
 [[package]]
@@ -5652,15 +5653,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2238066abf75f21be6cd7dc1a09d5414a671f4246e384e49fe3f8a4936bd04c"
 dependencies = [
- "devise",
- "glob",
- "indexmap",
- "proc-macro2",
- "quote",
- "rocket_http",
- "syn 2.0.48",
- "unicode-xid",
- "version_check",
+    "devise",
+    "glob",
+    "indexmap",
+    "proc-macro2",
+    "quote",
+    "rocket_http",
+    "syn 2.0.48",
+    "unicode-xid",
+    "version_check",
 ]
 
 [[package]]
@@ -5669,28 +5670,28 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a1663694d059fe5f943ea5481363e48050acedd241d46deb2e27f71110389e"
 dependencies = [
- "cookie",
- "either",
- "futures",
- "http",
- "hyper",
- "indexmap",
- "log",
- "memchr",
- "pear",
- "percent-encoding",
- "pin-project-lite",
- "ref-cast",
- "rustls",
- "rustls-pemfile",
- "serde",
- "smallvec",
- "stable-pattern",
- "state",
- "time",
- "tokio",
- "tokio-rustls",
- "uncased",
+    "cookie",
+    "either",
+    "futures",
+    "http",
+    "hyper",
+    "indexmap",
+    "log",
+    "memchr",
+    "pear",
+    "percent-encoding",
+    "pin-project-lite",
+    "ref-cast",
+    "rustls",
+    "rustls-pemfile",
+    "serde",
+    "smallvec",
+    "stable-pattern",
+    "state",
+    "time",
+    "tokio",
+    "tokio-rustls",
+    "uncased",
 ]
 
 [[package]]
@@ -5699,13 +5700,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f32721ed79509adac4328e97f817a8f55a47c4b64799f6fd6cc3adb6e42ff"
 dependencies = [
- "diesel",
- "r2d2",
- "rocket",
- "rocket_sync_db_pools_codegen",
- "serde",
- "tokio",
- "version_check",
+    "diesel",
+    "r2d2",
+    "rocket",
+    "rocket_sync_db_pools_codegen",
+    "serde",
+    "tokio",
+    "version_check",
 ]
 
 [[package]]
@@ -5714,8 +5715,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc890925dc79370c28eb15c9957677093fdb7e8c44966d189f38cedb995ee68"
 dependencies = [
- "devise",
- "quote",
+    "devise",
+    "quote",
 ]
 
 [[package]]
@@ -5724,8 +5725,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683e8c8e8aac6ffa4b2287bac3c69575d5346accac4f218ae1e084303bb174ca"
 dependencies = [
- "cc",
- "zeroize",
+    "cc",
+    "zeroize",
 ]
 
 [[package]]
@@ -5752,7 +5753,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+    "semver",
 ]
 
 [[package]]
@@ -5761,11 +5762,11 @@ version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.2",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+    "bitflags 2.4.2",
+    "errno",
+    "libc",
+    "linux-raw-sys",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5774,10 +5775,10 @@ version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
- "log",
- "ring 0.17.7",
- "rustls-webpki",
- "sct",
+    "log",
+    "ring 0.17.7",
+    "rustls-webpki",
+    "sct",
 ]
 
 [[package]]
@@ -5786,10 +5787,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
+    "openssl-probe",
+    "rustls-pemfile",
+    "schannel",
+    "security-framework",
 ]
 
 [[package]]
@@ -5798,7 +5799,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+    "base64",
 ]
 
 [[package]]
@@ -5807,8 +5808,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
+    "ring 0.17.7",
+    "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5829,7 +5830,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "winapi-util",
+    "winapi-util",
 ]
 
 [[package]]
@@ -5838,7 +5839,7 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.52.0",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5847,7 +5848,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot",
+    "parking_lot",
 ]
 
 [[package]]
@@ -5855,15 +5856,15 @@ name = "schnorrkel-og"
 version = "0.11.0-pre.0"
 source = "git+https://github.com/mobilecoinfoundation/schnorrkel.git?rev=049bf9d30f3bbe072e2ad1b5eefdf0f3c851215e#049bf9d30f3bbe072e2ad1b5eefdf0f3c851215e"
 dependencies = [
- "arrayref",
- "arrayvec",
- "cfg-if",
- "curve25519-dalek",
- "merlin",
- "rand_core 0.6.4",
- "sha2",
- "subtle",
- "zeroize",
+    "arrayref",
+    "arrayvec",
+    "cfg-if",
+    "curve25519-dalek",
+    "merlin",
+    "rand_core 0.6.4",
+    "sha2",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -5884,8 +5885,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
- "untrusted 0.9.0",
+    "ring 0.17.7",
+    "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5894,12 +5895,12 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
+    "base16ct",
+    "der",
+    "generic-array",
+    "pkcs8",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -5908,7 +5909,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "zeroize",
+    "zeroize",
 ]
 
 [[package]]
@@ -5917,11 +5918,11 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
+    "bitflags 1.3.2",
+    "core-foundation",
+    "core-foundation-sys",
+    "libc",
+    "security-framework-sys",
 ]
 
 [[package]]
@@ -5930,8 +5931,8 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
- "core-foundation-sys",
- "libc",
+    "core-foundation-sys",
+    "libc",
 ]
 
 [[package]]
@@ -5940,7 +5941,7 @@ version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -5949,20 +5950,20 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab18211f62fb890f27c9bb04861f76e4be35e4c2fcbfc2d98afa37aadebb16f1"
 dependencies = [
- "httpdate",
- "reqwest",
- "rustls",
- "sentry-backtrace",
- "sentry-contexts",
- "sentry-core",
- "sentry-log",
- "sentry-panic",
- "sentry-slog",
- "sentry-tracing",
- "serde_json",
- "tokio",
- "ureq",
- "webpki-roots",
+    "httpdate",
+    "reqwest",
+    "rustls",
+    "sentry-backtrace",
+    "sentry-contexts",
+    "sentry-core",
+    "sentry-log",
+    "sentry-panic",
+    "sentry-slog",
+    "sentry-tracing",
+    "serde_json",
+    "tokio",
+    "ureq",
+    "webpki-roots",
 ]
 
 [[package]]
@@ -5971,10 +5972,10 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf018ff7d5ce5b23165a9cbfee60b270a55ae219bc9eebef2a3b6039356dd7e5"
 dependencies = [
- "backtrace",
- "once_cell",
- "regex",
- "sentry-core",
+    "backtrace",
+    "once_cell",
+    "regex",
+    "sentry-core",
 ]
 
 [[package]]
@@ -5983,12 +5984,12 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d934df6f9a17b8c15b829860d9d6d39e78126b5b970b365ccbd817bc0fe82c9"
 dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version",
- "sentry-core",
- "uname",
+    "hostname",
+    "libc",
+    "os_info",
+    "rustc_version",
+    "sentry-core",
+    "uname",
 ]
 
 [[package]]
@@ -5997,11 +5998,11 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e362d3fb1c5de5124bf1681086eaca7adf6a8c4283a7e1545359c729f9128ff"
 dependencies = [
- "once_cell",
- "rand 0.8.5",
- "sentry-types",
- "serde",
- "serde_json",
+    "once_cell",
+    "rand 0.8.5",
+    "sentry-types",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
@@ -6010,8 +6011,8 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7574422f662fe062a2ef7d027659ad8745e05fb815770887aeb08e2fb92cf6"
 dependencies = [
- "log",
- "sentry-core",
+    "log",
+    "sentry-core",
 ]
 
 [[package]]
@@ -6020,8 +6021,8 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0224e7a8e2bd8a32d96804acb8243d6d6e073fed55618afbdabae8249a964d8"
 dependencies = [
- "sentry-backtrace",
- "sentry-core",
+    "sentry-backtrace",
+    "sentry-core",
 ]
 
 [[package]]
@@ -6030,9 +6031,9 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16adbbf6ec1e248d92b481e159eda295ea1d863c9ecaf12c88d3fb8de86f12a"
 dependencies = [
- "sentry-core",
- "serde_json",
- "slog",
+    "sentry-core",
+    "serde_json",
+    "slog",
 ]
 
 [[package]]
@@ -6041,10 +6042,10 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "087bed8c616d176a9c6b662a8155e5f23b40dc9e1fa96d0bd5fb56e8636a9275"
 dependencies = [
- "sentry-backtrace",
- "sentry-core",
- "tracing-core",
- "tracing-subscriber",
+    "sentry-backtrace",
+    "sentry-core",
+    "tracing-core",
+    "tracing-subscriber",
 ]
 
 [[package]]
@@ -6053,15 +6054,15 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4f0e37945b7a8ce7faebc310af92442e2d7c5aa7ef5b42fe6daa98ee133f65"
 dependencies = [
- "debugid",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "url",
- "uuid",
+    "debugid",
+    "hex",
+    "rand 0.8.5",
+    "serde",
+    "serde_json",
+    "thiserror",
+    "time",
+    "url",
+    "uuid",
 ]
 
 [[package]]
@@ -6070,7 +6071,7 @@ version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
- "serde_derive",
+    "serde_derive",
 ]
 
 [[package]]
@@ -6079,7 +6080,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -6088,10 +6089,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
 dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
+    "log",
+    "serde",
+    "thiserror",
+    "xml-rs",
 ]
 
 [[package]]
@@ -6100,8 +6101,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
- "serde",
+    "half",
+    "serde",
 ]
 
 [[package]]
@@ -6110,9 +6111,9 @@ version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6121,10 +6122,10 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
+    "indexmap",
+    "itoa",
+    "ryu",
+    "serde",
 ]
 
 [[package]]
@@ -6133,7 +6134,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -6142,10 +6143,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+    "form_urlencoded",
+    "itoa",
+    "ryu",
+    "serde",
 ]
 
 [[package]]
@@ -6154,8 +6155,8 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
 dependencies = [
- "serde",
- "serde_with_macros",
+    "serde",
+    "serde_with_macros",
 ]
 
 [[package]]
@@ -6164,10 +6165,10 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
- "darling 0.20.3",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "darling 0.20.3",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6176,9 +6177,9 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+    "cfg-if",
+    "cpufeatures",
+    "digest",
 ]
 
 [[package]]
@@ -6187,9 +6188,9 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+    "cfg-if",
+    "cpufeatures",
+    "digest",
 ]
 
 [[package]]
@@ -6198,8 +6199,8 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+    "digest",
+    "keccak",
 ]
 
 [[package]]
@@ -6208,7 +6209,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static",
+    "lazy_static",
 ]
 
 [[package]]
@@ -6223,8 +6224,8 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
- "libc",
- "signal-hook-registry",
+    "libc",
+    "signal-hook-registry",
 ]
 
 [[package]]
@@ -6233,7 +6234,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -6242,8 +6243,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core 0.6.4",
+    "digest",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6252,9 +6253,9 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
- "log",
- "termcolor",
- "time",
+    "log",
+    "termcolor",
+    "time",
 ]
 
 [[package]]
@@ -6269,7 +6270,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg",
+    "autocfg",
 ]
 
 [[package]]
@@ -6278,7 +6279,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be0ff28bf14f9610a342169084e87a4f435ad798ec528dc7579a3678fa9dc9a"
 dependencies = [
- "hmac-sha512",
+    "hmac-sha512",
 ]
 
 [[package]]
@@ -6287,7 +6288,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
- "erased-serde",
+    "erased-serde",
 ]
 
 [[package]]
@@ -6296,10 +6297,10 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
 dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
+    "crossbeam-channel",
+    "slog",
+    "take_mut",
+    "thread_local",
 ]
 
 [[package]]
@@ -6308,8 +6309,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b517f2dda9e1458733eb8350bad1a3632ffed8141be4c0f3d6def899a9b066"
 dependencies = [
- "arc-swap",
- "slog",
+    "arc-swap",
+    "slog",
 ]
 
 [[package]]
@@ -6318,13 +6319,13 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906a1a0bc43fed692df4b82a5e2fbfc3733db8dad8bb514ab27a4f23ad04f5c0"
 dependencies = [
- "log",
- "regex",
- "slog",
- "slog-async",
- "slog-scope",
- "slog-stdlog",
- "slog-term",
+    "log",
+    "regex",
+    "slog",
+    "slog-async",
+    "slog-scope",
+    "slog-stdlog",
+    "slog-term",
 ]
 
 [[package]]
@@ -6333,10 +6334,10 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
 dependencies = [
- "serde",
- "serde_json",
- "slog",
- "time",
+    "serde",
+    "serde_json",
+    "slog",
+    "time",
 ]
 
 [[package]]
@@ -6345,9 +6346,9 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
 dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
+    "arc-swap",
+    "lazy_static",
+    "slog",
 ]
 
 [[package]]
@@ -6356,9 +6357,9 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
 dependencies = [
- "log",
- "slog",
- "slog-scope",
+    "log",
+    "slog",
+    "slog-scope",
 ]
 
 [[package]]
@@ -6367,11 +6368,11 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
- "atty",
- "slog",
- "term",
- "thread_local",
- "time",
+    "atty",
+    "slog",
+    "term",
+    "thread_local",
+    "time",
 ]
 
 [[package]]
@@ -6386,8 +6387,8 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
- "libc",
- "windows-sys 0.48.0",
+    "libc",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6402,7 +6403,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api",
+    "lock_api",
 ]
 
 [[package]]
@@ -6411,8 +6412,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
- "base64ct",
- "der",
+    "base64ct",
+    "der",
 ]
 
 [[package]]
@@ -6421,7 +6422,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -6436,7 +6437,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
- "loom",
+    "loom",
 ]
 
 [[package]]
@@ -6463,9 +6464,9 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
+    "clap 2.34.0",
+    "lazy_static",
+    "structopt-derive",
 ]
 
 [[package]]
@@ -6474,11 +6475,11 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+    "heck 0.3.3",
+    "proc-macro-error",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -6487,7 +6488,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros 0.24.3",
+    "strum_macros 0.24.3",
 ]
 
 [[package]]
@@ -6496,7 +6497,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.3",
+    "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -6505,11 +6506,11 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+    "heck 0.4.1",
+    "proc-macro2",
+    "quote",
+    "rustversion",
+    "syn 1.0.109",
 ]
 
 [[package]]
@@ -6518,11 +6519,11 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.48",
+    "heck 0.4.1",
+    "proc-macro2",
+    "quote",
+    "rustversion",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6537,9 +6538,9 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+    "proc-macro2",
+    "quote",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -6548,9 +6549,9 @@ version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+    "proc-macro2",
+    "quote",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -6559,10 +6560,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
+    "proc-macro2",
+    "quote",
+    "syn 1.0.109",
+    "unicode-xid",
 ]
 
 [[package]]
@@ -6571,12 +6572,12 @@ version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "windows 0.52.0",
+    "cfg-if",
+    "core-foundation-sys",
+    "libc",
+    "ntapi",
+    "once_cell",
+    "windows 0.52.0",
 ]
 
 [[package]]
@@ -6585,9 +6586,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
+    "bitflags 1.3.2",
+    "core-foundation",
+    "system-configuration-sys",
 ]
 
 [[package]]
@@ -6596,36 +6597,36 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
- "core-foundation-sys",
- "libc",
+    "core-foundation-sys",
+    "libc",
 ]
 
 [[package]]
 name = "t3-api"
 version = "2.10.1"
 dependencies = [
- "cargo-emit",
- "futures",
- "grpcio",
- "mc-util-build-grpc",
- "mc-util-build-script",
- "mc-util-uri",
- "protobuf",
+    "cargo-emit",
+    "futures",
+    "grpcio",
+    "mc-util-build-grpc",
+    "mc-util-build-script",
+    "mc-util-uri",
+    "protobuf",
 ]
 
 [[package]]
 name = "t3-connection"
 version = "2.10.1"
 dependencies = [
- "displaydoc",
- "futures",
- "grpcio",
- "mc-common",
- "mc-connection",
- "mc-util-grpc",
- "mc-util-uri",
- "protobuf",
- "t3-api",
+    "displaydoc",
+    "futures",
+    "grpcio",
+    "mc-common",
+    "mc-connection",
+    "mc-util-grpc",
+    "mc-util-uri",
+    "protobuf",
+    "t3-api",
 ]
 
 [[package]]
@@ -6646,8 +6647,8 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
+    "rand 0.4.6",
+    "remove_dir_all",
 ]
 
 [[package]]
@@ -6656,11 +6657,11 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.52.0",
+    "cfg-if",
+    "fastrand",
+    "redox_syscall",
+    "rustix",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6669,9 +6670,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+    "dirs-next",
+    "rustversion",
+    "winapi",
 ]
 
 [[package]]
@@ -6680,7 +6681,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "winapi-util",
+    "winapi-util",
 ]
 
 [[package]]
@@ -6695,7 +6696,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+    "unicode-width",
 ]
 
 [[package]]
@@ -6704,7 +6705,7 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
- "thiserror-impl",
+    "thiserror-impl",
 ]
 
 [[package]]
@@ -6713,9 +6714,9 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6724,8 +6725,8 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
- "once_cell",
+    "cfg-if",
+    "once_cell",
 ]
 
 [[package]]
@@ -6734,7 +6735,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
- "num_cpus",
+    "num_cpus",
 ]
 
 [[package]]
@@ -6743,11 +6744,11 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 2.10.1",
- "threadpool",
+    "byteorder",
+    "integer-encoding",
+    "log",
+    "ordered-float 2.10.1",
+    "threadpool",
 ]
 
 [[package]]
@@ -6756,14 +6757,14 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num_threads",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
+    "deranged",
+    "itoa",
+    "libc",
+    "num_threads",
+    "powerfmt",
+    "serde",
+    "time-core",
+    "time-macros",
 ]
 
 [[package]]
@@ -6778,7 +6779,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
- "time-core",
+    "time-core",
 ]
 
 [[package]]
@@ -6787,17 +6788,17 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
- "anyhow",
- "hmac",
- "once_cell",
- "pbkdf2",
- "rand 0.8.5",
- "rustc-hash",
- "sha2",
- "thiserror",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
+    "anyhow",
+    "hmac",
+    "once_cell",
+    "pbkdf2",
+    "rand 0.8.5",
+    "rustc-hash",
+    "sha2",
+    "thiserror",
+    "unicode-normalization",
+    "wasm-bindgen",
+    "zeroize",
 ]
 
 [[package]]
@@ -6806,7 +6807,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
- "tinyvec_macros",
+    "tinyvec_macros",
 ]
 
 [[package]]
@@ -6821,17 +6822,17 @@ version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.48.0",
+    "backtrace",
+    "bytes",
+    "libc",
+    "mio",
+    "num_cpus",
+    "parking_lot",
+    "pin-project-lite",
+    "signal-hook-registry",
+    "socket2",
+    "tokio-macros",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6840,9 +6841,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6851,8 +6852,8 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
- "tokio",
+    "rustls",
+    "tokio",
 ]
 
 [[package]]
@@ -6861,10 +6862,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
+    "futures-core",
+    "pin-project-lite",
+    "tokio",
+    "tokio-util",
 ]
 
 [[package]]
@@ -6873,12 +6874,12 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
+    "bytes",
+    "futures-core",
+    "futures-sink",
+    "pin-project-lite",
+    "tokio",
+    "tracing",
 ]
 
 [[package]]
@@ -6887,10 +6888,10 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
+    "serde",
+    "serde_spanned",
+    "toml_datetime",
+    "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -6899,10 +6900,10 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.21.0",
+    "serde",
+    "serde_spanned",
+    "toml_datetime",
+    "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -6911,7 +6912,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -6920,11 +6921,11 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+    "indexmap",
+    "serde",
+    "serde_spanned",
+    "toml_datetime",
+    "winnow",
 ]
 
 [[package]]
@@ -6933,9 +6934,9 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
+    "indexmap",
+    "toml_datetime",
+    "winnow",
 ]
 
 [[package]]
@@ -6944,11 +6945,11 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+    "indexmap",
+    "serde",
+    "serde_spanned",
+    "toml_datetime",
+    "winnow",
 ]
 
 [[package]]
@@ -6963,9 +6964,9 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
+    "pin-project-lite",
+    "tracing-attributes",
+    "tracing-core",
 ]
 
 [[package]]
@@ -6974,9 +6975,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]
 
 [[package]]
@@ -6985,8 +6986,8 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
- "once_cell",
- "valuable",
+    "once_cell",
+    "valuable",
 ]
 
 [[package]]
@@ -6995,9 +6996,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log",
- "once_cell",
- "tracing-core",
+    "log",
+    "once_cell",
+    "tracing-core",
 ]
 
 [[package]]
@@ -7006,16 +7007,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
+    "matchers",
+    "nu-ansi-term",
+    "once_cell",
+    "regex",
+    "sharded-slab",
+    "smallvec",
+    "thread_local",
+    "tracing",
+    "tracing-core",
+    "tracing-log",
 ]
 
 [[package]]
@@ -7036,7 +7037,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -7045,10 +7046,10 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
+    "byteorder",
+    "crunchy",
+    "hex",
+    "static_assertions",
 ]
 
 [[package]]
@@ -7057,7 +7058,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -7066,8 +7067,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
- "serde",
- "version_check",
+    "serde",
+    "version_check",
 ]
 
 [[package]]
@@ -7088,7 +7089,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
- "tinyvec",
+    "tinyvec",
 ]
 
 [[package]]
@@ -7115,8 +7116,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
- "subtle",
+    "crypto-common",
+    "subtle",
 ]
 
 [[package]]
@@ -7137,13 +7138,13 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
- "base64",
- "log",
- "once_cell",
- "rustls",
- "rustls-webpki",
- "url",
- "webpki-roots",
+    "base64",
+    "log",
+    "once_cell",
+    "rustls",
+    "rustls-webpki",
+    "url",
+    "webpki-roots",
 ]
 
 [[package]]
@@ -7152,10 +7153,10 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
+    "form_urlencoded",
+    "idna",
+    "percent-encoding",
+    "serde",
 ]
 
 [[package]]
@@ -7176,8 +7177,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
- "getrandom",
- "serde",
+    "getrandom",
+    "serde",
 ]
 
 [[package]]
@@ -7204,14 +7205,14 @@ version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
- "anyhow",
- "cargo_metadata",
- "cfg-if",
- "regex",
- "rustc_version",
- "rustversion",
- "sysinfo",
- "time",
+    "anyhow",
+    "cargo_metadata",
+    "cfg-if",
+    "regex",
+    "rustc_version",
+    "rustversion",
+    "sysinfo",
+    "time",
 ]
 
 [[package]]
@@ -7232,8 +7233,8 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
- "same-file",
- "winapi-util",
+    "same-file",
+    "winapi-util",
 ]
 
 [[package]]
@@ -7242,7 +7243,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "try-lock",
+    "try-lock",
 ]
 
 [[package]]
@@ -7257,8 +7258,8 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
+    "cfg-if",
+    "wasm-bindgen-macro",
 ]
 
 [[package]]
@@ -7267,13 +7268,13 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-shared",
+    "bumpalo",
+    "log",
+    "once_cell",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
+    "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -7282,10 +7283,10 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+    "cfg-if",
+    "js-sys",
+    "wasm-bindgen",
+    "web-sys",
 ]
 
 [[package]]
@@ -7294,8 +7295,8 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
+    "quote",
+    "wasm-bindgen-macro-support",
 ]
 
 [[package]]
@@ -7304,11 +7305,11 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
+    "wasm-bindgen-backend",
+    "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -7323,8 +7324,8 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+    "js-sys",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -7339,10 +7340,10 @@ version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
+    "either",
+    "home",
+    "once_cell",
+    "rustix",
 ]
 
 [[package]]
@@ -7351,8 +7352,8 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+    "winapi-i686-pc-windows-gnu",
+    "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
@@ -7367,7 +7368,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
- "winapi",
+    "winapi",
 ]
 
 [[package]]
@@ -7382,7 +7383,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.5",
+    "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7391,8 +7392,8 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
- "windows-targets 0.52.0",
+    "windows-core",
+    "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7401,7 +7402,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+    "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7410,7 +7411,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
+    "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7419,7 +7420,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+    "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -7428,13 +7429,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+    "windows_aarch64_gnullvm 0.48.5",
+    "windows_aarch64_msvc 0.48.5",
+    "windows_i686_gnu 0.48.5",
+    "windows_i686_msvc 0.48.5",
+    "windows_x86_64_gnu 0.48.5",
+    "windows_x86_64_gnullvm 0.48.5",
+    "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7443,13 +7444,13 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+    "windows_aarch64_gnullvm 0.52.0",
+    "windows_aarch64_msvc 0.52.0",
+    "windows_i686_gnu 0.52.0",
+    "windows_i686_msvc 0.52.0",
+    "windows_x86_64_gnu 0.52.0",
+    "windows_x86_64_gnullvm 0.52.0",
+    "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -7542,7 +7543,7 @@ version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -7551,8 +7552,8 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+    "cfg-if",
+    "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7561,7 +7562,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
- "tap",
+    "tap",
 ]
 
 [[package]]
@@ -7570,8 +7571,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
+    "curve25519-dalek",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7580,9 +7581,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
- "der",
- "spki",
+    "const-oid",
+    "der",
+    "spki",
 ]
 
 [[package]]
@@ -7591,8 +7592,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb2bc2a902d992cd5f471ee3ab0ffd6603047a4207384562755b9d6de977518"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+    "ring 0.16.20",
+    "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -7607,7 +7608,7 @@ version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
 dependencies = [
- "is-terminal",
+    "is-terminal",
 ]
 
 [[package]]
@@ -7616,8 +7617,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "bit-vec",
- "num-bigint",
+    "bit-vec",
+    "num-bigint",
 ]
 
 [[package]]
@@ -7626,7 +7627,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
- "zeroize_derive",
+    "zeroize_derive",
 ]
 
 [[package]]
@@ -7635,7 +7636,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+    "proc-macro2",
+    "quote",
+    "syn 2.0.48",
 ]

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -75,6 +75,7 @@ dotenv = "0.15.0"
 ed25519-dalek = { version = "2.0.0-pre.0", default-features = false }
 grpcio = "0.13"
 hex = { version = "0.4", default-features = false }
+itertools = "0.10.5"
 libsqlite3-sys = { version = "0.26", features = ["bundled-sqlcipher"] }
 num_cpus = "1.16"
 prost = "0.11"
@@ -102,7 +103,6 @@ strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.1"
 tiny-bip39 = "1.0"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
-itertools = "0.10.5"
 
 [dev-dependencies]
 mc-blockchain-test-utils = { path = "../mobilecoin/blockchain/test-utils" }

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -102,6 +102,7 @@ strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.1"
 tiny-bip39 = "1.0"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
+itertools = "0.10.5"
 
 [dev-dependencies]
 mc-blockchain-test-utils = { path = "../mobilecoin/blockchain/test-utils" }

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -145,6 +145,7 @@ impl Txo {
     }
 }
 
+#[derive(Debug)]
 pub struct TxoInfo {
     pub txo: Txo,
     pub memo: TxoMemo,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -645,9 +645,9 @@ pub trait TxoModel {
         account_id_hex: &str,
         target_value: u128,
         max_spendable_value: Option<u64>,
+        assigned_subaddress_b58: Option<&str>,
         token_id: u64,
         default_token_fee: u64,
-        only_from_subaddress: Option<&str>,
         conn: Conn,
     ) -> Result<Vec<Txo>, WalletDbError>;
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -631,6 +631,7 @@ pub trait TxoModel {
     ///| Name                  | Purpose                                                    | Notes                               |
     ///|-----------------------|------------------------------------------------------------|-------------------------------------|
     ///| `account_id_hex`      | The account id where the Txos from                         | Account must exist in the database. |
+    ///| `subaccount_address`  | The subaddress at which the list of Txos from              | (optional)                          |
     ///| `target_value`        | The value used to filter spendable Txos on its value       |                                     |
     ///| `max_spendable_value` | The upper limit for the spendable TxOut value to filter on |                                     |
     ///| `token_id`            | The id of a supported type of token to filter on           |                                     |
@@ -641,6 +642,7 @@ pub trait TxoModel {
     /// * Vector of TxoOut
     fn select_spendable_txos_for_value(
         account_id_hex: &str,
+        subaccount_address: Option<&str>,
         target_value: u128,
         max_spendable_value: Option<u64>,
         token_id: u64,
@@ -1858,19 +1860,23 @@ impl TxoModel for Txo {
 
     fn select_spendable_txos_for_value(
         account_id_hex: &str,
+        subaccount_address: Option<&str>,
         target_value: u128,
         max_spendable_value: Option<u64>,
         token_id: u64,
         default_token_fee: u64,
         conn: Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
+
+        // TODO: Logic - switch on option account_id vs subaccount_address
+
         let SpendableTxosResult {
             mut spendable_txos,
             max_spendable_in_wallet,
         } = Txo::list_spendable(
             Some(account_id_hex),
             max_spendable_value,
-            None,
+            None, // TODO: Note, if !None, this will only get spendable for an address
             token_id,
             default_token_fee,
             conn,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -634,9 +634,9 @@ pub trait TxoModel {
     ///| `account_id_hex`      | The account id where the Txos from                         | Account must exist in the database. |
     ///| `target_value`        | The value used to filter spendable Txos on its value       |                                     |
     ///| `max_spendable_value` | The upper limit for the spendable TxOut value to filter on |                                     |
+    ///| `assigned_subaddress_b58`  | The subaddress where the spendable Txos can be sourced from |                                      |
     ///| `token_id`            | The id of a supported type of token to filter on           |                                     |
     ///| `default_token_fee`   | The default transaction fee in Mob network                 |                                     |
-    ///| `assigned_subaddress_b58`  | The subaddress where the spendable Txos can be sourced from                    |                                      |
     ///| `conn`                | An reference to the pool connection of wallet database     |                                     |
     ///
     /// # Returns:
@@ -1874,7 +1874,7 @@ impl TxoModel for Txo {
         } = Txo::list_spendable(
             Some(account_id_hex),
             max_spendable_value,
-            only_from_subaddress_b58,
+            assigned_subaddress_b58,
             token_id,
             default_token_fee,
             conn,
@@ -3142,9 +3142,9 @@ mod tests {
             &account_id_hex.to_string(),
             300 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3156,9 +3156,9 @@ mod tests {
             &account_id_hex.to_string(),
             (300 * MOB + Mob::MINIMUM_FEE) as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3173,9 +3173,9 @@ mod tests {
             &account_id_hex.to_string(),
             (300 * MOB + Mob::MINIMUM_FEE) as u128,
             Some(200 * MOB),
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         );
 
@@ -3191,9 +3191,9 @@ mod tests {
             &account_id_hex.to_string(),
             16800 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3312,9 +3312,9 @@ mod tests {
                 &account_id_hex.to_string(),
                 42 * MOB as u128,
                 None,
+                Some(subaddress),
                 0,
                 Mob::MINIMUM_FEE,
-                Some(subaddress),
                 conn,
             )
             .unwrap();
@@ -3328,9 +3328,9 @@ mod tests {
             &account_id_hex.to_string(),
             (100 * MOB + Mob::MINIMUM_FEE) as u128,
             None,
+            Some(&alice_public_address_b58),
             0,
             Mob::MINIMUM_FEE,
-            Some(&alice_public_address_b58),
             conn,
         );
 
@@ -3380,9 +3380,9 @@ mod tests {
             &account_id_hex.to_string(),
             16800 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3391,9 +3391,9 @@ mod tests {
             &account_id_hex.to_string(),
             16800 * MOB as u128,
             Some(100 * MOB),
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         );
 
@@ -3445,9 +3445,9 @@ mod tests {
             &account_id_hex.to_string(),
             1800 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         );
         match res {
@@ -4241,9 +4241,9 @@ mod tests {
             &account_id.to_string(),
             target_value,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4260,9 +4260,9 @@ mod tests {
             &account_id.to_string(),
             201 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         );
 
@@ -4279,9 +4279,9 @@ mod tests {
             &account_id.to_string(),
             3,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4296,9 +4296,9 @@ mod tests {
             &account_id.to_string(),
             500 * MOB as u128,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         );
         assert!(result.is_err());
@@ -4314,9 +4314,9 @@ mod tests {
             &account_id.to_string(),
             12400000000,
             None,
+            None,
             0,
             Mob::MINIMUM_FEE,
-            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1868,14 +1868,14 @@ impl TxoModel for Txo {
         only_from_subaddress_b58: Option<&str>,
         conn: Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
-
         let SpendableTxosResult {
             mut spendable_txos,
             max_spendable_in_wallet,
         } = Txo::list_spendable(
             Some(account_id_hex),
             max_spendable_value,
-            only_from_subaddress_b58, // Note, if !None, this will only get spendable for an address
+            only_from_subaddress_b58, /* Note, if !None, this will only get spendable for an
+                                       * address */
             token_id,
             default_token_fee,
             conn,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2993,7 +2993,7 @@ mod tests {
     // Confirm max spendable for Bob: 121 MOB
     // Confrim max spendable in entire exchange wallet: 198 MOB
     #[test_with_logger]
-    fn test_list_spendable_for_spend_only_subaddress(logger: Logger) {
+    fn test_list_spendable_for_assigned_subaddress(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
 
         let db_test_context = WalletDbTestContext::default();
@@ -3229,7 +3229,7 @@ mod tests {
     // and last, we verify that if we try to select txos for an amount larger
     // than Alice, but smaller than Carol and Bob, we get insufficient funds.
     #[test_with_logger]
-    fn test_select_txos_for_spend_only_from_subaddress(logger: Logger) {
+    fn test_select_txos_for_assigned_subaddress(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([3u8; 32]);
 
         let db_test_context = WalletDbTestContext::default();

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -3251,6 +3251,13 @@ mod tests {
         );
     }
 
+    // The narrative for this test is that an exchange creates three assigned
+    // subaddresses, Alice, Bob, and Carol. Alice receives 100 MOB, Bob receives
+    // 200 MOB, and Carol receives 300 MOB. We then confirm the max spendable is
+    // as expected for the exchange and each subaddress.
+    // We then confirm that we can select TXOs from only each respective subaddress,
+    // and last, we verify that if we try to select txos for an amount larger
+    // than Alice, but smaller than Carol and Bob, we get insufficient funds.
     #[test_with_logger]
     fn test_select_txos_for_spend_only_from_subaddress(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([3u8; 32]);

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -631,7 +631,7 @@ pub trait TxoModel {
     ///| Name                  | Purpose                                                    | Notes                               |
     ///|-----------------------|------------------------------------------------------------|-------------------------------------|
     ///| `account_id_hex`      | The account id where the Txos from                         | Account must exist in the database. |
-    ///| `subaccount_address`  | The subaddress at which the list of Txos from              | (optional)                          |
+    ///| `subaccount_address`  | The subaccount address at which the list of Txos from      | (optional)                          |
     ///| `target_value`        | The value used to filter spendable Txos on its value       |                                     |
     ///| `max_spendable_value` | The upper limit for the spendable TxOut value to filter on |                                     |
     ///| `token_id`            | The id of a supported type of token to filter on           |                                     |
@@ -642,7 +642,7 @@ pub trait TxoModel {
     /// * Vector of TxoOut
     fn select_spendable_txos_for_value(
         account_id_hex: &str,
-        subaccount_address: Option<&str>,
+        subaccount_address: Option<String>,
         target_value: u128,
         max_spendable_value: Option<u64>,
         token_id: u64,
@@ -1860,7 +1860,7 @@ impl TxoModel for Txo {
 
     fn select_spendable_txos_for_value(
         account_id_hex: &str,
-        subaccount_address: Option<&str>,
+        subaccount_address: Option<String>,
         target_value: u128,
         max_spendable_value: Option<u64>,
         token_id: u64,

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -636,7 +636,7 @@ pub trait TxoModel {
     ///| `max_spendable_value` | The upper limit for the spendable TxOut value to filter on |                                     |
     ///| `token_id`            | The id of a supported type of token to filter on           |                                     |
     ///| `default_token_fee`   | The default transaction fee in Mob network                 |                                     |
-    ///| `only_from_subaddress`| The subaddress from which spendable txos can be sourced    | (optional)                          |
+    ///| `assigned_subaddress_b58`  | The subaddress where the spendable Txos can be sourced from                    |                                      |
     ///| `conn`                | An reference to the pool connection of wallet database     |                                     |
     ///
     /// # Returns:

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1863,9 +1863,9 @@ impl TxoModel for Txo {
         account_id_hex: &str,
         target_value: u128,
         max_spendable_value: Option<u64>,
+        assigned_subaddress_b58: Option<&str>,
         token_id: u64,
         default_token_fee: u64,
-        only_from_subaddress_b58: Option<&str>,
         conn: Conn,
     ) -> Result<Vec<Txo>, WalletDbError> {
         let SpendableTxosResult {

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -181,7 +181,7 @@ where
                         subaddress_index: None,
                     },
                     None,
-                    None, // Note: Not including spend_only_from_subaddress in V1 API
+                    None, // Note: Not including subaddress_to_spend_from in V1 API
                 )
                 .await
                 .map_err(format_error)?;
@@ -298,7 +298,7 @@ where
                         subaddress_index: None,
                     },
                     None,
-                    None, // Note: not including spend_only_from_subaddress in V1 API
+                    None, // Note: not including subaddress_to_spend_from in V1 API
                 )
                 .await
                 .map_err(format_error)?;

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -181,6 +181,7 @@ where
                         subaddress_index: None,
                     },
                     None,
+                    None, // Note: Not including spend_only_from_subaddress in V1 API
                 )
                 .await
                 .map_err(format_error)?;
@@ -297,6 +298,7 @@ where
                         subaddress_index: None,
                     },
                     None,
+                    None, // Note: not including spend_only_from_subaddress in V1 API
                 )
                 .await
                 .map_err(format_error)?;

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -57,7 +57,7 @@ pub enum JsonCommandRequest {
         block_version: Option<String>,
         sender_memo_credential_subaddress_index: Option<String>,
         payment_request_id: Option<String>,
-        spend_only_from_subaddress: Option<String>,
+        subaddress_to_spend_from: Option<String>,
     },
     build_burn_transaction {
         account_id: String,
@@ -69,7 +69,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
-        spend_only_from_subaddress: Option<String>,
+        subaddress_to_spend_from: Option<String>,
     },
     build_transaction {
         account_id: String,
@@ -84,7 +84,7 @@ pub enum JsonCommandRequest {
         block_version: Option<String>,
         sender_memo_credential_subaddress_index: Option<String>,
         payment_request_id: Option<String>,
-        spend_only_from_subaddress: Option<String>,
+        subaddress_to_spend_from: Option<String>,
     },
     build_unsigned_burn_transaction {
         account_id: String,
@@ -96,7 +96,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
-        spend_only_from_subaddress: Option<String>,
+        subaddress_to_spend_from: Option<String>,
     },
     build_unsigned_transaction {
         account_id: String,
@@ -109,7 +109,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
-        spend_only_from_subaddress: Option<String>,
+        subaddress_to_spend_from: Option<String>,
     },
     check_b58_type {
         b58_code: String,

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -57,6 +57,7 @@ pub enum JsonCommandRequest {
         block_version: Option<String>,
         sender_memo_credential_subaddress_index: Option<String>,
         payment_request_id: Option<String>,
+        spend_only_from_subaddress: Option<String>,
     },
     build_burn_transaction {
         account_id: String,
@@ -68,6 +69,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
+        spend_only_from_subaddress: Option<String>,
     },
     build_transaction {
         account_id: String,
@@ -82,6 +84,7 @@ pub enum JsonCommandRequest {
         block_version: Option<String>,
         sender_memo_credential_subaddress_index: Option<String>,
         payment_request_id: Option<String>,
+        spend_only_from_subaddress: Option<String>,
     },
     build_unsigned_burn_transaction {
         account_id: String,
@@ -93,6 +96,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
+        spend_only_from_subaddress: Option<String>,
     },
     build_unsigned_transaction {
         account_id: String,
@@ -105,6 +109,7 @@ pub enum JsonCommandRequest {
         tombstone_block: Option<String>,
         max_spendable_value: Option<String>,
         block_version: Option<String>,
+        spend_only_from_subaddress: Option<String>,
     },
     check_b58_type {
         b58_code: String,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -172,7 +172,7 @@ where
             block_version,
             sender_memo_credential_subaddress_index,
             payment_request_id,
-            spend_only_from_subaddress,
+            subaddress_to_spend_from,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -219,7 +219,7 @@ where
                     comment,
                     transaction_memo,
                     block_version,
-                    spend_only_from_subaddress,
+                    subaddress_to_spend_from,
                 )
                 .await
                 .map_err(format_error)?;
@@ -243,7 +243,7 @@ where
             tombstone_block,
             max_spendable_value,
             block_version,
-            spend_only_from_subaddress,
+            subaddress_to_spend_from,
         } => {
             let mut memo_data = [0; BurnRedemptionMemo::MEMO_DATA_LEN];
             if let Some(redemption_memo_hex) = redemption_memo_hex {
@@ -279,7 +279,7 @@ where
                     max_spendable_value,
                     TransactionMemo::BurnRedemption(memo_data),
                     block_version,
-                    spend_only_from_subaddress,
+                    subaddress_to_spend_from,
                 )
                 .await
                 .map_err(format_error)?;
@@ -302,7 +302,7 @@ where
             block_version,
             sender_memo_credential_subaddress_index,
             payment_request_id,
-            spend_only_from_subaddress,
+            subaddress_to_spend_from,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -348,7 +348,7 @@ where
                     max_spendable_value,
                     transaction_memo,
                     block_version,
-                    spend_only_from_subaddress,
+                    subaddress_to_spend_from,
                 )
                 .await
                 .map_err(format_error)?;
@@ -368,7 +368,7 @@ where
             tombstone_block,
             max_spendable_value,
             block_version,
-            spend_only_from_subaddress,
+            subaddress_to_spend_from,
         } => {
             let mut memo_data = [0; BurnRedemptionMemo::MEMO_DATA_LEN];
             if let Some(redemption_memo_hex) = redemption_memo_hex {
@@ -404,7 +404,7 @@ where
                     max_spendable_value,
                     TransactionMemo::BurnRedemption(memo_data),
                     block_version,
-                    spend_only_from_subaddress,
+                    subaddress_to_spend_from,
                 )
                 .map_err(format_error)?)
                 .try_into()
@@ -426,7 +426,7 @@ where
             input_txo_ids,
             max_spendable_value,
             block_version,
-            spend_only_from_subaddress,
+            subaddress_to_spend_from,
         } => {
             let mut addresses_and_amounts = addresses_and_amounts.unwrap_or_default();
             if let (Some(address), Some(amount)) = (recipient_public_address, amount) {
@@ -452,7 +452,7 @@ where
                     max_spendable_value,
                     TransactionMemo::Empty,
                     block_version,
-                    spend_only_from_subaddress,
+                    subaddress_to_spend_from,
                 )
                 .map_err(format_error)?)
                 .try_into()

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -172,6 +172,7 @@ where
             block_version,
             sender_memo_credential_subaddress_index,
             payment_request_id,
+            spend_only_from_subaddress,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -218,6 +219,7 @@ where
                     comment,
                     transaction_memo,
                     block_version,
+                    spend_only_from_subaddress,
                 )
                 .await
                 .map_err(format_error)?;
@@ -241,6 +243,7 @@ where
             tombstone_block,
             max_spendable_value,
             block_version,
+            spend_only_from_subaddress,
         } => {
             let mut memo_data = [0; BurnRedemptionMemo::MEMO_DATA_LEN];
             if let Some(redemption_memo_hex) = redemption_memo_hex {
@@ -276,6 +279,7 @@ where
                     max_spendable_value,
                     TransactionMemo::BurnRedemption(memo_data),
                     block_version,
+                    spend_only_from_subaddress,
                 )
                 .await
                 .map_err(format_error)?;
@@ -298,6 +302,7 @@ where
             block_version,
             sender_memo_credential_subaddress_index,
             payment_request_id,
+            spend_only_from_subaddress,
         } => {
             // The user can specify a list of addresses and values,
             // or a single address and a single value.
@@ -343,6 +348,7 @@ where
                     max_spendable_value,
                     transaction_memo,
                     block_version,
+                    spend_only_from_subaddress,
                 )
                 .await
                 .map_err(format_error)?;
@@ -362,6 +368,7 @@ where
             tombstone_block,
             max_spendable_value,
             block_version,
+            spend_only_from_subaddress,
         } => {
             let mut memo_data = [0; BurnRedemptionMemo::MEMO_DATA_LEN];
             if let Some(redemption_memo_hex) = redemption_memo_hex {
@@ -397,6 +404,7 @@ where
                     max_spendable_value,
                     TransactionMemo::BurnRedemption(memo_data),
                     block_version,
+                    spend_only_from_subaddress,
                 )
                 .map_err(format_error)?)
                 .try_into()
@@ -418,6 +426,7 @@ where
             input_txo_ids,
             max_spendable_value,
             block_version,
+            spend_only_from_subaddress,
         } => {
             let mut addresses_and_amounts = addresses_and_amounts.unwrap_or_default();
             if let (Some(address), Some(amount)) = (recipient_public_address, amount) {
@@ -443,6 +452,7 @@ where
                     max_spendable_value,
                     TransactionMemo::Empty,
                     block_version,
+                    spend_only_from_subaddress,
                 )
                 .map_err(format_error)?)
                 .try_into()

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2020-2022 MobileCoin Inc.
+
+//! End-to-end tests for the Full Service Wallet API.
+
+#[cfg(test)]
+mod e2e_transaction {
+    use crate::{
+        db::account::AccountID,
+        json_rpc::v2::{
+            api::test_utils::{dispatch, setup},
+            models::{
+                amount::Amount as AmountJSON,
+                transaction_log::TransactionLog as TransactionLogJSON,
+                tx_proposal::TxProposal as TxProposalJSON,
+            },
+        },
+        service::models::tx_proposal::TxProposal,
+        test_utils::{add_block_to_ledger_db, add_block_with_tx, manually_sync_account, MOB},
+        util::b58::b58_decode_public_address,
+    };
+
+    use mc_common::logger::{test_with_logger, Logger};
+    use mc_crypto_keys::CompressedRistrettoPublic;
+    use mc_ledger_db::Ledger;
+    use mc_rand::rand_core::RngCore;
+    use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, tx::TxOut, Token};
+
+    use rand::{rngs::StdRng, SeedableRng};
+    use serde_json::json;
+
+    use std::convert::{TryFrom, TryInto};
+
+    #[test_with_logger]
+    fn test_build_and_submit_transaction_with_spend_only_from_subaddress(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([3u8; 32]);
+        let (client, mut ledger_db, db_ctx, _network_state) = setup(&mut rng, logger.clone());
+
+        // Add an account
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "create_account",
+            "params": {
+                "name": "Exchange Main Account",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let account_obj = result.get("account").unwrap();
+        let account_id = account_obj.get("id").unwrap().as_str().unwrap();
+
+        // Assign a block of subaddresses for Alice, Bob, and Carol
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "assign_address_for_account",
+            "params": {
+                "account_id": account_id,
+                "metadata": "Subaddress for Alice",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let alice_address = result.get("address").unwrap();
+        let alice_b58_public_address = alice_address
+            .get("public_address_b58")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let alice_public_address = b58_decode_public_address(alice_b58_public_address).unwrap();
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "assign_address_for_account",
+            "params": {
+                "account_id": account_id,
+                "metadata": "Subaddress for Bob",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let bob_address = result.get("address").unwrap();
+        let bob_b58_public_address = bob_address
+            .get("public_address_b58")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let bob_public_address = b58_decode_public_address(bob_b58_public_address).unwrap();
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "assign_address_for_account",
+            "params": {
+                "account_id": account_id,
+                "metadata": "Subaddress for Carol",
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let carol_address = result.get("address").unwrap();
+        let carol_b58_public_address = carol_address
+            .get("public_address_b58")
+            .unwrap()
+            .as_str()
+            .unwrap();
+        let carol_public_address = b58_decode_public_address(carol_b58_public_address).unwrap();
+
+        // Add a block with a txo for Alice
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address.clone()],
+            100_000_000_000_000, // 100.0 MOB
+            &[KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        // Add a block with a txo for Bob
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![bob_public_address.clone()],
+            200_000_000_000_000, // 200.0 MOB
+            &[KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+        // Add a block with a txo for Carol
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![carol_public_address.clone()],
+            300_000_000_000_000, // 300.0 MOB
+            &[KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+
+        manually_sync_account(
+            &ledger_db,
+            &db_ctx.get_db_instance(logger.clone()),
+            &AccountID(account_id.to_string()),
+            &logger,
+        );
+        assert_eq!(ledger_db.num_blocks().unwrap(), 15);
+
+        // Get balance for the exchange, which should include all three suabddress
+        // balances. The state of the wallet should be:
+        //
+        // Overall Balance: 600 MOB
+        // Alice Balance: 100 MOB
+        // Bob Balance: 200 MOB
+        // Carol Balance: 300 MOB
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_account_status",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, "600000000000000");
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        // Get balance for each subaddress
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": alice_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, (100 * MOB).to_string(),);
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": bob_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, (200 * MOB).to_string(),);
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": carol_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, (300 * MOB).to_string(),);
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        // Imagine that Bob is sending 42.0 MOB to Alice
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "build_and_submit_transaction",
+            "params": {
+                "account_id": account_id,
+                "recipient_public_address": alice_b58_public_address,
+                "amount": { "value": "42000000000000", "token_id": "0" }, // 42.0 MOB
+                "spend_only_from_subaddress": bob_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let tx_proposal: TxProposalJSON =
+            serde_json::from_value(result.get("tx_proposal").unwrap().clone()).unwrap();
+        let transaction_log: TransactionLogJSON =
+            serde_json::from_value(result.get("transaction_log").unwrap().clone()).unwrap();
+
+        let tx_log_payload_txo = transaction_log.output_txos[0].clone();
+        let tx_proposal_payload_txo = tx_proposal.payload_txos[0].clone();
+        let tx_out_proto_bytes = hex::decode(tx_proposal_payload_txo.tx_out_proto).unwrap();
+        let txo: TxOut = mc_util_serial::decode(&tx_out_proto_bytes).unwrap();
+
+        let txo_public_key_bytes = hex::decode(tx_log_payload_txo.public_key).unwrap();
+        let txo_public_key: CompressedRistrettoPublic =
+            txo_public_key_bytes.as_slice().try_into().unwrap();
+
+        assert_eq!(txo.public_key, txo_public_key);
+        assert_eq!(
+            tx_proposal.fee_amount,
+            AmountJSON::new(Mob::MINIMUM_FEE, Mob::ID)
+        );
+        assert_eq!(tx_proposal.input_txos.len(), 1);
+        assert_eq!(tx_proposal.payload_txos.len(), 1);
+        // One change (and that change should be going back to Bob)
+        assert_eq!(tx_proposal.change_txos.len(), 1);
+        assert_eq!(
+            tx_proposal.change_txos[0].recipient_public_address_b58,
+            bob_b58_public_address
+        );
+        // Tombstone block = ledger height (12 to start + 3 new blocks + 10 default
+        // tombstone)
+        assert_eq!(tx_proposal.tombstone_block_index, "25");
+
+        let payments_tx_proposal = TxProposal::try_from(&tx_proposal).unwrap();
+
+        add_block_with_tx(&mut ledger_db, payments_tx_proposal.tx, &mut rng);
+        manually_sync_account(
+            &ledger_db,
+            &db_ctx.get_db_instance(logger.clone()),
+            &AccountID(account_id.to_string()),
+            &logger,
+        );
+        assert_eq!(ledger_db.num_blocks().unwrap(), 16);
+
+        // Get balance after submission, since it is staying in the same wallet, the
+        // unspent balance should be the original balance - the fee
+        // The state of the wallet should now be:
+        //
+        // Overall Balance: 600 MOB - 0.0001 MOB
+        // Alice Balance: 142 MOB
+        // Bob Balance: 158 MOB - 0.0001 MOB
+        // Carol Balance: 300 MOB
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_account_status",
+            "params": {
+                "account_id": account_id,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, &(600 * MOB - Mob::MINIMUM_FEE).to_string());
+        assert_eq!(pending, "0");
+        // The SPENT value is calculated by the txos who have key_images that have been
+        // burned. It does not take into account change. Bob's 100 MOB TXO was
+        // burned to send 42 MOB to Alice.
+        assert_eq!(spent, (100 * MOB).to_string()); //FIXME: then shouldn't this be 200?
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        // Get balance for each address after submission
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": alice_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, (42 * MOB).to_string(),); // FIXME: shouldn't this be 142?
+        assert_eq!(pending, "0");
+        assert_eq!(spent, (100 * MOB).to_string(),); // FIXME: Why was it spent from Alice's balance?
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": bob_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        // assert_eq!(unspent, (138 * MOB - Mob::MINIMUM_FEE).to_string(),);
+        assert_eq!(
+            unspent,
+            ((300 * MOB) - (42 * MOB) - Mob::MINIMUM_FEE).to_string(),
+        ); // Should be 200 - 42
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "get_address_status",
+            "params": {
+                "address": carol_b58_public_address,
+            }
+        });
+        let res = dispatch(&client, body, &logger);
+        let result = res.get("result").unwrap();
+        let balance_per_token = result.get("balance_per_token").unwrap();
+        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+        let unspent = balance_mob["unspent"].as_str().unwrap();
+        let pending = balance_mob["pending"].as_str().unwrap();
+        let spent = balance_mob["spent"].as_str().unwrap();
+        let secreted = balance_mob["secreted"].as_str().unwrap();
+        let orphaned = balance_mob["orphaned"].as_str().unwrap();
+        assert_eq!(unspent, (300 * MOB).to_string(),);
+        assert_eq!(pending, "0");
+        assert_eq!(spent, "0");
+        assert_eq!(secreted, "0");
+        assert_eq!(orphaned, "0");
+    }
+}

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
@@ -327,7 +327,7 @@ mod e2e_transaction {
         let orphaned = balance_mob["orphaned"].as_str().unwrap();
         assert_eq!(unspent, &(600 * MOB - Mob::MINIMUM_FEE).to_string());
         assert_eq!(pending, "0");
-        // The SPENT value is calculated by the txos who have key_images that have been
+        // The SPENT value is calculated by the txos that have key_images that have been
         // burned. It does not take into account change. Bob's 200 MOB TXO was
         // burned to send 42 MOB to Alice.
         assert_eq!(spent, (200 * MOB).to_string()); //FIXME: then shouldn't this be 200?

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_spend_from_subaddress.rs
@@ -8,11 +8,7 @@ mod e2e_transaction {
         db::account::AccountID,
         json_rpc::v2::{
             api::test_utils::{dispatch, setup},
-            models::{
-                amount::Amount as AmountJSON,
-                transaction_log::TransactionLog as TransactionLogJSON,
-                tx_proposal::TxProposal as TxProposalJSON,
-            },
+            models::tx_proposal::TxProposal as TxProposalJSON,
         },
         service::models::tx_proposal::TxProposal,
         test_utils::{add_block_to_ledger_db, add_block_with_tx, manually_sync_account, MOB},
@@ -20,15 +16,15 @@ mod e2e_transaction {
     };
 
     use mc_common::logger::{test_with_logger, Logger};
-    use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_ledger_db::Ledger;
     use mc_rand::rand_core::RngCore;
-    use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, tx::TxOut, Token};
+    use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, Token};
 
     use rand::{rngs::StdRng, SeedableRng};
     use serde_json::json;
 
-    use std::convert::{TryFrom, TryInto};
+    use itertools::Itertools;
+    use std::convert::TryFrom;
 
     // The narrative for this test is that an exchange creates subaccounts for its
     // users, Alice, Bob, and Carol. They receive 100, 200, and 300 MOB
@@ -53,69 +49,41 @@ mod e2e_transaction {
         let account_obj = result.get("account").unwrap();
         let account_id = account_obj.get("id").unwrap().as_str().unwrap();
 
-        // Assign a block of subaddresses for Alice, Bob, and Carol
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "assign_address_for_account",
-            "params": {
-                "account_id": account_id,
-                "metadata": "Subaddress for Alice",
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let alice_address = result.get("address").unwrap();
-        let alice_b58_public_address = alice_address
-            .get("public_address_b58")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let alice_public_address = b58_decode_public_address(alice_b58_public_address).unwrap();
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "assign_address_for_account",
-            "params": {
-                "account_id": account_id,
-                "metadata": "Subaddress for Bob",
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let bob_address = result.get("address").unwrap();
-        let bob_b58_public_address = bob_address
-            .get("public_address_b58")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let bob_public_address = b58_decode_public_address(bob_b58_public_address).unwrap();
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "assign_address_for_account",
-            "params": {
-                "account_id": account_id,
-                "metadata": "Subaddress for Carol",
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let carol_address = result.get("address").unwrap();
-        let carol_b58_public_address = carol_address
-            .get("public_address_b58")
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let carol_public_address = b58_decode_public_address(carol_b58_public_address).unwrap();
+        let (
+            (alice_public_address, alice_b58_public_address),
+            (bob_public_address, bob_b58_public_address),
+            (carol_public_address, carol_b58_public_address),
+        ) = [
+            "Subaddress for Alice",
+            "Subaddress for Bob",
+            "Subaddress for Carol",
+        ]
+        .iter()
+        .map(|metadata| {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "assign_address_for_account",
+                "params": {
+                    "account_id": account_id,
+                    "metadata": metadata,
+                }
+            });
+            let res = dispatch(&client, body, &logger);
+            let result = res.get("result").unwrap();
+            let address = result.get("address").unwrap();
+            let b58_address = address.get("public_address_b58").unwrap().as_str().unwrap();
+            let public_address = b58_decode_public_address(b58_address).unwrap();
+            (public_address, b58_address.to_string())
+        })
+        .collect_tuple()
+        .unwrap();
 
         // Add a block with a txo for Alice
         add_block_to_ledger_db(
             &mut ledger_db,
             &vec![alice_public_address.clone()],
-            100_000_000_000_000, // 100.0 MOB
+            100 * MOB,
             &[KeyImage::from(rng.next_u64())],
             &mut rng,
         );
@@ -123,7 +91,7 @@ mod e2e_transaction {
         add_block_to_ledger_db(
             &mut ledger_db,
             &vec![bob_public_address.clone()],
-            200_000_000_000_000, // 200.0 MOB
+            200 * MOB,
             &[KeyImage::from(rng.next_u64())],
             &mut rng,
         );
@@ -131,7 +99,7 @@ mod e2e_transaction {
         add_block_to_ledger_db(
             &mut ledger_db,
             &vec![carol_public_address.clone()],
-            300_000_000_000_000, // 300.0 MOB
+            300 * MOB,
             &[KeyImage::from(rng.next_u64())],
             &mut rng,
         );
@@ -168,81 +136,42 @@ mod e2e_transaction {
         let spent = balance_mob["spent"].as_str().unwrap();
         let secreted = balance_mob["secreted"].as_str().unwrap();
         let orphaned = balance_mob["orphaned"].as_str().unwrap();
-        assert_eq!(unspent, "600000000000000");
+        assert_eq!(unspent, (600 * MOB).to_string());
         assert_eq!(pending, "0");
         assert_eq!(spent, "0");
         assert_eq!(secreted, "0");
         assert_eq!(orphaned, "0");
 
-        // Get balance for each subaddress
-        let body = json!({
+        for (public_address, amount) in [
+            (&alice_b58_public_address, 100),
+            (&bob_b58_public_address, 200),
+            (&carol_b58_public_address, 300),
+        ]
+        .iter()
+        {
+            let body = json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "get_address_status",
             "params": {
-                "address": alice_b58_public_address,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let balance_per_token = result.get("balance_per_token").unwrap();
-        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
-        let unspent = balance_mob["unspent"].as_str().unwrap();
-        let pending = balance_mob["pending"].as_str().unwrap();
-        let spent = balance_mob["spent"].as_str().unwrap();
-        let secreted = balance_mob["secreted"].as_str().unwrap();
-        let orphaned = balance_mob["orphaned"].as_str().unwrap();
-        assert_eq!(unspent, (100 * MOB).to_string(),);
-        assert_eq!(pending, "0");
-        assert_eq!(spent, "0");
-        assert_eq!(secreted, "0");
-        assert_eq!(orphaned, "0");
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "get_address_status",
-            "params": {
-                "address": bob_b58_public_address,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let balance_per_token = result.get("balance_per_token").unwrap();
-        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
-        let unspent = balance_mob["unspent"].as_str().unwrap();
-        let pending = balance_mob["pending"].as_str().unwrap();
-        let spent = balance_mob["spent"].as_str().unwrap();
-        let secreted = balance_mob["secreted"].as_str().unwrap();
-        let orphaned = balance_mob["orphaned"].as_str().unwrap();
-        assert_eq!(unspent, (200 * MOB).to_string(),);
-        assert_eq!(pending, "0");
-        assert_eq!(spent, "0");
-        assert_eq!(secreted, "0");
-        assert_eq!(orphaned, "0");
-
-        let body = json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "get_address_status",
-            "params": {
-                "address": carol_b58_public_address,
-            }
-        });
-        let res = dispatch(&client, body, &logger);
-        let result = res.get("result").unwrap();
-        let balance_per_token = result.get("balance_per_token").unwrap();
-        let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
-        let unspent = balance_mob["unspent"].as_str().unwrap();
-        let pending = balance_mob["pending"].as_str().unwrap();
-        let spent = balance_mob["spent"].as_str().unwrap();
-        let secreted = balance_mob["secreted"].as_str().unwrap();
-        let orphaned = balance_mob["orphaned"].as_str().unwrap();
-        assert_eq!(unspent, (300 * MOB).to_string(),);
-        assert_eq!(pending, "0");
-        assert_eq!(spent, "0");
-        assert_eq!(secreted, "0");
-        assert_eq!(orphaned, "0");
+                "address": public_address,
+                }
+            });
+            let res = dispatch(&client, body, &logger);
+            let result = res.get("result").unwrap();
+            let balance_per_token = result.get("balance_per_token").unwrap();
+            let balance_mob = balance_per_token.get(Mob::ID.to_string()).unwrap();
+            let unspent = balance_mob["unspent"].as_str().unwrap();
+            let pending = balance_mob["pending"].as_str().unwrap();
+            let spent = balance_mob["spent"].as_str().unwrap();
+            let secreted = balance_mob["secreted"].as_str().unwrap();
+            let orphaned = balance_mob["orphaned"].as_str().unwrap();
+            assert_eq!(unspent, (amount * MOB).to_string(),);
+            assert_eq!(pending, "0");
+            assert_eq!(spent, "0");
+            assert_eq!(secreted, "0");
+            assert_eq!(orphaned, "0");
+        }
 
         // Imagine that Bob is sending 42.0 MOB to Alice
         let body = json!({
@@ -260,35 +189,6 @@ mod e2e_transaction {
         let result = res.get("result").unwrap();
         let tx_proposal: TxProposalJSON =
             serde_json::from_value(result.get("tx_proposal").unwrap().clone()).unwrap();
-        let transaction_log: TransactionLogJSON =
-            serde_json::from_value(result.get("transaction_log").unwrap().clone()).unwrap();
-
-        let tx_log_payload_txo = transaction_log.output_txos[0].clone();
-        let tx_proposal_payload_txo = tx_proposal.payload_txos[0].clone();
-        let tx_out_proto_bytes = hex::decode(tx_proposal_payload_txo.tx_out_proto).unwrap();
-        let txo: TxOut = mc_util_serial::decode(&tx_out_proto_bytes).unwrap();
-
-        let txo_public_key_bytes = hex::decode(tx_log_payload_txo.public_key).unwrap();
-        let txo_public_key: CompressedRistrettoPublic =
-            txo_public_key_bytes.as_slice().try_into().unwrap();
-
-        assert_eq!(txo.public_key, txo_public_key);
-        assert_eq!(
-            tx_proposal.fee_amount,
-            AmountJSON::new(Mob::MINIMUM_FEE, Mob::ID)
-        );
-        assert_eq!(tx_proposal.input_txos.len(), 1);
-        assert_eq!(tx_proposal.payload_txos.len(), 1);
-        // One change (and that change should be going back to Bob)
-        assert_eq!(tx_proposal.change_txos.len(), 1);
-        assert_eq!(
-            tx_proposal.change_txos[0].recipient_public_address_b58,
-            bob_b58_public_address
-        );
-        // Tombstone block = ledger height (12 to start + 3 new blocks + 10 default
-        // tombstone)
-        assert_eq!(tx_proposal.tombstone_block_index, "25");
-
         let payments_tx_proposal = TxProposal::try_from(&tx_proposal).unwrap();
 
         add_block_with_tx(&mut ledger_db, payments_tx_proposal.tx, &mut rng);
@@ -330,7 +230,7 @@ mod e2e_transaction {
         // The SPENT value is calculated by the txos that have key_images that have been
         // burned. It does not take into account change. Bob's 200 MOB TXO was
         // burned to send 42 MOB to Alice.
-        assert_eq!(spent, (200 * MOB).to_string()); //FIXME: then shouldn't this be 200?
+        assert_eq!(spent, (200 * MOB).to_string());
         assert_eq!(secreted, "0");
         assert_eq!(orphaned, "0");
 
@@ -352,11 +252,9 @@ mod e2e_transaction {
         let spent = balance_mob["spent"].as_str().unwrap();
         let secreted = balance_mob["secreted"].as_str().unwrap();
         let orphaned = balance_mob["orphaned"].as_str().unwrap();
-        assert_eq!(unspent, (142 * MOB).to_string(),); // FIXME: shouldn't this be 142?
+        assert_eq!(unspent, (142 * MOB).to_string(),);
         assert_eq!(pending, "0");
-        assert_eq!(spent, (0).to_string(),); // FIXME: Why was it spent from Alice's balance?
-                                             //assert_eq!(spent, (100 * MOB).to_string(),); // FIXME: Why was it spent from
-                                             // Alice's balance?
+        assert_eq!(spent, (0).to_string(),);
         assert_eq!(secreted, "0");
         assert_eq!(orphaned, "0");
 

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_with_subaddress_to_spend_from.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit_with_subaddress_to_spend_from.rs
@@ -31,7 +31,7 @@ mod e2e_transaction {
     // respectively from an external source. Bob sends 42 MOB to Alice, and the
     // balances should end up as [Alice: 142 MOB, Bob: 158 MOB, Carol: 300 MOB].
     #[test_with_logger]
-    fn test_build_and_submit_transaction_with_spend_only_from_subaddress(logger: Logger) {
+    fn test_build_and_submit_transaction_with_subaddress_to_spend_from(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([3u8; 32]);
         let (client, mut ledger_db, db_ctx, _network_state) = setup(&mut rng, logger.clone());
 
@@ -182,7 +182,7 @@ mod e2e_transaction {
                 "account_id": account_id,
                 "recipient_public_address": alice_b58_public_address,
                 "amount": { "value": "42000000000000", "token_id": "0" }, // 42.0 MOB
-                "spend_only_from_subaddress": bob_b58_public_address,
+                "subaddress_to_spend_from": bob_b58_public_address,
             }
         });
         let res = dispatch(&client, body, &logger);

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/mod.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/mod.rs
@@ -1,4 +1,5 @@
 mod build_and_submit;
+mod build_and_submit_spend_from_subaddress;
 mod build_then_submit;
 mod build_unsigned;
 mod large_transaction;

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/mod.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/mod.rs
@@ -1,5 +1,5 @@
 mod build_and_submit;
-mod build_and_submit_spend_from_subaddress;
+mod build_and_submit_with_subaddress_to_spend_from;
 mod build_then_submit;
 mod build_unsigned;
 mod large_transaction;

--- a/full-service/src/lib.rs
+++ b/full-service/src/lib.rs
@@ -3,6 +3,7 @@
 //! Full Service Wallet.
 
 #![feature(proc_macro_hygiene, decl_macro)]
+#![feature(assert_matches)]
 
 pub mod check_host;
 pub mod config;

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -179,18 +179,6 @@ pub trait BalanceService {
         &self,
         address: &str,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
-
-    /// Get the current balance for a given subaccount.
-    /// 
-    /// # Arguments
-    ///| Name      | Purpose                                      | Notes                                                                   |
-    ///|-----------|----------------------------------------------|-------------------------------------------------------------------------|
-    ///| `subaccount` | The subaccount address on which to perform this action. | Subaccount must be assigned for an account in the wallet. |
-    ///
-    fn get_balance_for_subaccount(
-        &self,
-        subaccount: &str,
-    ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
     
     /// Get the current status of the network.
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError>;
@@ -267,10 +255,6 @@ where
             .collect::<Result<BTreeMap<TokenId, Balance>, BalanceServiceError>>()?;
 
         Ok(balances)
-    }
-
-    fn get_balance_for_subaccount(&self, subaccount: &str) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError> {
-        todo!()
     }
 
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError> {
@@ -584,10 +568,4 @@ mod tests {
             Err(e) => panic!("Unexpected error {:?}", e),
         }
     }
-    // The balance for a subaccount should be accurate.
-    #[test_with_logger]
-    fn test_subaccount_balance(logger: Logger) {
-        // TODO: Implement this test
-    }
-
 }

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -179,7 +179,7 @@ pub trait BalanceService {
         &self,
         address: &str,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
-    
+
     /// Get the current status of the network.
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError>;
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -180,6 +180,18 @@ pub trait BalanceService {
         address: &str,
     ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
 
+    /// Get the current balance for a given subaccount.
+    /// 
+    /// # Arguments
+    ///| Name      | Purpose                                      | Notes                                                                   |
+    ///|-----------|----------------------------------------------|-------------------------------------------------------------------------|
+    ///| `subaccount` | The subaccount address on which to perform this action. | Subaccount must be assigned for an account in the wallet. |
+    ///
+    fn get_balance_for_subaccount(
+        &self,
+        subaccount: &str,
+    ) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError>;
+    
     /// Get the current status of the network.
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError>;
 
@@ -255,6 +267,10 @@ where
             .collect::<Result<BTreeMap<TokenId, Balance>, BalanceServiceError>>()?;
 
         Ok(balances)
+    }
+
+    fn get_balance_for_subaccount(&self, subaccount: &str) -> Result<BTreeMap<TokenId, Balance>, BalanceServiceError> {
+        todo!()
     }
 
     fn get_network_status(&self) -> Result<NetworkStatus, BalanceServiceError> {
@@ -568,4 +584,10 @@ mod tests {
             Err(e) => panic!("Unexpected error {:?}", e),
         }
     }
+    // The balance for a subaccount should be accurate.
+    #[test_with_logger]
+    fn test_subaccount_balance(logger: Logger) {
+        // TODO: Implement this test
+    }
+
 }

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -544,6 +544,7 @@ where
                 subaddress_index: None,
             },
             None,
+            None, // FIXME: is spend_only_from_subaddress something a giftcode might want?
         )?;
 
         let tx_proposal = unsigned_tx_proposal.sign(&from_account).await?;

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -544,7 +544,8 @@ where
                 subaddress_index: None,
             },
             None,
-            None, // FIXME: is spend_only_from_subaddress something a giftcode might want?
+            None, /* NOTE: Assuming for now that we will not support spend_only_from_subaddress
+                   * in gift_code construction */
         )?;
 
         let tx_proposal = unsigned_tx_proposal.sign(&from_account).await?;

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -544,7 +544,7 @@ where
                 subaddress_index: None,
             },
             None,
-            None, /* NOTE: Assuming for now that we will not support spend_only_from_subaddress
+            None, /* NOTE: Assuming for now that we will not support subaddress_to_spend_from
                    * in gift_code construction */
         )?;
 

--- a/full-service/src/service/models/tx_proposal.rs
+++ b/full-service/src/service/models/tx_proposal.rs
@@ -547,6 +547,7 @@ mod tests {
                     subaddress_index: Some(alice_address_from_bob.subaddress_index as u64),
                 },
                 None,
+                None,
             )
             .unwrap();
 

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -433,6 +433,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
             .expect("Could not build transaction");
@@ -565,6 +566,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
             .expect("Could not build transaction");
@@ -689,6 +691,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await
@@ -834,6 +837,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -1978,10 +1978,10 @@ mod tests {
                 .await;
             match res {
                 Err(TransactionServiceError::TransactionBuilder(
-                        WalletTransactionBuilderError::WalletDb(
-                            WalletDbError::InsufficientFundsUnderMaxSpendable(_),
-                        ),
-                    )) => {}
+                    WalletTransactionBuilderError::WalletDb(
+                        WalletDbError::InsufficientFundsUnderMaxSpendable(_),
+                    ),
+                )) => {}
                 Ok(_) => panic!("Should error with InsufficientFundsUnderMaxSpendable"),
                 Err(e) => panic!(
                     "Should error with InsufficientFundsUnderMaxSpendable but got {:?}",

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -521,13 +521,11 @@ where
                 builder.set_txos(conn, inputs)?;
             } else {
                 if let Some(subaddress) = spend_only_from_subaddress {
-                    let assigned_subadress = AssignedSubaddress::get(&subaddress, conn)?;
+                    let assigned_subaddress = AssignedSubaddress::get(&subaddress, conn)?;
                     // Ensure the builder will filter to txos only from the specified subaddress
-                    // FIXME: I think we only need to pass in the u64, then derive the address from
-                    // it in the builder
                     builder.set_spend_only_from_subaddress(
-                        subaddress,
-                        assigned_subadress.subaddress_index as u64,
+                        assigned_subaddress.clone().public_address().unwrap(), // FIXME REMOVE
+                        assigned_subaddress.subaddress_index as u64,
                     )?;
                 }
 

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -460,12 +460,6 @@ where
         block_version: Option<BlockVersion>,
         spend_only_from_subaddress: Option<String>,
     ) -> Result<UnsignedTxProposal, TransactionServiceError> {
-        log::info!(
-            self.logger,
-            "Now building build_transaction with spend_only_from_subaddress {:?}",
-            spend_only_from_subaddress
-        );
-
         validate_number_inputs(input_txo_ids.unwrap_or(&Vec::new()).len() as u64)?;
         validate_number_outputs(addresses_and_amounts.len() as u64)?;
 
@@ -557,12 +551,6 @@ where
         block_version: Option<BlockVersion>,
         spend_only_from_subaddress: Option<String>,
     ) -> Result<TxProposal, TransactionServiceError> {
-        log::info!(
-            self.logger,
-            "Now building with spend_only_from_subaddress {:?}",
-            spend_only_from_subaddress
-        );
-
         let unsigned_tx_proposal = self.build_transaction(
             account_id_hex,
             addresses_and_amounts,
@@ -665,12 +653,6 @@ where
         spend_only_from_subaddress: Option<String>,
     ) -> Result<(TransactionLog, AssociatedTxos, ValueMap, TxProposal), TransactionServiceError>
     {
-        log::info!(
-            self.logger,
-            "Now building and submitting with spend_only_from_subaddress {:?}",
-            spend_only_from_subaddress
-        );
-
         let tx_proposal = self
             .build_and_sign_transaction(
                 account_id_hex,

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -561,7 +561,7 @@ where
             max_spendable_value,
             memo,
             block_version,
-            spend_only_from_subaddress
+            spend_only_from_subaddress,
         )?;
 
         let mut pooled_conn = self.get_pooled_conn()?;
@@ -664,7 +664,7 @@ where
                 max_spendable_value,
                 memo,
                 block_version,
-                spend_only_from_subaddress
+                spend_only_from_subaddress,
             )
             .await?;
 
@@ -821,6 +821,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -853,6 +854,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -884,6 +886,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await
@@ -976,6 +979,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await
@@ -1077,6 +1081,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await
@@ -1188,6 +1193,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
         {
@@ -1257,6 +1263,7 @@ mod tests {
                     subaddress_index: None,
                 },
                 None,
+                None,
             )
             .await
         {
@@ -1293,6 +1300,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await
@@ -1392,6 +1400,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: Some(alice_address_from_bob.subaddress_index as u64),
                 },
+                None,
                 None,
             )
             .await
@@ -1582,6 +1591,7 @@ mod tests {
                     subaddress_index: Some(alice_address_from_bob.subaddress_index as u64),
                     payment_request_id,
                 },
+                None,
                 None,
             )
             .await

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -524,7 +524,6 @@ where
                     let assigned_subaddress = AssignedSubaddress::get(&subaddress, conn)?;
                     // Ensure the builder will filter to txos only from the specified subaddress
                     builder.set_spend_only_from_subaddress(
-                        assigned_subaddress.clone().public_address().unwrap(), // FIXME REMOVE
                         assigned_subaddress.subaddress_index as u64,
                     )?;
                 }

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -1812,16 +1812,11 @@ mod tests {
             )
             .await
             .unwrap();
-        log::info!(
-            logger,
-            "Built and submitted transaction from Alice's Subaddress to Bob's Subaddress"
-        );
 
         // NOTE: Submitting to the test ledger via propose_tx doesn't actually add the
         // block to the ledger, because no consensus is occurring, so this is the
         // workaround.
         {
-            log::info!(logger, "Adding block from transaction log");
             let key_images: Vec<KeyImage> = tx_proposal
                 .input_txos
                 .iter()

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -172,9 +172,9 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
                 &self.account_id_hex,
                 target_value,
                 max_spendable_value,
+                subaddress_to_spend_from.as_deref(),
                 *token_id,
                 fee_value,
-                subaddress_to_spend_from.as_deref(),
                 conn,
             )?;
         }

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -150,11 +150,11 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
 
             self.inputs = Txo::select_spendable_txos_for_value(
                 &self.account_id_hex,
-                self.subaccount_address,
                 target_value,
                 max_spendable_value,
                 *token_id,
                 fee_value,
+                None, // FIXME: here's where we want to switch on the subaddress?
                 conn,
             )?;
         }

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -164,7 +164,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
                 max_spendable_value,
                 *token_id,
                 fee_value,
-                None, // FIXME: here's where we want to switch on the subaddress?
+                self.spend_only_from_subaddress.as_ref(),
                 conn,
             )?;
         }
@@ -450,6 +450,11 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
                 // Send the change back to the subaddress that is spending the inputs.
                 // In the future, we may want to allow this to be a bit more configurable
                 let change_address = b58_decode_public_address(&spend_from_subaddress)?;
+
+                // FIXME: We should change `transaction_builder.add_change_output` to accept
+                // a subaddress rather than the default change address. For now, the memo for
+                // transaction history will be incorrect on this change output, and it will
+                // instead validate only with the authenticated sender memo
                 let tx_out_context =
                     transaction_builder.add_output(change_amount, &change_address, &mut rng)?;
 

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -95,6 +95,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             fee: None,
             block_version: None,
             fog_resolver_factory,
+            subaccount_address: None,
         }
     }
 
@@ -149,6 +150,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
 
             self.inputs = Txo::select_spendable_txos_for_value(
                 &self.account_id_hex,
+                self.subaccount_address,
                 target_value,
                 max_spendable_value,
                 *token_id,

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -73,6 +73,10 @@ pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {
     /// connections to fog.
     #[allow(clippy::type_complexity)]
     fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
+
+    /// Subaccount Address (base58-encoded) from which to restrict TXOs for spending
+    /// (optional)
+    subaccount_address: Option<String>,
 }
 
 impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -74,9 +74,9 @@ pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {
     #[allow(clippy::type_complexity)]
     fog_resolver_factory: Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>,
 
-    /// Subaccount Address (base58-encoded) from which to restrict TXOs for spending
+    /// Subaddress (base58-encoded) from which to restrict TXOs for spending
     /// (optional)
-    subaccount_address: Option<String>,
+    spend_only_from_subaddress: Option<String>,
 }
 
 impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
@@ -95,8 +95,17 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             fee: None,
             block_version: None,
             fog_resolver_factory,
-            subaccount_address: None,
+            spend_only_from_subaddress: None,
         }
+    }
+
+    /// Sets the subaddress from which to restrict TXOs for spending.
+    pub fn set_spend_only_from_subaddress(
+        &mut self,
+        subaddress: String
+    ) -> Result<(), WalletTransactionBuilderError> {
+        self.spend_only_from_subaddress = Some(subaddress);
+        Ok(())
     }
 
     /// Sets inputs to the txos associated with the given txo_ids. Only unspent

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -164,7 +164,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
                 max_spendable_value,
                 *token_id,
                 fee_value,
-                self.spend_only_from_subaddress.as_ref(),
+                self.spend_only_from_subaddress.as_ref().map(|x| x.as_str()),
                 conn,
             )?;
         }

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -210,6 +210,7 @@ mod tests {
                         subaddress_index: None,
                     },
                     None,
+                    None,
                 )
                 .await
                 .unwrap();

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -339,7 +339,8 @@ where
                 subaddress_index: None,
             },
             None,
-            None, // FIXME: I don't believe we need to provide spend_only_from_subaddress for splitting
+            None, /* FIXME: I don't believe we need to provide spend_only_from_subaddress for
+                   * splitting */
         )?;
 
         let account = Account::get(&AccountID(account_id_hex), conn)?;
@@ -451,6 +452,7 @@ mod tests {
                 TransactionMemo::RTH {
                     subaddress_index: None,
                 },
+                None,
                 None,
             )
             .await

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -339,8 +339,7 @@ where
                 subaddress_index: None,
             },
             None,
-            None, /* FIXME: I don't believe we need to provide spend_only_from_subaddress for
-                   * splitting */
+            None,
         )?;
 
         let account = Account::get(&AccountID(account_id_hex), conn)?;

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -339,6 +339,7 @@ where
                 subaddress_index: None,
             },
             None,
+            None, // FIXME: I don't believe we need to provide spend_only_from_subaddress for splitting
         )?;
 
         let account = Account::get(&AccountID(account_id_hex), conn)?;


### PR DESCRIPTION
### Motivation

Some full-service users would prefer a mode that enables spending only from a given subaddress. While subaddresses were conceived as "turnstiles" - only tracking the amounts that come into a wallet through a given address, it is reasonable to want to instrument a wallet layer with this restriction. This PR introduces an API for spending only TXOs that were received at a given subaddress. 

### In this PR
- [x] Adds `spend_only_from_subaddress` field to `build_and_submit_transaction` (and affiliated API endpoints)
- [x] Updates documentation to add the new endpoint (see change request here: https://app.gitbook.com/o/-MW0kJdX5CaZTiJrSPwE/s/-MXOsD-rEx51AyOMlu_p-2910905616/~/changes/161/)
- [x] Ensures that change returns to the subaddress that was being spent from
- [x] Ensures the memo is constructed correctly 
- [x] Question: does `build_unsigned` and `build_unsigned_burn` need this as well? 
    - Note: I included, since they both ultimately call the same underlying function, but I did not expose the `spend_only_subaddress` in the API for these methods
- [x] Confirms T3 works correctly 
    - T3 syncs from TXOs, uses the AuthenticatedSenderMemo directly, and derives the Destination RecipientAddressHash from the recipient logged with the TXO data (https://github.com/mobilecoinofficial/full-service/blob/main/full-service/src/service/t3_sync.rs#L125). To select which TXOs to upload to T3, it [filters only on TXOs with a sender memo](https://github.com/mobilecoinofficial/full-service/blob/main/full-service/src/db/txo.rs#L1001) (so now that we are writing the change memo correctly, T3 syncing will continue to work as designed)

### Test Plan

- [x] Unittests added for new functionality
- [x] Integration test added and run (e2e) for new functionality
- [x] Tested against deployed network (Prod and/or TestNet)


### Future Work
* Add a specific mode that restricts usage to only the above features when it is enabled (need to think through what other functionality might be needed in this mode), and a concept of "subaccounts" to flesh this out
* Add a test for T3 uploading to confirm it filters the txos correctly (something that would have caught the change txo having a sender memo rather than a destination memo)
