### PR TITLE
bump version to 2.10.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @briancorbin @christian-oudard @holtzman @nick-mobilecoin
+*       @holtzman @jgreat @joekottke @nick-mobilecoin @starkriedesel @sugargoat 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "mc-full-service"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "mc-full-service-mirror"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "boring",
  "cargo-emit",
@@ -3942,7 +3942,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-signer"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "mc-validator-api"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "mc-validator-connection"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "displaydoc",
  "futures",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-validator-service"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "clap 4.5.4",
  "grpcio",
@@ -6645,7 +6645,7 @@ dependencies = [
 
 [[package]]
 name = "t3-api"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -6658,7 +6658,7 @@ dependencies = [
 
 [[package]]
 name = "t3-connection"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "displaydoc",
  "futures",

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-full-service"
-version = "2.10.1"
+version = "2.10.2"
 authors = ["MobileCoin"]
 edition = "2018"
 build = "build.rs"

--- a/mirror/Cargo.toml
+++ b/mirror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-full-service-mirror"
-version = "2.10.1"
+version = "2.10.2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-signer"
 authors = ["MobileCoin"]
-version = "2.10.1"
+version = "2.10.2"
 edition = "2021"
 build = "build.rs"
 

--- a/t3/api/Cargo.toml
+++ b/t3/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "t3-api"
-version = "2.10.1"
+version = "2.10.2"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/t3/connection/Cargo.toml
+++ b/t3/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "t3-connection"
-version = "2.10.1"
+version = "2.10.2"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/validator/api/Cargo.toml
+++ b/validator/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-validator-api"
-version = "2.10.1"
+version = "2.10.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/validator/connection/Cargo.toml
+++ b/validator/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-validator-connection"
-version = "2.10.1"
+version = "2.10.2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/validator/service/Cargo.toml
+++ b/validator/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-validator-service"
-version = "2.10.1"
+version = "2.10.2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
### Motivation

Prepare for release v2.10.2
- Adds building transactions where the input txos are filtered to only those belonging to a particular subaddress of the account.
- Minor bug fixes

### In This PR
- bump version strings
- adjust CODEOWNERS to current active team members
