### PR TITLE
uprev builder image to v0.0.36

### DIFF
--- a/.github/workflows/build-docker-release.yaml
+++ b/.github/workflows/build-docker-release.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.33
+      image: mobilecoin/rust-sgx-base:v0.0.36
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           - runner-tags: [self-hosted, macOS, ARM64]
             container: ""
           - runner-tags: mco-dev-large-x64
-            container: mobilecoin/rust-sgx-base:v0.0.32
+            container: mobilecoin/rust-sgx-base:v0.0.36
           - namespace: test
             network: testnet
           - namespace: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   lint:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.33
+      image: mobilecoin/rust-sgx-base:v0.0.36
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
   test:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.33
+      image: mobilecoin/rust-sgx-base:v0.0.36
 
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
   docs:
     runs-on: mco-dev-large-x64
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.33
+      image: mobilecoin/rust-sgx-base:v0.0.36
 
     permissions:
       contents: write

--- a/.github/workflows/dev-cd.disabled
+++ b/.github/workflows/dev-cd.disabled
@@ -27,7 +27,7 @@
 #         # - chain_id: main
 #     runs-on: mco-dev-large-x64
 #     container:
-#       image: mobilecoin/rust-sgx-base:v0.0.32
+#       image: mobilecoin/rust-sgx-base:v0.0.36
 #     steps:
 #       - name: Checkout
 #         uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.internal-ci/docker/Dockerfile.full-service-with-build
+++ b/.internal-ci/docker/Dockerfile.full-service-with-build
@@ -28,7 +28,7 @@
 # In order to create a consistent and verifiable the build environment, only add
 # or update in the mobilecoin/rust-sgx-base image and refer to the image by its hash.
 
-FROM mobilecoin/rust-sgx-base:v0.0.33 as builder
+FROM mobilecoin/rust-sgx-base:v0.0.36 as builder
 
 ARG NAMESPACE=test
 ARG SIGNED_ENCLAVE_BASE=enclave-distribution.${NAMESPACE}.mobilecoin.com


### PR DESCRIPTION
### Motivation

building full-service with v6.0.1 of submodule mobilecoin requires at least v0.0.33 of the docker mobilecoin/rust-sgx-base image.

### In this PR
* uprev the version of mobilecoin/rust-sgx-base docker image to v0.0.36, the image currently used to build the v6.0.1 release of mobilecoin, which is the version of mobilecoin currently submoduled by full-service.