### PR TITLE
Add spend_only_from_subaddress_mode for Accounf

### DIFF
--- a/full-service/migrations/2024-05-21-035622_subaddress-only-account/down.sql
+++ b/full-service/migrations/2024-05-21-035622_subaddress-only-account/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE accounts DROP COLUMN spend_only_from_subaddress;

--- a/full-service/migrations/2024-05-21-035622_subaddress-only-account/up.sql
+++ b/full-service/migrations/2024-05-21-035622_subaddress-only-account/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE accounts
+    ADD COLUMN spend_only_from_subaddress BOOLEAN NOT NULL DEFAULT FALSE;

--- a/full-service/src/db/account.rs
+++ b/full-service/src/db/account.rs
@@ -82,6 +82,7 @@ pub trait AccountModel {
     ///| `name`                  | The display name for the account.                                       | A label can have duplicates, but it is not recommended.               |
     ///| `fog_report_url`        | Fog Report server url.                                                  | Applicable only if user has Fog service, empty string otherwise.      |
     ///| `fog_authority_spki`    | Fog Authority Subject Public Key Info.                                  | Applicable only if user has Fog service, empty string otherwise.      |
+    ///| `spend_only_from_subaddress_mode` | If enabled, this mode requires all transactions to spend from a provided subaddress |                                                      |
     ///
     /// # Returns:
     /// * (account_id, main_subaddress_b58)
@@ -94,6 +95,7 @@ pub trait AccountModel {
         name: &str,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -110,6 +112,7 @@ pub trait AccountModel {
     ///| `name`                  | The display name for the account.                                       | A label can have duplicates, but it is not recommended.               |
     ///| `fog_report_url`        | Fog Report server url.                                                  | Applicable only if user has Fog service, empty string otherwise.      |
     ///| `fog_authority_spki`    | Fog Authority Subject Public Key Info.                                  | Applicable only if user has Fog service, empty string otherwise.      |
+    ///| `spend_only_from_subaddress_mode` | If enabled, this mode requires all transactions to spend from a provided subaddress |                                                      |
     ///| `conn`                  | An reference to the pool connection of wallet database                  |                                                                       |
     ///
     /// # Returns:
@@ -123,6 +126,7 @@ pub trait AccountModel {
         name: &str,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -140,6 +144,7 @@ pub trait AccountModel {
     ///| `next_subaddress_index`  | This index represents the next subaddress to be assigned as an address.                           | This is useful information in case the account is imported elsewhere. |
     ///| `name`                   | The display name for the account.                                                                 | A label can have duplicates, but it is not recommended.               |
     ///| `fog_enabled`            | Indicate if fog server is enabled or disabled                                                     |                                                                       |
+    ///| `spend_only_from_subaddress_mode` | If enabled, this mode requires all transactions to spend from a provided subaddress |                                                      |
     ///| `conn`                   | An reference to the pool connection of wallet database                                            |                                                                       |
     ///
     /// # Returns:
@@ -154,6 +159,7 @@ pub trait AccountModel {
         next_subaddress_index: Option<u64>,
         name: &str,
         fog_enabled: bool,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError>;
 
@@ -170,6 +176,7 @@ pub trait AccountModel {
     ///| `next_subaddress_index` | This index represents the next subaddress to be assigned as an address. | This is useful information in case the account is imported elsewhere. |
     ///| `fog_report_url`        | Fog Report server url.                                                  | Applicable only if user has Fog service, empty string otherwise.      |
     ///| `fog_authority_spki`    | Fog Authority Subject Public Key Info.                                  | Applicable only if user has Fog service, empty string otherwise.      |
+    ///| `spend_only_from_subaddress_mode` | If enabled, this mode requires all transactions to spend from a provided subaddress |                                                      |
     ///| `conn`                  | An reference to the pool connection of wallet database                  |                                                                       |
     ///
     /// # Returns:
@@ -183,6 +190,7 @@ pub trait AccountModel {
         next_subaddress_index: Option<u64>,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<Account, WalletDbError>;
 
@@ -199,6 +207,7 @@ pub trait AccountModel {
     ///| `next_subaddress_index` | This index represents the next subaddress to be assigned as an address. | This is useful information in case the account is imported elsewhere. |
     ///| `fog_report_url`        | Fog Report server url.                                                  | Applicable only if user has Fog service, empty string otherwise.      |
     ///| `fog_authority_spki`    | Fog Authority Subject Public Key Info.                                  | Applicable only if user has Fog service, empty string otherwise.      |
+    ///| `spend_only_from_subaddress_mode` | If enabled, this mode requires all transactions to spend from a provided subaddress |                                                      |
     ///| `conn`                  | An reference to the pool connection of wallet database                  |                                                                       |
     ///
     /// # Returns:
@@ -212,6 +221,7 @@ pub trait AccountModel {
         next_subaddress_index: Option<u64>,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<Account, WalletDbError>;
 
@@ -453,6 +463,7 @@ impl AccountModel for Account {
         name: &str,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError> {
         let fog_enabled = !fog_report_url.is_empty();
@@ -474,6 +485,7 @@ impl AccountModel for Account {
             next_subaddress_index,
             name,
             fog_enabled,
+            spend_only_from_subaddress_mode,
             conn,
         )
     }
@@ -486,6 +498,7 @@ impl AccountModel for Account {
         name: &str,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError> {
         let fog_enabled = !fog_report_url.is_empty();
@@ -507,6 +520,7 @@ impl AccountModel for Account {
             next_subaddress_index,
             name,
             fog_enabled,
+            spend_only_from_subaddress_mode,
             conn,
         )
     }
@@ -520,6 +534,7 @@ impl AccountModel for Account {
         next_subaddress_index: Option<u64>,
         name: &str,
         fog_enabled: bool,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<(AccountID, String), WalletDbError> {
         use crate::db::schema::accounts;
@@ -548,6 +563,7 @@ impl AccountModel for Account {
             fog_enabled,
             view_only: false,
             managed_by_hardware_wallet: false,
+            spend_only_from_subaddress: spend_only_from_subaddress_mode.unwrap_or(false),
         };
 
         diesel::insert_into(accounts::table)
@@ -583,6 +599,7 @@ impl AccountModel for Account {
         next_subaddress_index: Option<u64>,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<Account, WalletDbError> {
         let (account_id, _public_address_b58) = Account::create_from_mnemonic(
@@ -593,6 +610,7 @@ impl AccountModel for Account {
             &name.unwrap_or_default(),
             fog_report_url,
             fog_authority_spki,
+            spend_only_from_subaddress_mode,
             conn,
         )?;
         Account::get(&account_id, conn)
@@ -606,6 +624,7 @@ impl AccountModel for Account {
         next_subaddress_index: Option<u64>,
         fog_report_url: String,
         fog_authority_spki: String,
+        spend_only_from_subaddress_mode: Option<bool>,
         conn: Conn,
     ) -> Result<Account, WalletDbError> {
         let (account_id, _public_address_b58) = Account::create_from_root_entropy(
@@ -616,6 +635,7 @@ impl AccountModel for Account {
             &name.unwrap_or_default(),
             fog_report_url,
             fog_authority_spki,
+            spend_only_from_subaddress_mode,
             conn,
         )?;
         Account::get(&account_id, conn)
@@ -656,6 +676,7 @@ impl AccountModel for Account {
             fog_enabled: false,
             view_only: true,
             managed_by_hardware_wallet,
+            spend_only_from_subaddress: false,
         };
 
         diesel::insert_into(accounts::table)
@@ -726,6 +747,7 @@ impl AccountModel for Account {
             fog_enabled: true,
             view_only: true,
             managed_by_hardware_wallet: true,
+            spend_only_from_subaddress: false,
         };
 
         diesel::insert_into(accounts::table)
@@ -964,6 +986,7 @@ mod tests {
                 "Alice's Main Account",
                 "".to_string(),
                 "".to_string(),
+                None,
                 conn,
             )
             .unwrap();
@@ -995,6 +1018,7 @@ mod tests {
             view_only: false,
             managed_by_hardware_wallet: false,
             resyncing: false,
+            spend_only_from_subaddress: false,
         };
         assert_eq!(expected_account, acc);
 
@@ -1037,6 +1061,7 @@ mod tests {
                 "",
                 "".to_string(),
                 "".to_string(),
+                None,
                 wallet_db.get_pooled_conn().unwrap().deref_mut(),
             )
             .unwrap();
@@ -1062,6 +1087,7 @@ mod tests {
             view_only: false,
             managed_by_hardware_wallet: false,
             resyncing: false,
+            spend_only_from_subaddress: false,
         };
         assert_eq!(expected_account_secondary, acc_secondary);
 
@@ -1125,6 +1151,7 @@ mod tests {
                 "Alice's Main Account",
                 "".to_string(),
                 "".to_string(),
+                None,
                 conn,
             )
             .unwrap();
@@ -1160,6 +1187,7 @@ mod tests {
                 "Alice's FOG Account",
                 "fog//some.fog.url".to_string(),
                 "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cCAwEAAQ==".to_string(),
+                None,
                 conn,
             )
                 .unwrap();
@@ -1229,6 +1257,7 @@ mod tests {
             view_only: false,
             managed_by_hardware_wallet: false,
             resyncing: false,
+            spend_only_from_subaddress: false,
         };
         assert_eq!(expected_account, acc);
     }
@@ -1287,6 +1316,7 @@ mod tests {
             view_only: true,
             managed_by_hardware_wallet: false,
             resyncing: false,
+            spend_only_from_subaddress: false,
         };
         assert_eq!(expected_account, account);
     }
@@ -1347,6 +1377,7 @@ mod tests {
             view_only: true,
             managed_by_hardware_wallet: true,
             resyncing: false,
+            spend_only_from_subaddress: false,
         };
 
         // Check to make sure the account in the database is correct

--- a/full-service/src/db/models.rs
+++ b/full-service/src/db/models.rs
@@ -40,6 +40,8 @@ pub struct Account {
     /// account.
     pub managed_by_hardware_wallet: bool,
     pub resyncing: bool,
+    /// If true, this account is only allowed to spend from subaddresses.
+    pub spend_only_from_subaddress: bool,
 }
 
 /// A structure that can be inserted to create a new entity in the `accounts`
@@ -58,6 +60,7 @@ pub struct NewAccount<'a> {
     pub fog_enabled: bool,
     pub view_only: bool,
     pub managed_by_hardware_wallet: bool,
+    pub spend_only_from_subaddress: bool,
 }
 
 /// A transaction output entity that either was received to an Account in this

--- a/full-service/src/db/schema.rs
+++ b/full-service/src/db/schema.rs
@@ -1,5 +1,3 @@
-// @generated automatically by Diesel CLI.
-
 diesel::table! {
     accounts (id) {
         id -> Text,
@@ -14,6 +12,7 @@ diesel::table! {
         view_only -> Bool,
         managed_by_hardware_wallet -> Bool,
         resyncing -> Bool,
+        spend_only_from_subaddress -> Bool,
     }
 }
 
@@ -116,6 +115,7 @@ diesel::table! {
 
 diesel::joinable!(assigned_subaddresses -> accounts (account_id));
 diesel::joinable!(authenticated_sender_memos -> txos (txo_id));
+diesel::joinable!(destination_memos -> txos (txo_id));
 diesel::joinable!(transaction_input_txos -> transaction_logs (transaction_log_id));
 diesel::joinable!(transaction_input_txos -> txos (txo_id));
 diesel::joinable!(transaction_logs -> accounts (account_id));

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -2481,6 +2481,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -2825,6 +2826,7 @@ mod tests {
             "Bob's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -2930,6 +2932,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -3012,6 +3015,7 @@ mod tests {
             "Exchange Account",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -3120,6 +3124,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3248,6 +3253,7 @@ mod tests {
             "Exchange Account",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -3357,6 +3363,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3424,6 +3431,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3482,6 +3490,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3557,6 +3566,7 @@ mod tests {
             "Alice",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3719,6 +3729,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3770,6 +3781,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -3861,6 +3873,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -3917,6 +3930,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -3970,6 +3984,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -4059,6 +4074,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4159,6 +4175,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4346,6 +4363,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4498,6 +4516,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();
@@ -4601,6 +4620,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -4688,6 +4708,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();
@@ -4816,6 +4837,7 @@ mod tests {
             "",
             "".to_string(),
             "".to_string(),
+            None,
             conn,
         )
         .unwrap();

--- a/full-service/src/json_rpc/v1/api/request.rs
+++ b/full-service/src/json_rpc/v1/api/request.rs
@@ -102,6 +102,7 @@ pub enum JsonCommandRequest {
         fog_report_url: Option<String>,
         fog_report_id: Option<String>, // Deprecated
         fog_authority_spki: Option<String>,
+        spend_only_from_subaddress_mode: Option<bool>,
     },
     create_payment_request {
         account_id: String,

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -377,12 +377,14 @@ where
             fog_report_url,
             fog_report_id: _, // Deprecated
             fog_authority_spki,
+            spend_only_from_subaddress_mode,
         } => {
             let account = service
                 .create_account(
                     name,
                     fog_report_url.unwrap_or_default(),
                     fog_authority_spki.unwrap_or_default(),
+                    spend_only_from_subaddress_mode,
                 )
                 .map_err(format_error)?;
             let next_subaddress_index = service
@@ -1005,6 +1007,7 @@ where
                     ns,
                     fog_report_url.unwrap_or_default(),
                     fog_authority_spki.unwrap_or_default(),
+                    None,
                 )
                 .map_err(format_error)?;
 
@@ -1045,6 +1048,7 @@ where
                     ns,
                     fog_report_url.unwrap_or_default(),
                     fog_authority_spki.unwrap_or_default(),
+                    None,
                 )
                 .map_err(format_error)?;
 

--- a/full-service/src/json_rpc/v1/models/txo.rs
+++ b/full-service/src/json_rpc/v1/models/txo.rs
@@ -237,6 +237,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -121,6 +121,7 @@ pub enum JsonCommandRequest {
     create_account {
         name: Option<String>,
         fog_info: Option<FogInfo>,
+        spend_only_from_subaddress_mode: Option<bool>,
     },
     create_payment_request {
         account_id: String,
@@ -226,6 +227,7 @@ pub enum JsonCommandRequest {
         first_block_index: Option<String>,
         next_subaddress_index: Option<String>,
         fog_info: Option<FogInfo>,
+        spend_only_from_subaddress_mode: Option<bool>,
     },
     import_account {
         mnemonic: String,
@@ -233,6 +235,7 @@ pub enum JsonCommandRequest {
         first_block_index: Option<String>,
         next_subaddress_index: Option<String>,
         fog_info: Option<FogInfo>,
+        spend_only_from_subaddress_mode: Option<bool>,
     },
     import_view_only_account {
         view_private_key: String,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -504,11 +504,20 @@ where
                 txo: txo_status_and_memo.map(|txo_info| (&txo_info).into()),
             }
         }
-        JsonCommandRequest::create_account { name, fog_info } => {
+        JsonCommandRequest::create_account {
+            name,
+            fog_info,
+            spend_only_from_subaddress_mode,
+        } => {
             let fog_info = fog_info.unwrap_or_default();
 
             let account = service
-                .create_account(name, fog_info.report_url, fog_info.authority_spki)
+                .create_account(
+                    name,
+                    fog_info.report_url,
+                    fog_info.authority_spki,
+                    spend_only_from_subaddress_mode,
+                )
                 .map_err(format_error)?;
 
             let next_subaddress_index = service
@@ -1109,6 +1118,7 @@ where
             first_block_index,
             next_subaddress_index,
             fog_info,
+            spend_only_from_subaddress_mode,
         } => {
             let fb = first_block_index
                 .map(|fb| fb.parse::<u64>())
@@ -1129,6 +1139,7 @@ where
                     ns,
                     fog_info.report_url,
                     fog_info.authority_spki,
+                    spend_only_from_subaddress_mode,
                 )
                 .map_err(format_error)?;
 
@@ -1156,6 +1167,7 @@ where
             first_block_index,
             next_subaddress_index,
             fog_info,
+            spend_only_from_subaddress_mode,
         } => {
             let fb = first_block_index
                 .map(|fb| fb.parse::<u64>())
@@ -1176,6 +1188,7 @@ where
                     ns,
                     fog_info.report_url,
                     fog_info.authority_spki,
+                    spend_only_from_subaddress_mode,
                 )
                 .map_err(format_error)?;
 

--- a/full-service/src/json_rpc/v2/models/txo.rs
+++ b/full-service/src/json_rpc/v2/models/txo.rs
@@ -133,6 +133,7 @@ mod tests {
             "Alice's Main Account",
             "".to_string(),
             "".to_string(),
+            None,
             &mut wallet_db.get_pooled_conn().unwrap(),
         )
         .unwrap();

--- a/full-service/src/service/address.rs
+++ b/full-service/src/service/address.rs
@@ -220,7 +220,7 @@ mod tests {
 
         // Create an account.
         let account = service
-            .create_account(None, "".to_string(), "".to_string())
+            .create_account(None, "".to_string(), "".to_string(), None)
             .unwrap();
         assert_eq!(account.clone().next_subaddress_index(conn).unwrap(), 2);
 

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -493,6 +493,7 @@ mod tests {
                 None,
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .expect("Could not import account entropy");
 

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -890,6 +890,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -1006,6 +1007,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         manually_sync_account(
@@ -1071,6 +1073,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 

--- a/full-service/src/service/models/tx_proposal.rs
+++ b/full-service/src/service/models/tx_proposal.rs
@@ -489,6 +489,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -517,6 +518,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -387,6 +387,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -412,6 +413,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_addresses = service
@@ -520,6 +522,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -545,6 +548,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_addresses = service
@@ -645,6 +649,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -670,6 +675,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_addresses = service
@@ -791,6 +797,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -816,6 +823,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_addresses = service

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -501,6 +501,7 @@ mod tests {
                 None,
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .expect("Could not import account entropy");
 

--- a/full-service/src/service/transaction.rs
+++ b/full-service/src/service/transaction.rs
@@ -754,6 +754,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -802,6 +803,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_account_key: AccountKey =
@@ -924,6 +926,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -959,6 +962,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_account_key: AccountKey =
@@ -1166,6 +1170,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -1228,6 +1233,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -1339,6 +1345,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -1374,6 +1381,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_account_key: AccountKey =
@@ -1527,6 +1535,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -1562,6 +1571,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let bob_account_key: AccountKey =
@@ -1747,6 +1757,7 @@ mod tests {
                 Some("Exchange's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
         let exchange_account_key: AccountKey =

--- a/full-service/src/service/transaction_log.rs
+++ b/full-service/src/service/transaction_log.rs
@@ -157,6 +157,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -381,6 +381,7 @@ mod tests {
                 Some("Alice's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 
@@ -431,6 +432,7 @@ mod tests {
                 Some("Bob's Main Account".to_string()),
                 "".to_string(),
                 "".to_string(),
+                None,
             )
             .unwrap();
 

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -565,6 +565,7 @@ pub fn random_account_with_seed_values(
             &format!("SeedAccount{}", rng.next_u32()),
             "".to_string(),
             "".to_string(),
+            None,
             wallet_db.get_pooled_conn().unwrap().deref_mut(),
         )
         .unwrap();


### PR DESCRIPTION
### Motivation

We would like to provide a guard rail for the use of subaddress_to_spend_from, so that an account can enforce that transactions using the Txos within the account adhere to the scheme of spending from any Txo regardless of which subaddress it was sent to (the turnstile model), or requiring that a subaddress to spend from is always specified (so the Txos don’t get mixed together and create inconsistent subaddress balances)

### In this PR
* Adds subaddress_to_spend_from to the Account db as a book column
* Adds migration 
* Adds subaddress_to_spend_from_mode to the APIs for create and import account
* Adds logic to enforce building a transaction with an account with this enabled or not uses the correct params
* adds tests
* Adds toggle to enable or disable this mode for an account

### Test Plan

< How to run the unit test, e2e test etc. >
< Or what are the actual request/response might look like (like grpcurl) >


### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

