### PR TITLE
convert hex encloded account_id to AccountId instead of using zeros

### DIFF
--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -605,7 +605,6 @@ where
                 });
             }
 
-            // convert hex encoded string representation of account_id to AccountId struct
             let account_id = AccountId::try_from(account_id).map_err(format_error)?;
 
             let txo_sync_request = TxoSyncReq {

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -578,7 +578,7 @@ where
         JsonCommandRequest::create_view_only_account_sync_request { account_id } => {
             let unverified_txos = service
                 .list_txos(
-                    Some(account_id),
+                    Some(account_id.clone()),
                     None,
                     Some(TxoStatus::Unverified),
                     None,
@@ -605,9 +605,8 @@ where
                 });
             }
 
-            // let account_id: AccountId =
-            // account_id.as_str().try_into().map_err(format_error)?;
-            let account_id = AccountId::from([0u8; 32]);
+            // convert hex encoded string representation of account_id to AccountId struct
+            let account_id = AccountId::try_from(account_id).map_err(format_error)?;
 
             let txo_sync_request = TxoSyncReq {
                 account_id,


### PR DESCRIPTION
### Motivation

In order to keep a `view-only `account's balances in sync with activity happening on the account outside of this instance of full-service, one can:
- use `create_view_only_account_sync_request ` to obtain a list of txos for which the `view-only` account does not know the corresponding key images
- process the resulting txo_sync_request using software that has access to the account's private keys, producing a `sync_view_only_account` request that associates `tx_out_public_keys` with their corresponding `key_images`, and
- submit the `sync_view_only_account` request to the full-service with the `view-only` account.

The `txo_sync_request` generated in response to the `create_view_only_account_sync_request` method is supposed to include the account_id of the `view-only` account.  This helps ensure that the `tx_out_public_keys` are processed with the correct account keys when generating the `key_images` 

Prior to this PR, the account_id returned was all zeros.

### In this PR
* update the response to `create_view_only_account_sync_request` to include the actual `account_id` of the `view-only` account, instead of generating an all-zeros placeholder `account_id`.