### PR TITLE
add bip39_entropy as alternative to mnemonic for signer-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ __pycache__
 
 # Python/Poetry projects
 .venv/
+env/
+venv/
 
 # Node
 node_modules/

--- a/signer/src/service/api/mod.rs
+++ b/signer/src/service/api/mod.rs
@@ -84,6 +84,9 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
                 let account_info = service::get_account_by_bip39_entropy(&bip39_entropy)?;
                 JsonCommandResponse::get_account { account_info }
             }
+            (None, None) => {
+                return Err(anyhow!("Either mnemonic or bip39_entropy must be provided"));
+            }
             _ => {
                 return Err(anyhow!(
                     "Only one of mnemonic or bip39_entropy can be provided"
@@ -94,7 +97,7 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
             mnemonic,
             bip39_entropy,
             unsigned_tx_proposal,
-        } => match mnemonic {
+        } => match (mnemonic, bip39_entropy) {
             (Some(mnemonic), None) => {
                 let signed_tx = service::sign_tx_with_mnemonic(
                     &mnemonic,
@@ -117,6 +120,9 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
                     tx_proposal: (&signed_tx).try_into().map_err(|e: String| anyhow!(e))?,
                 }
             }
+            (None, None) => {
+                return Err(anyhow!("Either mnemonic or bip39_entropy must be provided"));
+            }
             _ => {
                 return Err(anyhow!(
                     "Only one of mnemonic or bip39_entropy can be provided"
@@ -127,6 +133,7 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
             mnemonic,
             bip39_entropy,
             txos_unsynced,
+        } => match (mnemonic, bip39_entropy) {
             (Some(mnemonic), None) => {
                 let txos_synced = service::sync_txos_by_mnemonic(&mnemonic, txos_unsynced)?;
                 JsonCommandResponse::sync_txos { txos_synced }
@@ -135,6 +142,9 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
                 let txos_synced =
                     service::sync_txos_by_bip39_entropy(&bip39_entropy, txos_unsynced)?;
                 JsonCommandResponse::sync_txos { txos_synced }
+            }
+            (None, None) => {
+                return Err(anyhow!("Either mnemonic or bip39_entropy must be provided"));
             }
             _ => {
                 return Err(anyhow!(

--- a/signer/src/service/api/mod.rs
+++ b/signer/src/service/api/mod.rs
@@ -75,27 +75,20 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
         JsonCommandRequest::get_account {
             mnemonic,
             bip39_entropy,
-        } => match mnemonic {
-            Some(mnemonic) => match bip39_entropy {
-                Some(_) => {
-                    return Err(anyhow!(
-                        "Only one of mnemonic or bip39_entropy can be provided"
-                    ));
-                }
-                None => {
-                    let account_info = service::get_account_by_mnemonic(&mnemonic)?;
-                    JsonCommandResponse::get_account { account_info }
-                }
-            },
-            None => match bip39_entropy {
-                Some(bip39_entropy) => {
-                    let account_info = service::get_account_by_bip39_entropy(&bip39_entropy)?;
-                    JsonCommandResponse::get_account { account_info }
-                }
-                None => {
-                    return Err(anyhow!("Either mnemonic or bip39_entropy must be provided"));
-                }
-            },
+        } => match (mnemonic, bip39_entropy) {
+            (Some(mnemonic), None) => {
+                let account_info = service::get_account_by_mnemonic(&mnemonic)?;
+                JsonCommandResponse::get_account { account_info }
+            }
+            (None, Some(bip39_entropy)) => {
+                let account_info = service::get_account_by_bip39_entropy(&bip39_entropy)?;
+                JsonCommandResponse::get_account { account_info }
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Only one of mnemonic or bip39_entropy can be provided"
+                ))
+            }
         },
         JsonCommandRequest::sign_tx {
             mnemonic,

--- a/signer/src/service/api/mod.rs
+++ b/signer/src/service/api/mod.rs
@@ -127,28 +127,20 @@ fn signer_service_api_inner(command: JsonCommandRequest) -> Result<JsonCommandRe
             mnemonic,
             bip39_entropy,
             txos_unsynced,
-        } => match mnemonic {
-            Some(mnemonic) => match bip39_entropy {
-                Some(_) => {
-                    return Err(anyhow!(
-                        "Only one of mnemonic or bip39_entropy can be provided"
-                    ));
-                }
-                None => {
-                    let txos_synced = service::sync_txos_by_mnemonic(&mnemonic, txos_unsynced)?;
-                    JsonCommandResponse::sync_txos { txos_synced }
-                }
-            },
-            None => match bip39_entropy {
-                Some(bip39_entropy) => {
-                    let txos_synced =
-                        service::sync_txos_by_bip39_entropy(&bip39_entropy, txos_unsynced)?;
-                    JsonCommandResponse::sync_txos { txos_synced }
-                }
-                None => {
-                    return Err(anyhow!("Either mnemonic or bip39_entropy must be provided"));
-                }
-            },
+            (Some(mnemonic), None) => {
+                let txos_synced = service::sync_txos_by_mnemonic(&mnemonic, txos_unsynced)?;
+                JsonCommandResponse::sync_txos { txos_synced }
+            }
+            (None, Some(bip39_entropy)) => {
+                let txos_synced =
+                    service::sync_txos_by_bip39_entropy(&bip39_entropy, txos_unsynced)?;
+                JsonCommandResponse::sync_txos { txos_synced }
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Only one of mnemonic or bip39_entropy can be provided"
+                ))
+            }
         },
     };
 

--- a/signer/src/service/api/request.rs
+++ b/signer/src/service/api/request.rs
@@ -33,14 +33,17 @@ impl TryFrom<&JsonRPCRequest> for JsonCommandRequest {
 pub enum JsonCommandRequest {
     create_account {},
     get_account {
-        mnemonic: String,
+        mnemonic: Option<String>,
+        bip39_entropy: Option<String>,
     },
     sign_tx {
-        mnemonic: String,
+        mnemonic: Option<String>,
+        bip39_entropy: Option<String>,
         unsigned_tx_proposal: UnsignedTxProposal,
     },
     sync_txos {
-        mnemonic: String,
+        mnemonic: Option<String>,
+        bip39_entropy: Option<String>,
         txos_unsynced: Vec<TxoUnsynced>,
     },
 }

--- a/signer/src/service/mod.rs
+++ b/signer/src/service/mod.rs
@@ -24,8 +24,19 @@ pub fn create_account() -> (Mnemonic, AccountInfo) {
     (mnemonic, account_info)
 }
 
-pub fn get_account(mnemonic: &str) -> Result<AccountInfo> {
+pub fn get_account_by_mnemonic(mnemonic: &str) -> Result<AccountInfo> {
     let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    get_account(mnemonic)
+}
+
+pub fn get_account_by_bip39_entropy(bip39_entropy: &str) -> Result<AccountInfo> {
+    let mut entropy = [0u8; 32];
+    hex::decode_to_slice(bip39_entropy, &mut entropy)?;
+    let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)?;
+    get_account(mnemonic)
+}
+
+fn get_account(mnemonic: Mnemonic) -> Result<AccountInfo> {
     let account = get_account_from_mnemonic(mnemonic);
 
     Ok(AccountInfo {
@@ -34,9 +45,22 @@ pub fn get_account(mnemonic: &str) -> Result<AccountInfo> {
         account_index: 0,
     })
 }
-
-pub fn sync_txos(mnemonic: &str, txos: Vec<TxoUnsynced>) -> Result<Vec<TxoSynced>> {
+pub fn sync_txos_by_mnemonic(mnemonic: &str, txos: Vec<TxoUnsynced>) -> Result<Vec<TxoSynced>> {
     let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    sync_txos(mnemonic, txos)
+}
+
+pub fn sync_txos_by_bip39_entropy(
+    bip39_entropy: &str,
+    txos: Vec<TxoUnsynced>,
+) -> Result<Vec<TxoSynced>> {
+    let mut entropy = [0u8; 32];
+    hex::decode_to_slice(bip39_entropy, &mut entropy)?;
+    let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)?;
+    sync_txos(mnemonic, txos)
+}
+
+pub fn sync_txos(mnemonic: Mnemonic, txos: Vec<TxoUnsynced>) -> Result<Vec<TxoSynced>> {
     let account = get_account_from_mnemonic(mnemonic);
 
     let mut synced: Vec<TxoSynced> = Vec::new();
@@ -56,8 +80,25 @@ pub fn sync_txos(mnemonic: &str, txos: Vec<TxoUnsynced>) -> Result<Vec<TxoSynced
     Ok(synced)
 }
 
-pub fn sign_tx(mnemonic: &str, unsigned_tx_proposal: UnsignedTxProposal) -> Result<TxProposal> {
+pub fn sign_tx_with_mnemonic(
+    mnemonic: &str,
+    unsigned_tx_proposal: UnsignedTxProposal,
+) -> Result<TxProposal> {
     let mnemonic = Mnemonic::from_phrase(mnemonic, Language::English)?;
+    sign_tx(mnemonic, unsigned_tx_proposal)
+}
+
+pub fn sign_tx_with_bip39_entropy(
+    bip39_entropy: &str,
+    unsigned_tx_proposal: UnsignedTxProposal,
+) -> Result<TxProposal> {
+    let mut entropy = [0u8; 32];
+    hex::decode_to_slice(bip39_entropy, &mut entropy)?;
+    let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)?;
+    sign_tx(mnemonic, unsigned_tx_proposal)
+}
+
+pub fn sign_tx(mnemonic: Mnemonic, unsigned_tx_proposal: UnsignedTxProposal) -> Result<TxProposal> {
     let account = get_account_from_mnemonic(mnemonic);
     let account_key = AccountKey::new(
         account.spend_private_key().as_ref(),


### PR DESCRIPTION
### Motivation

Offline signers have expressed a desire to store and manage the secret entropy of their account as a 32 byte value rather than as a 24 word mnemonic phrase for consistency with other blockchain wallets that their software manages this way.

Herein we introduce `bip39_entropy`, a 32 byte, hex-encoded string (64 characters) to the `signer-service` API to satisfy this need.  When outputting account keys, signing txos, or syncing txos for a `view-only` wallet, users of the `signer-service` can now chose  between providing a 24 word phrase, `mnemonic`, or a 64 character hex-encoded 32 byte secret, using `bip39_entropy`.


### In this PR
* json rpc request data structures updated to make `mnemonic` optional and to optionally allow `bip39_entropy`.
* service calls updated to require exactly one of `mnemonic` or `bip39_entropy` and to use whichever is provided.