### PR TITLE
update python test client for require_spend_subaddress

### DIFF
--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -82,6 +82,7 @@ async def test_account_status(client, source_account):
         'next_block_index',
         'next_subaddress_index',
         'recovery_mode',
+        'require_spend_subaddress',
         'view_only',
     ]
 


### PR DESCRIPTION
### Motivation

python test client was throwing error on `test_account_status` test.

### In this PR
* updated python test client to be aware of new `require_spend_subaddress` key in `get_account_status` response.

### Test Plan

`poetry run test-client -v` throws an error and indicates `FAILED` prior to this patch and indicates `PASSED` with patch applied.