### PR TITLE
Unit tests for FS-154 New TransactionId Derivation

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2024,8 +2024,7 @@ mod tests {
 
         use std::assert_matches::assert_matches;
 
-        let output_vec: Vec<OutputTxo> = Vec::new();
-        let transaction_log_id = TransactionId::try_from(output_vec);
+        let transaction_log_id = TransactionId::try_from(vec![]);
 
         assert_matches!(transaction_log_id, Err("no valid payload_txo"));
     }

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -53,7 +53,7 @@ impl TryFrom<Vec<OutputTxo>> for TransactionId {
                     .iter()
                     .map(|txo| txo.tx_out.public_key)
                     .min()
-                    .ok_or("no valid payload_txo")?
+                    .ok_or("no valid payload_txo")?,
             )
             .to_string(),
         ))
@@ -1980,11 +1980,9 @@ mod tests {
         let num_loops = 10;
 
         for loop_number in 1..=num_loops {
-
             let mut output_vec: Vec<OutputTxo> = Vec::new();
 
             for _ in 1..=loop_number {
-
                 let subaddress_index = 0;
                 let (tx_out, _) = create_test_txo_for_recipient(
                     &recipient_account_key,
@@ -2017,7 +2015,6 @@ mod tests {
 
     #[test]
     fn test_try_from_empty_vec_output_txo_for_transaction_id() {
-
         use std::assert_matches::assert_matches;
 
         let transaction_log_id = TransactionId::try_from(vec![]);

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -51,10 +51,9 @@ impl TryFrom<Vec<OutputTxo>> for TransactionId {
             HexFmt(
                 _payload_txos
                     .iter()
-                    .min_by_key(|txo| txo.tx_out.public_key)
+                    .map(|txo| txo.tx_out.public_key)
+                    .min()
                     .ok_or("no valid payload_txo")?
-                    .tx_out
-                    .public_key,
             )
             .to_string(),
         ))
@@ -2008,10 +2007,9 @@ mod tests {
 
             let min_public_key = output_vec
                 .iter()
-                .min_by_key(|txo| txo.tx_out.public_key)
-                .unwrap()
-                .tx_out
-                .public_key;
+                .map(|txo| txo.tx_out.public_key)
+                .min()
+                .unwrap();
             let transaction_log_id = TransactionId::try_from(output_vec).unwrap();
 
             assert_eq!(min_public_key.to_string(), transaction_log_id.0);

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -848,6 +848,7 @@ impl TransactionLogModel for TransactionLog {
 #[cfg(test)]
 mod tests {
     use std::{
+        assert_matches::assert_matches,
         collections::HashMap,
         ops::DerefMut,
         sync::{Arc, Mutex},
@@ -2015,8 +2016,6 @@ mod tests {
 
     #[test]
     fn test_try_from_empty_vec_output_txo_for_transaction_id() {
-        use std::assert_matches::assert_matches;
-
         let transaction_log_id = TransactionId::try_from(vec![]);
 
         assert_matches!(transaction_log_id, Err("no valid payload_txo"));

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -1972,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn try_from_vec_output_txo_for_transaction_id() {
+    fn test_try_from_vec_output_txo_for_transaction_id() {
 
         let mut rng: StdRng = SeedableRng::from_entropy();
         let root_id = RootIdentity::from_random(&mut rng);
@@ -2016,7 +2016,6 @@ mod tests {
 
             assert_eq!(min_public_key.to_string(), transaction_log_id.0);
         }
-        assert_eq!(num_txos, num_loops );
     }
 }
 

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2017,5 +2017,35 @@ mod tests {
             assert_eq!(min_public_key.to_string(), transaction_log_id.0);
         }
     }
+
+    #[test]
+    fn test_try_from_empty_vec_output_txo_for_transaction_id() {
+
+let mut rng: StdRng = SeedableRng::from_entropy();
+let root_id = RootIdentity::from_random(&mut rng);
+let recipient_account_key = AccountKey::from(&root_id);
+let (tx_out, _) = create_test_txo_for_recipient(
+            &recipient_account_key,
+            0, // subaddress_index
+            Amount::new(77 * MOB, Mob::ID),
+            &mut rng,
+        );
+let output_txo = OutputTxo {
+    tx_out: tx_out.clone(),
+    recipient_public_address: recipient_account_key.subaddress(0),
+    confirmation_number: TxOutConfirmationNumber::default(),
+    amount: Amount::new(77 * MOB, Mob::ID),
+    shared_secret: None,
+};
+
+        let mut output_vec: Vec<OutputTxo> = Vec::new();
+output_vec.push(output_txo);
+// output_vec.pop();
+        let transaction_log_id = TransactionId::try_from(output_vec);
+        match transaction_log_id {
+            Ok(_) => assert!(false, "Expected error, but got Ok"),
+            Err(err) => assert_eq!(err, "no valid payload_txo"),
+        }
+    }
 }
 

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -857,9 +857,9 @@ mod tests {
     use mc_account_keys::{AccountKey, PublicAddress, RootIdentity, CHANGE_SUBADDRESS_INDEX};
     use mc_common::logger::{async_test_with_logger, Logger};
     use mc_ledger_db::Ledger;
-    use mc_util_from_random::FromRandom;
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, tx::Tx, Token};
     use mc_transaction_extra::TxOutConfirmationNumber;
+    use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
     use crate::{
@@ -870,8 +870,8 @@ mod tests {
         },
         test_utils::{
             add_block_with_tx_outs, builder_for_random_recipient, create_test_txo_for_recipient,
-            get_resolver_factory, get_test_ledger, manually_sync_account, random_account_with_seed_values,
-            WalletDbTestContext, MOB,
+            get_resolver_factory, get_test_ledger, manually_sync_account,
+            random_account_with_seed_values, WalletDbTestContext, MOB,
         },
         util::b58::b58_encode_public_address,
     };
@@ -1973,7 +1973,6 @@ mod tests {
 
     #[test]
     fn test_try_from_vec_output_txo_for_transaction_id() {
-
         let mut rng: StdRng = SeedableRng::from_entropy();
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
@@ -1982,18 +1981,20 @@ mod tests {
         let num_loops = 5; // number of times to run test
         let amount = 77;
 
-        for _ in 1..=num_loops { // run test loop
+        for _ in 1..=num_loops {
+            // run test loop
 
             let mut output_vec: Vec<OutputTxo> = Vec::new();
 
-            for _ in 0..num_txos { // loop to build vector and test try_from()
+            for _ in 0..num_txos {
+                // loop to build vector and test try_from()
 
                 let (tx_out, _) = create_test_txo_for_recipient(
-                            &recipient_account_key,
-                            0, // subaddress_index
-                            Amount::new(amount * MOB, Mob::ID),
-                            &mut rng,
-                        );
+                    &recipient_account_key,
+                    0, // subaddress_index
+                    Amount::new(amount * MOB, Mob::ID),
+                    &mut rng,
+                );
 
                 let output_txo = OutputTxo {
                     tx_out: tx_out.clone(),
@@ -2020,7 +2021,6 @@ mod tests {
 
     #[test]
     fn test_try_from_empty_vec_output_txo_for_transaction_id() {
-
         let output_vec: Vec<OutputTxo> = Vec::new();
         let transaction_log_id = TransactionId::try_from(output_vec);
 
@@ -2030,4 +2030,3 @@ mod tests {
         }
     }
 }
-

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -1977,17 +1977,15 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
 
-        let num_txos = 5; // txo vector size
-        let num_loops = 5; // number of times to run test
+        let txo_vector_size = 5;
+        let num_test_runs = 5;
         let amount = 77;
 
-        for _ in 1..=num_loops {
-            // run test loop
+        for _ in 1..=num_test_runs {
 
             let mut output_vec: Vec<OutputTxo> = Vec::new();
 
-            for _ in 0..num_txos {
-                // loop to build vector and test try_from()
+            for _ in 0..txo_vector_size {
 
                 let (tx_out, _) = create_test_txo_for_recipient(
                     &recipient_account_key,

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -1975,16 +1975,15 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_entropy();
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
-
-        let txo_vector_size = 5;
-        let num_test_runs = 5;
         let amount = 77;
 
-        for _ in 1..=num_test_runs {
+        let num_loops = 10;
+
+        for loop_number in 1..=num_loops {
 
             let mut output_vec: Vec<OutputTxo> = Vec::new();
 
-            for _ in 0..txo_vector_size {
+            for _ in 1..=loop_number {
 
                 let subaddress_index = 0;
                 let (tx_out, _) = create_test_txo_for_recipient(

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2021,12 +2021,12 @@ mod tests {
 
     #[test]
     fn test_try_from_empty_vec_output_txo_for_transaction_id() {
+
+        use std::assert_matches::assert_matches;
+
         let output_vec: Vec<OutputTxo> = Vec::new();
         let transaction_log_id = TransactionId::try_from(output_vec);
 
-        match transaction_log_id {
-            Ok(_) => assert!(false, "Expected error, but got Ok"),
-            Err(err) => assert_eq!(err, "no valid payload_txo"),
-        }
+        assert_matches!(transaction_log_id, Err("no valid payload_txo"));
     }
 }

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -1978,14 +1978,15 @@ mod tests {
         let root_id = RootIdentity::from_random(&mut rng);
         let recipient_account_key = AccountKey::from(&root_id);
 
-        let num_txos = 5;
-        let num_loops = 5;
+        let num_txos = 5; // txo vector size
+        let num_loops = 5; // number of times to run test
         let amount = 77;
 
-        for _ in 1..=num_loops {
+        for _ in 1..=num_loops { // run test loop
+
             let mut output_vec: Vec<OutputTxo> = Vec::new();
 
-            for _ in 0..num_txos {
+            for _ in 0..num_txos { // loop to build vector and test try_from()
 
                 let (tx_out, _) = create_test_txo_for_recipient(
                             &recipient_account_key,
@@ -2005,67 +2006,17 @@ mod tests {
                 output_vec.push(output_txo);
             }
 
-            for output_txo in &output_vec {
-                println!("{}", output_txo.tx_out.public_key);
-            }
-            println!("\n{}", output_vec.iter().min_by_key(|txo| txo.tx_out.public_key).unwrap().tx_out.public_key);
-
-            let min_public_key = output_vec.iter().min_by_key(|txo| txo.tx_out.public_key).unwrap().tx_out.public_key;
+            let min_public_key = output_vec
+                .iter()
+                .min_by_key(|txo| txo.tx_out.public_key)
+                .unwrap()
+                .tx_out
+                .public_key;
             let transaction_log_id = TransactionId::try_from(output_vec).unwrap();
-            println!("\n{}", transaction_log_id);
 
             assert_eq!(min_public_key.to_string(), transaction_log_id.0);
-            println!("\n\n=======================\n\n");
         }
-/*
-        let (tx_out_1, _) = create_test_txo_for_recipient(
-                    &recipient_account_key,
-                    0, // subaddress_index
-                    Amount::new(11 * MOB, Mob::ID),
-                    &mut rng,
-                );
-        let output_txo_1 = OutputTxo {
-            tx_out: tx_out_1.clone(),
-            recipient_public_address: recipient_account_key.subaddress(0),
-            confirmation_number: TxOutConfirmationNumber::default(),
-            amount: Amount::new(11 * MOB, Mob::ID),
-            shared_secret: None,
-        };
-
-        let (tx_out_2, _) = create_test_txo_for_recipient(
-                    &recipient_account_key,
-                    0, // subaddress_index
-                    Amount::new(12 * MOB, Mob::ID),
-                    &mut rng,
-                );
-        let output_txo_2 = OutputTxo {
-            tx_out: tx_out_2.clone(),
-            recipient_public_address: recipient_account_key.subaddress(0),
-            confirmation_number: TxOutConfirmationNumber::default(),
-            amount: Amount::new(12 * MOB, Mob::ID),
-            shared_secret: None,
-        };
-
-        let (tx_out_3, _) = create_test_txo_for_recipient(
-                    &recipient_account_key,
-                    0, // subaddress_index
-                    Amount::new(13 * MOB, Mob::ID),
-                    &mut rng,
-                );
-        let output_txo_3 = OutputTxo {
-            tx_out: tx_out_3.clone(),
-            recipient_public_address: recipient_account_key.subaddress(0),
-            confirmation_number: TxOutConfirmationNumber::default(),
-            amount: Amount::new(13 * MOB, Mob::ID),
-            shared_secret: None,
-        };
-
-        let output_vec = vec![output_txo_1, output_txo_2, output_txo_3];
-        let transaction_log_id = TransactionId::try_from(output_vec).unwrap();
-        assert_eq!(HexFmt(tx_out_1.public_key).to_string(), transaction_log_id.0);
-*/
         assert_eq!(num_txos, num_loops );
     }
 }
-
 

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2021,27 +2021,9 @@ mod tests {
     #[test]
     fn test_try_from_empty_vec_output_txo_for_transaction_id() {
 
-let mut rng: StdRng = SeedableRng::from_entropy();
-let root_id = RootIdentity::from_random(&mut rng);
-let recipient_account_key = AccountKey::from(&root_id);
-let (tx_out, _) = create_test_txo_for_recipient(
-            &recipient_account_key,
-            0, // subaddress_index
-            Amount::new(77 * MOB, Mob::ID),
-            &mut rng,
-        );
-let output_txo = OutputTxo {
-    tx_out: tx_out.clone(),
-    recipient_public_address: recipient_account_key.subaddress(0),
-    confirmation_number: TxOutConfirmationNumber::default(),
-    amount: Amount::new(77 * MOB, Mob::ID),
-    shared_secret: None,
-};
-
-        let mut output_vec: Vec<OutputTxo> = Vec::new();
-output_vec.push(output_txo);
-// output_vec.pop();
+        let output_vec: Vec<OutputTxo> = Vec::new();
         let transaction_log_id = TransactionId::try_from(output_vec);
+
         match transaction_log_id {
             Ok(_) => assert!(false, "Expected error, but got Ok"),
             Err(err) => assert_eq!(err, "no valid payload_txo"),

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -1987,9 +1987,10 @@ mod tests {
 
             for _ in 0..txo_vector_size {
 
+                let subaddress_index = 0;
                 let (tx_out, _) = create_test_txo_for_recipient(
                     &recipient_account_key,
-                    0, // subaddress_index
+                    subaddress_index,
                     Amount::new(amount * MOB, Mob::ID),
                     &mut rng,
                 );

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2010,9 +2010,9 @@ mod tests {
                 .map(|txo| txo.tx_out.public_key)
                 .min()
                 .unwrap();
-            let transaction_log_id = TransactionId::try_from(output_vec).unwrap();
+            let transaction_id = TransactionId::try_from(output_vec).unwrap();
 
-            assert_eq!(min_public_key.to_string(), transaction_log_id.0);
+            assert_eq!(min_public_key.to_string(), transaction_id.0);
         }
     }
 


### PR DESCRIPTION
### Motivation

Added rust unit tests to confirm the new method of `transaction_log_id` generation for vectors of `OutputTxos` passed to the `TryFrom<Vec<OutputTxo>>`  implementation for `TransactionId`.

### In this PR

There are two new unit tests added:

1. `test_try_from_vec_output_txo_for_transaction_id`
2. `test_try_from_empty_vec_output_txo_for_transaction_id`

The first test creates different sized vectors of `OutputTxo` structures.  The vectors are of size 1 through 10.  The embedded `TxOut` structs are initialized from entropy, so the public keys are unique on each run.  Each vector is first scanned for its minimum public key.  The vector is then passed to `TransactionId::try_from()` and the resulting `transaction_log_id` is asserted to be equal to the vector's minimum public key.

The second test checks that the expected error message is returned when an empty vector is passed to `TransactionId::try_from()`