### PR TITLE
increase default valid block window for new tx to 100

### DIFF
--- a/full-service/src/json_rpc/v1/e2e_tests/transaction/build_submit/build_and_submit.rs
+++ b/full-service/src/json_rpc/v1/e2e_tests/transaction/build_submit/build_and_submit.rs
@@ -157,10 +157,10 @@ mod e2e_transaction {
             .unwrap();
         assert_eq!(outlay_confirmation_numbers.len(), 1);
 
-        // Tombstone block = ledger height (12 to start + 2 new blocks + 10 default
+        // Tombstone block = ledger height (12 to start + 2 new blocks + 100 default
         // tombstone)
         let prefix_tombstone = tx_prefix.get("tombstone_block").unwrap();
-        assert_eq!(prefix_tombstone, "24");
+        assert_eq!(prefix_tombstone, "114");
 
         let json_tx_proposal: json_rpc::v1::models::tx_proposal::TxProposal =
             serde_json::from_value(tx_proposal.clone()).unwrap();

--- a/full-service/src/json_rpc/v1/e2e_tests/transaction/build_submit/build_then_submit.rs
+++ b/full-service/src/json_rpc/v1/e2e_tests/transaction/build_submit/build_then_submit.rs
@@ -164,10 +164,10 @@ mod e2e_transaction {
             .unwrap();
         assert_eq!(outlay_confirmation_numbers.len(), 1);
 
-        // Tombstone block = ledger height (12 to start + 2 new blocks + 10 default
+        // Tombstone block = ledger height (12 to start + 2 new blocks + 100 default
         // tombstone)
         let prefix_tombstone = tx_prefix.get("tombstone_block").unwrap();
-        assert_eq!(prefix_tombstone, "24");
+        assert_eq!(prefix_tombstone, "114");
 
         // Get current balance
         assert_eq!(ledger_db.num_blocks().unwrap(), 14);

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_and_submit.rs
@@ -160,9 +160,9 @@ mod e2e_transaction {
 
         assert_eq!(tx_proposal.change_txos.len(), 1);
 
-        // Tombstone block = ledger height (12 to start + 2 new blocks + 10 default
+        // Tombstone block = ledger height (12 to start + 2 new blocks + 100 default
         // tombstone)
-        assert_eq!(tx_proposal.tombstone_block_index, "24");
+        assert_eq!(tx_proposal.tombstone_block_index, "114");
 
         let payments_tx_proposal = TxProposal::try_from(&tx_proposal).unwrap();
 
@@ -305,9 +305,9 @@ mod e2e_transaction {
 
         assert_eq!(tx_proposal.change_txos.len(), 1);
 
-        // Tombstone block = ledger height (14 to start + 2 new blocks + 10 default
+        // Tombstone block = ledger height (14 to start + 2 new blocks + 100 default
         // tombstone)
-        assert_eq!(tx_proposal.tombstone_block_index, "26");
+        assert_eq!(tx_proposal.tombstone_block_index, "116");
 
         let payments_tx_proposal = TxProposal::try_from(&tx_proposal).unwrap();
 

--- a/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_then_submit.rs
+++ b/full-service/src/json_rpc/v2/e2e_tests/transaction/build_submit/build_then_submit.rs
@@ -153,9 +153,9 @@ mod e2e_transaction {
 
         assert_eq!(tx_proposal.change_txos.len(), 1);
 
-        // Tombstone block = ledger height (12 to start + 2 new blocks + 10 default
+        // Tombstone block = ledger height (12 to start + 2 new blocks + 100 default
         // tombstone)
-        assert_eq!(tx_proposal.tombstone_block_index, "24");
+        assert_eq!(tx_proposal.tombstone_block_index, "114");
 
         // Get current balance
         assert_eq!(ledger_db.num_blocks().unwrap(), 14);
@@ -404,9 +404,9 @@ mod e2e_transaction {
 
         assert_eq!(tx_proposal.change_txos.len(), 1);
 
-        // Tombstone block = ledger height (12 to start + 4 new blocks + 10 default
+        // Tombstone block = ledger height (12 to start + 4 new blocks + 100 default
         // tombstone)
-        assert_eq!(tx_proposal.tombstone_block_index, "26");
+        assert_eq!(tx_proposal.tombstone_block_index, "116");
 
         // Get current balance
         assert_eq!(ledger_db.num_blocks().unwrap(), 16);

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -496,7 +496,7 @@ mod tests {
         let txo_pubkey = mc_util_serial::decode(&txos_and_statuses[0].txo.public_key)
             .expect("Could not decode pubkey");
         assert_eq!(receipt.public_key, txo_pubkey);
-        assert_eq!(receipt.tombstone_block, 23); // Ledger seeded with 12 blocks at tx construction, then one appended + 10
+        assert_eq!(receipt.tombstone_block, 113); // Ledger seeded with 12 blocks at tx construction, then one appended + 100
         let public_key = txos_and_statuses[0]
             .txo
             .public_key()

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -43,7 +43,7 @@ use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 /// Default number of blocks used for calculating transaction tombstone block
 /// number.
 // TODO support for making this configurable
-pub const DEFAULT_NEW_TX_BLOCK_ATTEMPTS: u64 = 10;
+pub const DEFAULT_NEW_TX_BLOCK_ATTEMPTS: u64 = 100;
 
 /// A builder of transactions constructed from this wallet.
 pub struct WalletTransactionBuilder<FPR: FogPubkeyResolver + 'static> {

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -1207,7 +1207,7 @@ mod tests {
             )
             .unwrap();
         let proposal = unsigned_tx_proposal.sign(&account).await.unwrap();
-        assert_eq!(proposal.tx.prefix.tombstone_block, 23);
+        assert_eq!(proposal.tx.prefix.tombstone_block, 13 + DEFAULT_NEW_TX_BLOCK_ATTEMPTS );
 
         // Build a transaction and explicitly set tombstone
         let (recipient, mut builder) =

--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -1207,7 +1207,10 @@ mod tests {
             )
             .unwrap();
         let proposal = unsigned_tx_proposal.sign(&account).await.unwrap();
-        assert_eq!(proposal.tx.prefix.tombstone_block, 13 + DEFAULT_NEW_TX_BLOCK_ATTEMPTS );
+        assert_eq!(
+            proposal.tx.prefix.tombstone_block,
+            13 + DEFAULT_NEW_TX_BLOCK_ATTEMPTS
+        );
 
         // Build a transaction and explicitly set tombstone
         let (recipient, mut builder) =


### PR DESCRIPTION
### Motivation

Block production rate on mainnet has increased.  Previously, full-service used a default of setting the tombstone block 10 blocks in the future. This is now causing a lot of tombstone block exceeded errors.
### In this PR
* set the default tombstone block to 100 blocks in the future. This matches the current setting for fog.

