### PR TITLE
fix update_key_images to not mark spent txos as unspent

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -961,12 +961,18 @@ impl TxoModel for Txo {
 
         let encoded_key_image = mc_util_serial::encode(key_image);
 
-        diesel::update(txos::table.filter(txos::id.eq(txo_id_hex)))
-            .set((
-                txos::key_image.eq(Some(encoded_key_image)),
-                txos::spent_block_index.eq(spent_block_index.map(|i| i as i64)),
-            ))
-            .execute(conn)?;
+        if spent_block_index.is_none() {
+            diesel::update(txos::table.filter(txos::id.eq(txo_id_hex)))
+                .set(txos::key_image.eq(Some(encoded_key_image)))
+                .execute(conn)?;
+        } else {
+            diesel::update(txos::table.filter(txos::id.eq(txo_id_hex)))
+                .set((
+                    txos::key_image.eq(Some(encoded_key_image)),
+                    txos::spent_block_index.eq(spent_block_index.map(|i| i as i64)),
+                ))
+                .execute(conn)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation

Full-service is taking spent txos and sometimes clearing their `spent_block_index` in the wallet db, which makes them appear unspent.  This causes double spend `key_image` errors when trying to spend funds, and can result in a complete inability for a client to spend any funds in an account.

### In this PR
Fixes `update_key_image` function to treat a `None` value for the `spent_block_index` parameter is an indication that the function should not update the `spent_block_index`, rather than setting it to `null` in the database.

As the spent_block_index database column starts as null, and is only changed to a `block_index` when the key_image that corresponds to the txo appears in the ledger, there is no need or reason to set it to `null` in this function.

### Test Plan

* without this patch can exercise full-service with a test client that corrupts the wallet db with spent txos that seem to be unspent because their spent_block_index has been reset to null
* with this patch, above test client no longer corrupts the wallet db.

* todo: unit test(s) for `update_key_image`


