### PR TITLE
Only fail transaction logs for specified account.

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -4178,6 +4178,7 @@ mod tests {
         // spendable again
         let block_index = transaction_log.tombstone_block_index.unwrap() as u64;
         TransactionLog::update_pending_exceeding_tombstone_block_index_to_failed(
+            &account_id,
             block_index + 1,
             conn,
         )

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -182,7 +182,8 @@ pub fn sync_account_next_chunk(
     exclusive_transaction(conn, |conn| {
         // Get the account data. If it is no longer available, the account has been
         // removed and we can simply return.
-        let account = Account::get(&AccountID(account_id_hex.to_string()), conn)?;
+        let account_id = AccountID(account_id_hex.to_string());
+        let account = Account::get(&account_id, conn)?;
 
         let start_time = Instant::now();
         let start_block_index = account.next_block_index as u64;
@@ -284,7 +285,8 @@ pub fn sync_account_next_chunk(
             }
 
             TransactionLog::update_pending_exceeding_tombstone_block_index_to_failed(
-                end_block_index + 1,
+                &account_id,
+                end_block_index,
                 conn,
             )?;
 
@@ -373,6 +375,7 @@ pub fn sync_account_next_chunk(
             }
 
             TransactionLog::update_pending_exceeding_tombstone_block_index_to_failed(
+                &account_id,
                 end_block_index + 1,
                 conn,
             )?;

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -286,7 +286,7 @@ pub fn sync_account_next_chunk(
 
             TransactionLog::update_pending_exceeding_tombstone_block_index_to_failed(
                 &account_id,
-                end_block_index,
+                end_block_index + 1,
                 conn,
             )?;
 


### PR DESCRIPTION
Previously when syncing multiple accounts the first account synced would
fail expired transaction logs from other accounts. This would result in
failing transaction logs that may have actually succeeded. Now only
expired transaction logs for the currently processing account will be
failed.