### PR TITLE
CI/CD Refactor - Release Process

### DIFF
--- a/.github/actions/build-publish-docker/action.yaml
+++ b/.github/actions/build-publish-docker/action.yaml
@@ -34,7 +34,7 @@ runs:
           MC_TX_SOURCE_URL=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/,https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com
       fi
 
-      ARTIFACT_NAME="full-service-${{ inputs.network }}net-${{ runner.os }}-${{ runner.arch }}"
+      ARTIFACT_NAME="full-service-${{ inputs.network }}net-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}"
 
       echo "MC_PEER=${MC_PEER}" >> "${GITHUB_ENV}"
       echo "MC_TX_SOURCE_URL=${MC_TX_SOURCE_URL}" >> "${GITHUB_ENV}"
@@ -70,6 +70,6 @@ runs:
       flavor: |
         latest=false
       tags: |
-        ${{ inputs.version }}
+        ${{ inputs.version }}-${{ inputs.network }}net
       password: ${{ inputs.docker_password }}
       username: ${{ inputs.docker_username }}

--- a/.github/actions/build-publish-docker/action.yaml
+++ b/.github/actions/build-publish-docker/action.yaml
@@ -34,12 +34,11 @@ runs:
           MC_TX_SOURCE_URL=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/,https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com
       fi
 
-      ARTIFACT_NAME="full-service-${{ inputs.network }}net-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}"
+      ARTIFACT_BASE="full-service-${{ inputs.network }}net-${{ runner.os }}-${{ runner.arch }}"
 
       echo "MC_PEER=${MC_PEER}" >> "${GITHUB_ENV}"
       echo "MC_TX_SOURCE_URL=${MC_TX_SOURCE_URL}" >> "${GITHUB_ENV}"
-      echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
-      echo "RUST_BIN_PATH=build_artifacts/${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
+      echo "RUST_BIN_PATH=build_artifacts/${ARTIFACT_BASE}" >> "${GITHUB_ENV}"
 
   - name: Cache Rust Binaries
     id: cache

--- a/.github/actions/build-rust/action.yaml
+++ b/.github/actions/build-rust/action.yaml
@@ -22,6 +22,7 @@ runs:
   - name: Setup ENV
     shell: bash
     run: |
+      # Set Local Environment Variables
       if [[ "${{ inputs.target }}" == "aarch64-apple-darwin" ]]
       then
           ARCH="ARM64"
@@ -38,11 +39,16 @@ runs:
           TARGET=""
       fi
 
+      ARTIFACT_NAME="full-service-${{ inputs.network }}net-${{ runner.os }}-${ARCH}-${{ inputs.version }}"
+
+      # Set GitHub environment variables for later use
       echo "ARCH=${ARCH}" >> "${GITHUB_ENV}"
       echo "TARGET_DIR=${TARGET_DIR}" >> "${GITHUB_ENV}"
       echo "TARGET=${TARGET}" >> "${GITHUB_ENV}"
       echo "CONSENSUS_ENCLAVE_CSS=/var/tmp/consensus-enclave.css" >> "${GITHUB_ENV}"
       echo "INGEST_ENCLAVE_CSS=/var/tmp/ingest-enclave.css" >> "${GITHUB_ENV}"
+      echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
+      echo "ARTIFACT_DIR=build_artifacts/${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
 
   - name: Consensus SigStruct
     uses: ./.github/actions/download-sigstruct
@@ -79,8 +85,6 @@ runs:
     if: steps.cache.outputs.cache-hit != 'true'
     shell: bash
     run: |
-      ARTIFACT_DIR="build_artifacts/full-service-${{ inputs.network }}net-${{ runner.os }}-${{ env.ARCH }}"
-
       mkdir -p "${ARTIFACT_DIR}/mirror"
       cp "${INGEST_ENCLAVE_CSS}" "${ARTIFACT_DIR}"
       cp "${CONSENSUS_ENCLAVE_CSS}" "${ARTIFACT_DIR}"
@@ -93,8 +97,13 @@ runs:
       cp "${TARGET_DIR}/generate-rsa-keypair" "${ARTIFACT_DIR}/mirror"
       cp mirror/EXAMPLE.md "${ARTIFACT_DIR}/mirror"
 
+  - name: Tar up artifacts
+    shell: bash
+    run: |
+      tar --strip-components=1 -c -z -v -f "${ARTIFACT_NAME}.tar.gz" "${ARTIFACT_DIR}"
+
   - name: Upload artifacts
     uses: mobilecoinofficial/gh-actions/upload-artifact@v0
     with:
       name: full-service-${{ inputs.network }}net-${{ runner.os }}-${{ env.ARCH }}-${{ inputs.version }}
-      path: build_artifacts
+      path: full-service-${{ inputs.network }}net-${{ runner.os }}-${{ env.ARCH }}-${{ inputs.version }}.tar.gz

--- a/.github/actions/build-rust/action.yaml
+++ b/.github/actions/build-rust/action.yaml
@@ -39,7 +39,8 @@ runs:
           TARGET=""
       fi
 
-      ARTIFACT_NAME="full-service-${{ inputs.network }}net-${{ runner.os }}-${ARCH}-${{ inputs.version }}"
+      ARTIFACT_BASE="full-service-${{ inputs.network }}net-${{ runner.os }}-${ARCH}"
+      ARTIFACT_NAME="${ARTIFACT_BASE}-${{ inputs.version }}"
 
       # Set GitHub environment variables for later use
       echo "ARCH=${ARCH}" >> "${GITHUB_ENV}"
@@ -48,7 +49,7 @@ runs:
       echo "CONSENSUS_ENCLAVE_CSS=/var/tmp/consensus-enclave.css" >> "${GITHUB_ENV}"
       echo "INGEST_ENCLAVE_CSS=/var/tmp/ingest-enclave.css" >> "${GITHUB_ENV}"
       echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
-      echo "ARTIFACT_DIR=build_artifacts/${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
+      echo "ARTIFACT_DIR=build_artifacts/${ARTIFACT_BASE}" >> "${GITHUB_ENV}"
 
   - name: Consensus SigStruct
     uses: ./.github/actions/download-sigstruct

--- a/.github/actions/build-rust/action.yaml
+++ b/.github/actions/build-rust/action.yaml
@@ -82,10 +82,11 @@ runs:
     run: |
       cargo build --release --locked ${TARGET}
 
-  - name: Copy binaries to artifact directory
+  - name: Copy binaries to cache directory
     if: steps.cache.outputs.cache-hit != 'true'
     shell: bash
     run: |
+      # Cache should not use version in the path.
       mkdir -p "${ARTIFACT_DIR}/mirror"
       cp "${INGEST_ENCLAVE_CSS}" "${ARTIFACT_DIR}"
       cp "${CONSENSUS_ENCLAVE_CSS}" "${ARTIFACT_DIR}"
@@ -101,7 +102,10 @@ runs:
   - name: Tar up artifacts
     shell: bash
     run: |
-      tar --strip-components=1 -c -z -v -f "${ARTIFACT_NAME}.tar.gz" "${ARTIFACT_DIR}"
+      # Create path with version for artifacts
+      mkdir -p artifacts
+      cp -R "${ARTIFACT_DIR}" "artifacts/${ARTIFACT_NAME}"
+      tar --strip-components=1 -c -z -v -f "${ARTIFACT_NAME}.tar.gz" "artifacts/${ARTIFACT_NAME}"
 
   - name: Upload artifacts
     uses: mobilecoinofficial/gh-actions/upload-artifact@v0

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -258,7 +258,7 @@ jobs:
       uses: ./.github/actions/build-publish-docker
       with:
         network: ${{ matrix.network }}
-        version: ${{ needs.meta.outputs.version }}.${{ matrix.network }}net
+        version: ${{ needs.meta.outputs.version }}
         cache_buster: ${{ vars.CACHE_BUSTER }}
         docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
         docker_password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -280,7 +280,7 @@ jobs:
     - name: Build and Publish Helm Charts
       uses: ./.github/actions/build-publish-charts
       with:
-        version: ${{ needs.meta.outputs.version }}.${{ matrix.network }}net
+        version: ${{ needs.meta.outputs.version }}-${{ matrix.network }}net
         repo_username: ${{ secrets.HARBOR_USERNAME }}
         repo_password: ${{ secrets.HARBOR_PASSWORD }}
 

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -123,8 +123,6 @@ jobs:
     runs-on: mco-dev-large-x64
     container:
       image: mobilecoin/rust-sgx-base:v0.0.36
-    env:
-      SGX_MODE: SW
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0
@@ -157,6 +155,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       env:
+        SGX_MODE: SW
+        CARGO_BACKTRACE: "1"
         CARGO_INCREMENTAL: "0"
         RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
         RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -7,10 +7,210 @@ on:
     - "v*"
 
 jobs:
-  dummy:
-    runs-on: ubuntu-latest
+  build-rust-linux:
+    strategy:
+      matrix:
+        runner:
+        - mco-dev-large-x64
+        network:
+        - main
+        - test
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: mobilecoin/rust-sgx-base:v0.0.36
     steps:
-    - name: Run a multi-line script
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Build Rust
+      uses: ./.github/actions/build-rust
+      with:
+        network: ${{ matrix.network }}
+        version: ${{ github.ref_name }}
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+
+  build-rust-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - aarch64-apple-darwin
+        - x86_64-apple-darwin
+        network:
+        - main
+        - test
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Bootstrap MacOS Rust
+      uses: ./.github/actions/bootstrap-macos
+      with:
+        target: ${{ matrix.target }}
+
+    - name: Build Rust
+      uses: ./.github/actions/build-rust
+      with:
+        target: ${{ matrix.target }}
+        network: ${{ matrix.network }}
+        version: ${{ github.ref_name }}
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+
+  build-publish-containers:
+    needs:
+    - build-rust-linux
+    strategy:
+      matrix:
+        runner:
+        - mco-dev-small-x64
+        network:
+        - main
+        - test
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Build and Publish Docker
+      uses: ./.github/actions/build-publish-docker
+      with:
+        network: ${{ matrix.network }}
+        version: ${{ github.ref_name }}
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+        docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
+        docker_password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  build-publish-charts:
+    needs:
+    - build-publish-containers
+    strategy:
+      matrix:
+        network:
+        - main
+        - test
+    runs-on: mco-dev-small-x64
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Build and Publish Helm Charts
+      uses: ./.github/actions/build-publish-charts
+      with:
+        version: ${{ github.ref_name }}-${{ matrix.network }}net
+        repo_username: ${{ secrets.HARBOR_USERNAME }}
+        repo_password: ${{ secrets.HARBOR_PASSWORD }}
+
+  gh-release:
+    needs:
+    - build-rust-macos
+    - build-publish-charts
+    runs-on: mco-dev-small-x64
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    # we need to get all the artifacts from the previous steps and package them up
+    - name: Download Artifacts
+      uses: mobilecoinofficial/gh-actions/download-artifact@v0
+      with:
+        pattern: full-service-*
+        path: build_artifacts
+
+    - name: Check Artifacts
       shell: bash
       run: |
-        true
+        ls -alR build_artifacts
+
+    - name: Create a GitHub Release
+      uses: mobilecoinofficial/gh-actions/gh-release@v0
+      with:
+        body: |
+          # What's Changed
+
+          # 📦Downloads
+
+          ### TestNet
+
+          #### Binaries
+          - [Linux X64 TestNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-testnet-Linux-X64-${{ github.ref_name }}.tar.gz)
+          - [MacOS ARM64 TestNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-testnet-macOS-ARM64-${{ github.ref_name }}.tar.gz)
+          - [MacOS X64 TestNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-testnet-macOS-X64-${{ github.ref_name }}.tar.gz)
+
+          #### Docker Images
+          - [Docker Image TestNet](https://hub.docker.com/r/mobilecoin/full-service/tags?name=${{ github.ref_name }}-testnet)
+
+          ### MainNet
+
+          #### Binaries
+          - [Linux X64 MainNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-mainnet-Linux-X64-${{ github.ref_name }}.tar.gz)
+          - [MacOS ARM64 MainNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-mainnet-macOS-ARM64-${{ github.ref_name }}.tar.gz)
+          - [MacOS X64 MainNet](https://github.com/mobilecoinofficial/full-service/releases/download/${{ github.ref_name }}/full-service-mainnet-macOS-X64-${{ github.ref_name }}.tar.gz)
+
+          #### Docker Images
+          - [Docker Image MainNet](https://hub.docker.com/r/mobilecoin/full-service/tags?name=${{ github.ref_name }}-mainnet)
+
+          # Running full-service
+
+          ### [full-service API Documentation](https://mobilecoin.gitbook.io/full-service-api/)
+
+          ### Running with Docker
+          The `full-service` docker images are published for `testnet` and `mainnet` usage and are pre-configured to connect to MobileCoin peer nodes. See [Setting Parameters as Environment Variables](https://github.com/mobilecoinofficial/full-service#parameters-as-environment-variables) to customize the default configuration.
+
+          Block and Wallet data are stored in the `/data` directory. You can mount a volume to persist data across container restarts.
+
+          `full-service` docker image with the following command:
+
+          ```bash
+          # TestNet Example
+          docker run -it -p 127.0.0.1:9090:9090 \
+            --volume $(pwd)/testnet/fs-data:/data \
+            mobilecoin/full-service:${{ github.ref_name }}-testnet
+          ```
+
+          ```bash
+          # MainNet Example
+          docker run -it -p 127.0.0.1:9090:9090 \
+            --volume $(pwd)/testnet/fs-data:/data \
+            mobilecoin/full-service:${{ github.ref_name }}-mainnet
+          ```
+
+          ### Running with Binaries
+          Download the appropriate binary for your platform and network from the links above. Extract the tarball and run the binary with the following command:
+
+          ```bash
+          # TestNet Example
+          mkdir -p ./testnet-dbs/
+          RUST_LOG=info,mc_connection=info,mc_ledger_sync=info ./full-service \
+            --wallet-db ./testnet-dbs/wallet.db \
+            --ledger-db ./testnet-dbs/ledger-db/ \
+            --peer mc://node1.test.mobilecoin.com/ \
+            --peer mc://node2.test.mobilecoin.com/ \
+            --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/ \
+            --tx-source-url https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/ \
+            --fog-ingest-enclave-css $(pwd)/ingest-enclave.css \
+            --chain-id test
+          ```
+
+          ```bash
+          # MainNet Example
+          mkdir -p ./mainnet-dbs/
+          RUST_LOG=info,mc_connection=info,mc_ledger_sync=info ./full-service \
+            --wallet-db ./mainnet-dbs/wallet.db \
+            --ledger-db ./mainnet-dbs/ledger-db/ \
+            --peer mc://node1.prod.mobilecoinww.com/ \
+            --peer mc://node2.prod.mobilecoinww.com/ \
+            --tx-source-url https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com/ \
+            --tx-source-url https://ledger.mobilecoinww.com/node2.prod.mobilecoinww.com/ \
+            --fog-ingest-enclave-css $(pwd)/ingest-enclave.css \
+            --chain-id main
+          ```
+        generate_release_notes: true
+        draft: true
+        files: |
+          build_artifacts/full-service-mainnet-Linux-X64-${{ github.ref_name }}/full-service-mainnet-Linux-X64-${{ github.ref_name }}.tar.gz
+          build_artifacts/full-service-mainnet-macOS-ARM64-${{ github.ref_name }}/full-service-mainnet-macOS-ARM64-${{ github.ref_name }}.tar.gz
+          build_artifacts/full-service-mainnet-macOS-X64-${{ github.ref_name }}/full-service-mainnet-macOS-X64-${{ github.ref_name }}.tar.gz
+          build_artifacts/full-service-testnet-Linux-X64-${{ github.ref_name }}/full-service-mainnet-Linux-X64-${{ github.ref_name }}.tar.gz
+          build_artifacts/full-service-testnet-macOS-ARM64-${{ github.ref_name }}/full-service-testnet-macOS-ARM64-${{ github.ref_name }}.tar.gz
+          build_artifacts/full-service-testnet-macOS-X64-${{ github.ref_name }}/full-service-testnet-macOS-X64-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
### Motivation

Refactor the "release on tag" process.  Clean up and simplify the process.  Build binaries, package up and publish results and Generate a draft GitHub Release.

### In this PR

Change build-rust to use cache module for built binaries, but change the zip artifacts attached to the action from directories to the tarballs with permissions preserved, ready to attach to the Github Release.  

Just a note on why I'm using this pattern: Yes its a bit silly to zip a tar.gz file, but zip files are what GH uses for their actions artifacts. For some reason when you use the GH action to restore an artifact they remove the executable permissions from any files in the zip. I don't really understand why this is since the permissions are preserved if I download the same zip locally.

The release step includes boilerplate markdown for the GitHub Release body with links and instructions for running full-service. 

### Future Work
* Need to update the configuration and operations instructions in the README.md
