### PR TITLE
python cli status cmd should only display fees for tokens on chain

### DIFF
--- a/python/mobilecoin/cli.py
+++ b/python/mobilecoin/cli.py
@@ -246,9 +246,10 @@ class CommandLineInterface:
         print()
         print('Transaction Fees:')
         for token in TOKENS:
-            if str(token.token_id) in network_status['fees']:
+            fee_storage_units = network_status['fees'].get(str(token.token_id))
+            if fee_storage_units is not None:
                 amount = Amount.from_storage_units(
-                    network_status['fees'][str(token.token_id)],
+                    fee_storage_units,
                     token
                 )
                 print(indent(amount.format(), '  '))

--- a/python/mobilecoin/cli.py
+++ b/python/mobilecoin/cli.py
@@ -246,11 +246,12 @@ class CommandLineInterface:
         print()
         print('Transaction Fees:')
         for token in TOKENS:
-            amount = Amount.from_storage_units(
-                network_status['fees'][str(token.token_id)],
-                token
-            )
-            print(indent(amount.format(), '  '))
+            if str(token.token_id) in network_status['fees']:
+                amount = Amount.from_storage_units(
+                    network_status['fees'][str(token.token_id)],
+                    token
+                )
+                print(indent(amount.format(), '  '))
 
     def list(self):
         accounts = self.client.get_accounts()


### PR DESCRIPTION
### Motivation

python CLI used on mainnet was getting a fatal error when used with the `status` command due to trying to display fees for token 8192, which is testnet only.
### In this PR
* when iterating over the defined tokens in order to display their minimum fees, only try and display fees for tokens that are present in the fee map.