### PR TITLE
calculate min_synced_block_index using local_block_height

### DIFF
--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -297,7 +297,7 @@ where
 
         let mut balance_per_token = BTreeMap::new();
 
-        let mut min_synced_block_index = network_status.network_block_height.saturating_sub(1);
+        let mut min_synced_block_index = network_status.local_block_height.saturating_sub(1);
         let mut account_ids = Vec::new();
 
         for account in accounts {


### PR DESCRIPTION
### Motivation

PR #1013 notes that the python CLI reports the wallet sync status incorrectly under conditions where accounts exist in the `wallet_db` that have sync status ahead of the `ledger_db`'s sync status.

This can happen either when:

1.  importing an account who's `first_block_index` is ahead of the local `ledger_db`'s `local_block_height`, or
2.  when the local `ledger_db` is lost, full-service is resync'ing it from the network, and has not yet caught up to where the  accounts in the `wallet_db` were previously synced.

#1013 proposes a fix for the issue by changing the CLI `status` command to report `local_block_height` instead of `min_synced_block_index`.

This PR proposes an alternate approach where instead we fix the calculation of `min_synced_block_index` so that it is the minimum of `local_block_height` and every account's (`next_block_index` -1).

We believe this to be an improved fix for a couple of  reasons:
* it fixes the underlying issue for all clients using the `get_wallet_status` method, not just for the python CLI
* it shows more accurate status for the cases where the `ledger_db` sync is ahead of one or more account's ledger scanning, which is a much more frequent occurrence than importing accounts or zeroing the local ledger.

### In this PR
* change the calculation of `min_synced_block_index` to use `local_block_height` as the sync status of the `ledger_db` rather than using `network_block_height`