### PR TITLE
renovate should update Cargo.lock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,13 +16,19 @@
         "pin",
         "digest"
       ],
-      "automerge": true
+      "automerge": true,
+      "lockFileMaintenance": {
+        "enabled": true
+      }
     },
     {
       "matchDepTypes": [
         "devDependencies"
       ],
-      "automerge": true
+      "automerge": true,
+      "lockFileMaintenance": {
+        "enabled": true
+      }
     }
   ],
   "reviewers": [

--- a/renovate.json
+++ b/renovate.json
@@ -16,21 +16,19 @@
         "pin",
         "digest"
       ],
-      "automerge": true,
-      "lockFileMaintenance": {
-        "enabled": true
-      }
+      "automerge": true
     },
     {
       "matchDepTypes": [
         "devDependencies"
       ],
-      "automerge": true,
-      "lockFileMaintenance": {
-        "enabled": true
-      }
+      "automerge": true
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "rangeStrategy": "update-lockfile",
   "reviewers": [
     "team:ramps-eng"
   ]


### PR DESCRIPTION
### Motivation

renovate isn't updating Cargo.lock when its trying to update cargo dependencies.  The documentation is...limited, but seems like it should update lock files by default, but that doesn't seem to be working.  Let's enable the lockFileMaintenance feature in the config.

I can't really test this without updating the main branch, so this might take a few tries to figure out.

