### PR TITLE
enable python integration tests.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,13 +1,13 @@
 {
   "image": "mobilecoin/fat-devcontainer:v0.0.38",
-  "forwardPorts": [
-    9090
+  "runArgs": [
+    "--network=host"
   ],
   "capAdd": ["SYS_PTRACE"],
   "containerEnv": {
     "MC_CHAIN_ID": "local",
     "RUST_BACKTRACE": "1",
-    "SGX_MODE": "SW"
+    "SGX_MODE": "HW"
   },
   "remoteUser": "sentz",
   "postCreateCommand": "/usr/local/bin/startup-devcontainer.sh",
@@ -21,7 +21,8 @@
         "rust-lang.rust-analyzer",
         "timonwong.shellcheck",
         "be5invis.toml",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "ms-python.python"
       ]
     }
   }

--- a/.github/actions/test-python-integration/action.yaml
+++ b/.github/actions/test-python-integration/action.yaml
@@ -1,0 +1,114 @@
+name: Test - Python Integration
+description: Set up environment and run integration tests
+
+inputs:
+  network:
+    description: "main|test"
+    required: true
+  cache_buster:
+    description: "cache buster"
+    required: true
+  version:
+    description: "Version of the full-service to test"
+    required: true
+  rancher_cluster:
+    description: "Rancher cluster to deploy to"
+    required: true
+  rancher_url:
+    description: "Rancher URL"
+    required: true
+  rancher_token:
+    description: "Rancher token"
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Install pip
+    shell: bash
+    run: |
+      sudo apt-get update
+      sudo apt-get install -y python3-pip
+
+  # Deploy fs chart with cloned volume
+  # All tests will need to be deployed in the full-service-ledger namespace so we can clone the target PVC
+  - name: Generate full-service values file
+    shell: bash
+    run: |
+      mkdir -p .mob/
+      cat <<EOF > .mob/${{ inputs.network }}.values.yaml
+      fullService:
+        persistence:
+          enabled: true
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 128Gi
+            dataSource:
+              name: full-service-ledger-${{ inputs.network }}net
+              kind: PersistentVolumeClaim
+      EOF
+
+  - name: Deploy Full-Service
+    uses: mobilecoinofficial/gha-k8s-toolbox@v1
+    with:
+      action: helm-deploy
+      chart_repo: https://harbor.mobilecoin.com/chartrepo/mobilecoinofficial-public
+      chart_name: full-service
+      chart_version: ${{ inputs.version }}-${{ inputs.network }}net
+      chart_values: .mob/${{ inputs.network }}.values.yaml
+      chart_wait_timeout: 30m
+      release_name: ${{ inputs.version }}-${{ inputs.network }}net
+      namespace: full-service-ledger
+      rancher_cluster: ${{ inputs.rancher_cluster }}
+      rancher_url: ${{ inputs.rancher_url }}
+      rancher_token: ${{ inputs.rancher_token }}
+
+  - name: Get IP address of full-service
+    uses: mobilecoinofficial/gha-k8s-toolbox@v1
+    with:
+      action: kubectl-exec
+      rancher_cluster: ${{ inputs.rancher_cluster }}
+      rancher_url: ${{ inputs.rancher_url }}
+      rancher_token: ${{ inputs.rancher_token }}
+      command: |
+        target_ip=$(kubectl -n full-service-ledger get svc ${{ inputs.version }}-${{ inputs.network }}net-full-service -o jsonpath='{.spec.clusterIP}')
+        funding_ip=$(kubectl -n dev-wallet-${{ inputs.network }}net get svc full-service -o jsonpath='{.spec.clusterIP}')
+        echo "TARGET_IP=${target_ip}" >> "${GITHUB_ENV}"
+        echo "FUNDING_IP=${funding_ip}" >> "${GITHUB_ENV}"
+
+  - name: Run Integration Tests
+    env:
+      FUNDING_FS_URL: http://${{ env.FUNDING_IP }}:9090/wallet/v2
+      TARGET_FS_URL: http://${{ env.TARGET_IP }}:9090/wallet/v2
+    shell: bash
+    run: |
+      set -e
+
+      # Wait for the full-service to be ready
+      .internal-ci/util/wait-for-full-service.sh
+
+      # Run integration tests
+      ./tools/test-python-integration.sh ${{ inputs.network }}
+
+  - name: Cleanup helm chart
+    uses: mobilecoinofficial/gha-k8s-toolbox@v1
+    with:
+      action: helm-release-delete
+      release_name: ${{ inputs.version }}-${{ inputs.network }}net
+      namespace: full-service-ledger
+      rancher_cluster: ${{ inputs.rancher_cluster }}
+      rancher_url: ${{ inputs.rancher_url }}
+      rancher_token: ${{ inputs.rancher_token }}
+
+  - name: Cleanup PVC
+    uses: mobilecoinofficial/gha-k8s-toolbox@v1
+    with:
+      action: pvc-delete
+      namespace: full-service-ledger
+      object_name: data-${{ inputs.version }}-${{ inputs.network }}net-full-service-0
+      rancher_cluster: ${{ inputs.rancher_cluster }}
+      rancher_url: ${{ inputs.rancher_url }}
+      rancher_token: ${{ inputs.rancher_token }}

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -223,6 +223,7 @@ jobs:
     - meta
     - build-rust-linux
     strategy:
+      fail-fast: false
       matrix:
         runner:
         - mco-dev-small-x64
@@ -248,6 +249,7 @@ jobs:
     - meta
     - build-containers
     strategy:
+      fail-fast: false
       matrix:
         network:
         - main
@@ -270,6 +272,7 @@ jobs:
     - meta
     - publish-containers
     strategy:
+      fail-fast: false
       matrix:
         network:
         - main
@@ -286,6 +289,31 @@ jobs:
         repo_username: ${{ secrets.HARBOR_USERNAME }}
         repo_password: ${{ secrets.HARBOR_PASSWORD }}
 
+  test-python-integration:
+    needs:
+    - meta
+    - build-publish-charts
+    strategy:
+      fail-fast: false
+      matrix:
+        network:
+        - main
+        - test
+    runs-on: mco-dev-small-x64
+    steps:
+    - name: Checkout
+      uses: mobilecoinofficial/gh-actions/checkout@v0
+
+    - name: Run Python Integration Tests
+      uses: ./.github/actions/test-python-integration
+      with:
+        version: ${{ needs.meta.outputs.version }}
+        network: ${{ matrix.network }}
+        cache_buster: ${{ vars.CACHE_BUSTER }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
   checks-successful:
     needs:
     - lint-actions
@@ -296,6 +324,7 @@ jobs:
     - test-rust
     - build-rust-macos
     - build-publish-charts
+    - test-python-integration
     runs-on: mco-dev-small-x64
     steps:
     - name: Success

--- a/.internal-ci/docker/Dockerfile.full-service
+++ b/.internal-ci/docker/Dockerfile.full-service
@@ -17,7 +17,7 @@ RUN  addgroup --system --gid 1000 app \
 
 RUN  apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y ca-certificates curl libdbus-1-3 libusb-1.0-0 \
+  && apt-get install -y jq ca-certificates curl libdbus-1-3 libusb-1.0-0 \
   && apt-get clean \
   && rm -r /var/lib/apt/lists/* \
   && mkdir -p /usr/share/grpc \
@@ -33,6 +33,7 @@ COPY ${RUST_BIN_PATH}/wallet-service-mirror-public /usr/local/bin/
 COPY ${RUST_BIN_PATH}/generate-rsa-keypair /usr/local/bin/
 COPY ${RUST_BIN_PATH}/ingest-enclave.css /usr/local/bin/
 COPY .internal-ci/docker/entrypoints/full-service.sh /usr/local/bin/entrypoint.sh
+COPY .internal-ci/util/wait-for-full-service.sh /usr/local/bin/wait-for-full-service.sh
 # not implemented yet
 # COPY .internal-ci/docker/support/full-service/initialize-wallets.sh /usr/local/bin/initialize-wallets.sh
 

--- a/.internal-ci/docker/entrypoints/full-service.sh
+++ b/.internal-ci/docker/entrypoints/full-service.sh
@@ -41,6 +41,15 @@ then
     fi
 fi
 
+# Run until we have a valid ledger database then quit.
+if [[ -n "${SYNC_LEDGER_ONLY}" ]]
+then
+    echo "SYNC_LEDGER_ONLY set. Exiting after syncing ledger."
+    RUST_LOG=error /usr/local/bin/full-service &
+    /usr/local/bin/wait-for-full-service.sh
+    exit 0
+fi
+
 # Check to see if leading argument starts with "--".
 # If so execute with full-service for compatibility with the previous container/cli arg only configuration.
 if [[ "${1}" =~ ^--.* ]]

--- a/.internal-ci/helm/full-service/templates/full-service-service.yaml
+++ b/.internal-ci/helm/full-service/templates/full-service-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: full-service
+  name: {{ include "fullService.fullname" . }}
   labels:
     {{- include "fullService.labels" . | nindent 4 }}
 spec:

--- a/.internal-ci/helm/full-service/templates/full-service-statefulSet.yaml
+++ b/.internal-ci/helm/full-service/templates/full-service-statefulSet.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "fullService.fullname" . }}-full-service
+  name: {{ include "fullService.fullname" . }}
   labels:
     {{- include "fullService.labels" . | nindent 4 }}
 spec:
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       app: full-service
       {{- include "fullService.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "fullService.fullname" . }}-full-service
+  serviceName: {{ include "fullService.fullname" . }}
   template:
     metadata:
       annotations:

--- a/.internal-ci/util/wait-for-full-service.sh
+++ b/.internal-ci/util/wait-for-full-service.sh
@@ -4,13 +4,27 @@ set -e
 set -o pipefail
 
 
-echo "Checking block height - wait for full-service to start"
-sleep 15
+echo "-- Checking block height - wait for full-service to start"
+
+TARGET_FS_URL=${TARGET_FS_URL:-"http://localhost:9090/wallet/v2"}
 
 curl_post()
 {
-    curl --connect-timeout 2 -sSL -X POST -H 'Content-type: application/json' http://localhost:9090/wallet/v2 --data '{"method": "get_wallet_status", "jsonrpc": "2.0", "id": 1}' 2>/dev/null
+    curl --connect-timeout 2 -sSfL -X POST -H 'Content-type: application/json' "${TARGET_FS_URL}" --data '{"method": "get_wallet_status", "jsonrpc": "2.0", "id": 1}' 2>/dev/null
 }
+
+count=0
+while ! curl_post
+do
+    echo "-- Waiting for full-service to respond"
+    count=$((count + 1))
+    if [[ "${count}" -gt 300 ]]
+    then
+        echo "Full-service did not start"
+        exit 1
+    fi
+    sleep 2
+done
 
 # wait for blocks
 wallet_json=$(curl_post)
@@ -19,7 +33,7 @@ local_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.local_b
 
 while [[ "${local_block_height}" != "${network_block_height}" ]]
 do
-    echo "- Waiting for blocks to download ${local_block_height} of ${network_block_height}"
+    echo "-- Waiting for blocks to download ${local_block_height} of ${network_block_height}"
 
     wallet_json=$(curl_post)
     network_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.network_block_height)
@@ -28,4 +42,4 @@ do
     sleep 10
 done
 
-echo "full-service sync is done"
+echo "-- full-service sync is done"

--- a/.internal-ci/util/wait-for-full-service.sh
+++ b/.internal-ci/util/wait-for-full-service.sh
@@ -10,7 +10,7 @@ TARGET_FS_URL=${TARGET_FS_URL:-"http://localhost:9090/wallet/v2"}
 
 curl_post()
 {
-    curl --connect-timeout 2 -sSfL -X POST -H 'Content-type: application/json' "${TARGET_FS_URL}" --data '{"method": "get_wallet_status", "jsonrpc": "2.0", "id": 1}' 2>/dev/null
+    curl --connect-timeout 2 -sSfL -X POST -H 'Content-type: application/json' "${TARGET_FS_URL}" --data '{"method": "get_network_status", "jsonrpc": "2.0", "id": 1}' 2>/dev/null
 }
 
 count=0
@@ -27,17 +27,17 @@ do
 done
 
 # wait for blocks
-wallet_json=$(curl_post)
-network_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.network_block_height)
-local_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.local_block_height)
+network_json=$(curl_post)
+network_block_height=$(echo "${network_json}" | jq -r .result.network_status.network_block_height)
+local_block_height=$(echo "${network_json}" | jq -r .result.network_status.local_block_height)
 
 while [[ "${local_block_height}" != "${network_block_height}" ]]
 do
     echo "-- Waiting for blocks to download ${local_block_height} of ${network_block_height}"
 
-    wallet_json=$(curl_post)
-    network_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.network_block_height)
-    local_block_height=$(echo "${wallet_json}" | jq -r .result.wallet_status.local_block_height)
+    network_json=$(curl_post)
+    network_block_height=$(echo "${network_json}" | jq -r .result.network_status.network_block_height)
+    local_block_height=$(echo "${network_json}" | jq -r .result.network_status.local_block_height)
 
     sleep 10
 done

--- a/python/mobilecoin/cli.py
+++ b/python/mobilecoin/cli.py
@@ -112,7 +112,7 @@ class CommandLineInterface:
         self.send_args.add_argument('--build-only', action='store_true', help='Just build the transaction, do not submit it.')
         self.send_args.add_argument('--fee', type=str, default=None, help='The fee paid to the network.')
         self.send_args.add_argument('account_id', help='Source account ID.')
-        self.send_args.add_argument('amount', help='Amount to send.')
+        self.send_args.add_argument('amount', help='Amount to send. Use "all" to automatically calculate fees and send all available funds.')
         self.send_args.add_argument('token', help='Token to send (MOB, eUSD).')
         self.send_args.add_argument('to_address', help='Address to send to.')
 

--- a/python/mobilecoin/cli.py
+++ b/python/mobilecoin/cli.py
@@ -60,6 +60,7 @@ class CommandLineInterface:
 
         # List accounts.
         self.list_args = command_sp.add_parser('list', help='List accounts.')
+        self.list_args.add_argument('account_id', nargs='?', type=str, default=None, help='ID or name of the account to list.')
 
         # Create account.
         self.create_args = command_sp.add_parser('create', help='Create a new account.')
@@ -95,6 +96,7 @@ class CommandLineInterface:
         self.export_args.add_argument('account_id', help='ID of the account to export.')
         self.export_args.add_argument('-s', '--show', action='store_true',
                                       help='Only show the secret entropy mnemonic, do not write it to file.')
+        self.export_args.add_argument('-f', '--file', type=str, default=None, help='Write the secret entropy mnemonic to a file path.')
 
         # Remove account.
         self.remove_args = command_sp.add_parser('remove', help='Remove an account from local storage.')
@@ -131,6 +133,7 @@ class CommandLineInterface:
         # List addresses.
         self.address_list_args = address_action.add_parser('list', help='List addresses and balances for an account.')
         self.address_list_args.add_argument('account_id', help='Account ID.')
+        self.address_list_args.add_argument('-i', '--index', nargs='?', type=int, default=None, help='Show only main address.')
 
         # Create address.
         self.address_create_args = address_action.add_parser(
@@ -177,6 +180,11 @@ class CommandLineInterface:
         # Remove gift code.
         self.gift_remove_args = gift_action.add_parser('remove', help='Remove a gift code.')
         self.gift_remove_args.add_argument('gift_code', help='Gift code to remove.')
+
+        # List balance for account
+        self.balance_args = command_sp.add_parser('balance', help='get balance for account')
+        self.balance_args.add_argument('account_id', type=str, nargs='?', default=None, help='ID or name of the account to list, or empty for all accounts.')
+        self.balance_args.add_argument('-t', '--token', type=str, default='MOB', help='Token to get balance for (MOB, eUSD).')
 
         # Version
         self.version_args = command_sp.add_parser('version', help='Show version number.')
@@ -254,20 +262,44 @@ class CommandLineInterface:
                 )
                 print(indent(amount.format(), '  '))
 
-    def list(self):
-        accounts = self.client.get_accounts()
-        if len(accounts) == 0:
-            print('No accounts.')
-            return
-
-        account_list = []
-        for account_id in accounts.keys():
-            status = self.client.get_account_status(account_id)
-            account_list.append(status)
-
-        for status in account_list:
-            print()
+    def list(self, account_id):
+        if account_id:
+            # Show a single account.
+            account = self._load_account_prefix(account_id)
+            status = self.client.get_account_status(account['id'])
             _print_account(status)
+        else:
+            accounts = self.client.get_accounts()
+            if len(accounts) == 0:
+                print('No accounts.')
+                return
+
+            account_list = []
+            for account_id in accounts.keys():
+                status = self.client.get_account_status(account_id)
+                account_list.append(status)
+
+            for status in account_list:
+                print()
+                _print_account(status)
+
+    def balance(self, account_id, token):
+        if account_id is None:
+            accounts = self.client.get_accounts()
+            for account_id in accounts.keys():
+                self.balance(account_id, token)
+            return
+        account = self._load_account_prefix(account_id)
+        account_id = account['id']
+        token = get_token(token)
+
+        status = self.client.get_account_status(account_id)
+        balance = status['balance_per_token'].get(str(token.token_id))
+        if balance is None:
+            print('{} 0 {} {}'.format(account_id[:6], token.short_code, _format_sync_state(status)))
+            return
+        balance = Amount.from_storage_units(balance['unspent'], token)
+        print('{} {} {}'.format(account_id[:6], balance.format(), _format_sync_state(status)))
 
     def create(self, name=None, disable_fog=False):
         if disable_fog:
@@ -364,10 +396,15 @@ class CommandLineInterface:
         print('Imported account.')
         print(_format_account_header(account))
 
-    def export(self, account_id, show=False):
+    def export(self, account_id, file, show=False):
         account = self._load_account_prefix(account_id)
         account_id = account['id']
         status = self.client.get_account_status(account_id)
+
+        if file is None:
+            filename = 'mobilecoin_secret_mnemonic_{}.json'.format(account_id[:6])
+        else:
+            filename = file
 
         print('You are about to export the secret entropy mnemonic for this account:')
         print()
@@ -383,7 +420,7 @@ class CommandLineInterface:
         if show:
             confirm_message = 'Really show account entropy mnemonic? (Y/N) '
         else:
-            confirm_message = 'Really write account entropy mnemonic to a file? (Y/N) '
+            confirm_message = 'Really write account entropy mnemonic to file: {} (Y/N) '.format(filename)
         if not self.confirm(confirm_message):
             print('Cancelled.')
             return
@@ -396,14 +433,13 @@ class CommandLineInterface:
                 print('{:<2}  {}'.format(i, word))
             print()
         else:
-            filename = 'mobilecoin_secret_mnemonic_{}.json'.format(account_id[:6])
             try:
                 _save_export(account, secrets, filename)
             except OSError as e:
                 print('Could not write file: {}'.format(e))
                 exit(1)
             else:
-                print(f'Wrote {filename}.')
+                print(f'Wrote {filename}')
 
     def remove(self, account_id):
         account = self._load_account_prefix(account_id)
@@ -484,7 +520,7 @@ class CommandLineInterface:
                     txo['amount']['token_id'],
                 )
                 print(indent(amount.format(), '    '))
-                address = txo['recipient_public_address_b58'] 
+                address = txo['recipient_public_address_b58']
                 if address in own_addresses:
                     print('    Received at', address)
                 else:
@@ -529,7 +565,7 @@ class CommandLineInterface:
                 token.short_code,
                 account_id[:6],
             ))
-            return
+            exit(1)
 
         if build_only:
             verb = 'Building transaction for'
@@ -700,27 +736,32 @@ class CommandLineInterface:
         else:
             func(**args)
 
-    def address_list(self, account_id):
+    def address_list(self, account_id, index):
         account = self._load_account_prefix(account_id)
-        print()
-        print(_format_account_header(account))
 
         addresses = self.client.get_addresses(account['id'], limit=1000)
         addresses = list(addresses.values())
         addresses.sort(key=lambda a: int(a['subaddress_index']))
 
-        for address in addresses:
-            address_status = self.client.get_address_status(address['public_address_b58'])
+        # only print headers if we're listing multiple accounts
+        if index is None:
+            print()
+            print(_format_account_header(account))
+
+            for address in addresses:
+                address_status = self.client.get_address_status(address['public_address_b58'])
+
+                print()
+                print('#{} {}'.format(
+                    address['subaddress_index'],
+                    address['metadata'],
+                ))
+                print(indent(address['public_address_b58'], '  '))
+                print(indent(_format_balances(address_status['balance_per_token']), '  '))
 
             print()
-            print('#{} {}'.format(
-                address['subaddress_index'],
-                address['metadata'],
-            ))
-            print(indent(address['public_address_b58'], '  '))
-            print(indent(_format_balances(address_status['balance_per_token']), '  '))
-
-        print()
+        else:
+            print(addresses[index]['public_address_b58'])
 
     def address_create(self, account_id, metadata):
         account = self._load_account_prefix(account_id)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -85,7 +85,7 @@ async def source_account(client):
         status['balance_per_token'][str(MOB.token_id)]['unspent'],
         MOB,
     )
-    assert initial_balance >= Amount.from_display_units(0.1, MOB)
+    assert initial_balance >= Amount.from_display_units(0.001, MOB)
 
     return status['account']
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -106,14 +106,14 @@ async def test_send_transaction_self(client, source_account, fees):
     # Send a transaction from the account back to itself.
     transaction_log, _ = await client.build_and_submit_transaction(
         source_account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         source_account['main_address'],
     )
     tx_value = Amount.from_storage_units(
         transaction_log['value_map'][str(MOB.token_id)],
         MOB,
     )
-    assert tx_value == Amount.from_display_units(0.01, MOB)
+    assert tx_value == Amount.from_display_units(0.001, MOB)
 
     # Wait for the account to sync.
     tx_index = int(transaction_log['submitted_block_index'])
@@ -131,14 +131,14 @@ async def _test_send_transaction(client, account, temp_account):
     # Send a transaction to the temporary account.
     transaction_log, _ = await client.build_and_submit_transaction(
         account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         temp_account['main_address'],
     )
     tx_value = Amount.from_storage_units(
         transaction_log['value_map'][str(MOB.token_id)],
         MOB,
     )
-    assert tx_value == Amount.from_display_units(0.01, MOB)
+    assert tx_value == Amount.from_display_units(0.001, MOB)
     assert transaction_log['output_txos'][0]['public_key'] == transaction_log['id']
 
     # Wait for the temporary account to sync.
@@ -150,7 +150,7 @@ async def _test_send_transaction(client, account, temp_account):
         temp_status['balance_per_token'][str(MOB.token_id)]['unspent'],
         MOB,
     )
-    assert temp_balance == Amount.from_display_units(0.01, MOB)
+    assert temp_balance == Amount.from_display_units(0.001, MOB)
 
 
 async def test_send_transaction(client, source_account, account_factory):
@@ -180,7 +180,7 @@ async def test_send_transaction_subaddress(client, source_account, account_facto
     # Send a transaction to the temporary account.
     transaction_log, _ = await client.build_and_submit_transaction(
         source_account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         address,
     )
 
@@ -194,7 +194,7 @@ async def test_send_transaction_subaddress(client, source_account, account_facto
         temp_status['balance_per_token'][str(MOB.token_id)]['unspent'],
         MOB,
     )
-    assert temp_balance == Amount.from_display_units(0.01, MOB)
+    assert temp_balance == Amount.from_display_units(0.001, MOB)
 
     # The subaddress balance also shows the transaction.
     subaddress_status = await client.get_address_status(address)
@@ -202,7 +202,7 @@ async def test_send_transaction_subaddress(client, source_account, account_facto
         subaddress_status['balance_per_token'][str(MOB.token_id)]['unspent'],
         MOB,
     )
-    assert subaddress_balance == Amount.from_display_units(0.01, MOB)
+    assert subaddress_balance == Amount.from_display_units(0.001, MOB)
 
 
 async def test_build_transaction_multiple_outputs(client, source_account, account_factory):
@@ -212,8 +212,8 @@ async def test_build_transaction_multiple_outputs(client, source_account, accoun
     tx_proposal, _ = await client.build_transaction(
         source_account['id'],
         {
-            temp_account_1['main_address']: Amount.from_display_units(0.01, MOB),
-            temp_account_2['main_address']: Amount.from_display_units(0.01, MOB),
+            temp_account_1['main_address']: Amount.from_display_units(0.001, MOB),
+            temp_account_2['main_address']: Amount.from_display_units(0.001, MOB),
         },
     )
     transaction_log = await client.submit_transaction(tx_proposal, source_account['id'])
@@ -231,7 +231,7 @@ async def test_build_transaction_multiple_outputs(client, source_account, accoun
             status['balance_per_token'][str(MOB.token_id)]['unspent'],
             MOB,
         )
-        assert balance == Amount.from_display_units(0.01, MOB)
+        assert balance == Amount.from_display_units(0.001, MOB)
 
 
 async def test_build_burn_transaction(client, source_account, fees):

--- a/python/tests/test_client_v1.py
+++ b/python/tests/test_client_v1.py
@@ -109,11 +109,11 @@ def test_send_transaction_self(client_v1, source_account, fee):
     # Send a transaction from the account back to itself.
     transaction_log, _ = client_v1.build_and_submit_transaction(
         source_account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         source_account['main_address'],
     )
     tx_value = Amount.from_storage_units(transaction_log['value_pmob'], MOB)
-    assert tx_value == Amount.from_display_units(0.01, MOB)
+    assert tx_value == Amount.from_display_units(0.001, MOB)
 
     # Wait for the account to sync.
     tx_index = int(transaction_log['submitted_block_index'])
@@ -128,11 +128,11 @@ def _test_send_transaction(client_v1, account, temp_account):
     # Send a transaction to the temporary account.
     transaction_log, _ = client_v1.build_and_submit_transaction(
         account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         temp_account['main_address'],
     )
     tx_value = Amount.from_storage_units(transaction_log['value_pmob'], MOB)
-    assert tx_value == Amount.from_display_units(0.01, MOB)
+    assert tx_value == Amount.from_display_units(0.001, MOB)
 
     # Wait for the temporary account to sync.
     tx_index = int(transaction_log['submitted_block_index'])
@@ -143,7 +143,7 @@ def _test_send_transaction(client_v1, account, temp_account):
         temp_balance['unspent_pmob'],
         MOB,
     )
-    assert temp_balance == Amount.from_display_units(0.01, MOB)
+    assert temp_balance == Amount.from_display_units(0.001, MOB)
 
 
 async def test_send_transaction(client_v1, source_account, account_factory):
@@ -162,7 +162,7 @@ async def test_send_transaction_fog(client_v1, source_account, account_factory):
     temp_fog_account = await account_factory.create_fog()
     _test_send_transaction(client_v1, source_account, temp_fog_account)
 
-
+# failed - not waiting for primary account to be synced
 async def test_send_transaction_subaddress(client_v1, source_account, account_factory):
     temp_account = await account_factory.create()
 
@@ -178,7 +178,7 @@ async def test_send_transaction_subaddress(client_v1, source_account, account_fa
     # Send a transaction to the temporary account.
     transaction_log, _ = client_v1.build_and_submit_transaction(
         source_account['id'],
-        Amount.from_display_units(0.01, MOB),
+        Amount.from_display_units(0.001, MOB),
         address,
     )
 
@@ -188,13 +188,12 @@ async def test_send_transaction_subaddress(client_v1, source_account, account_fa
 
     # Check that the transaction has arrived.
     temp_balance = Amount.from_storage_units(temp_balance['unspent_pmob'], MOB)
-    assert temp_balance == Amount.from_display_units(0.01, MOB)
+    assert temp_balance == Amount.from_display_units(0.001, MOB)
 
     # The subaddress balance also shows the transaction.
     balance = client_v1.get_balance_for_address(address)
     subaddress_balance = Amount.from_storage_units(balance['unspent_pmob'], MOB)
-    assert subaddress_balance == Amount.from_display_units(0.01, MOB)
-
+    assert subaddress_balance == Amount.from_display_units(0.001, MOB)
 
 async def test_build_transaction_multiple_outputs(client_v1, source_account, account_factory):
     temp_account_1 = await account_factory.create()
@@ -203,8 +202,8 @@ async def test_build_transaction_multiple_outputs(client_v1, source_account, acc
     tx_proposal, _ = client_v1.build_transaction(
         source_account['id'],
         {
-            temp_account_1['main_address']: Amount.from_display_units(0.01, MOB),
-            temp_account_2['main_address']: Amount.from_display_units(0.01, MOB),
+            temp_account_1['main_address']: Amount.from_display_units(0.001, MOB),
+            temp_account_2['main_address']: Amount.from_display_units(0.001, MOB),
         },
     )
     transaction_log = client_v1.submit_transaction(
@@ -225,4 +224,4 @@ async def test_build_transaction_multiple_outputs(client_v1, source_account, acc
             balance['unspent_pmob'],
             MOB,
         )
-        assert balance == Amount.from_display_units(0.01, MOB)
+        assert balance == Amount.from_display_units(0.001, MOB)

--- a/tools/test-python-integration.sh
+++ b/tools/test-python-integration.sh
@@ -222,15 +222,14 @@ do
     account=$(echo "${b}" | cut -d' ' -f1)
     amount=$(echo "${b}" | cut -d' ' -f2)
     token=$(echo "${b}" | cut -d' ' -f3)
-    amount_minus_fee=$(awk "BEGIN{print ${amount} - 0.0004}")
-    if (( $(echo "${amount_minus_fee} 0" | awk '{print ($1 > $2)}') ))
+    if (( $(echo "${amount} 0" | awk '{print ($1 > $2)}') ))
     then
         echo "INFO: found leftover funds: ${b}"
         echo "INFO: drain funds to ${funding_account_address:0:5}...${funding_account_address: -5}"
-        echo "mob -y send ${account} ${amount_minus_fee} ${token} ..."
+        echo "mob -y send ${account} all ${token} ..."
         # I think there can be a timing issue when sending funds. If full-service has not yet polled the network, it
         # might think its in sync, but might have transactions pending.  As a work around, we will retry sending.
-        while ! target_mob -y send "${account}" "${amount_minus_fee}" "${token}" "${funding_account_address}"
+        while ! target_mob -y send "${account}" all "${token}" "${funding_account_address}"
         do
             sleep 5
             echo "INFO: retrying send"

--- a/tools/test-python-integration.sh
+++ b/tools/test-python-integration.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+usage()
+{
+    echo "Usage:"
+    echo "${0} <network>|check"
+    echo "    <network> - main|prod|test"
+    echo "Environment Variables:"
+    echo "    FUNDING_FS_URL - optional: URL of the funding full-service"
+    echo "    FUNDING_ACCOUNT_ID - optional: account_id of the funding account"
+    echo "    TARGET_FS_URL - optional: URL of the full-service we want to test"
+}
+
+while (( "$#" ))
+do
+    case "${1}" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        *)
+            net="${1}"
+            shift 1
+            ;;
+    esac
+done
+
+if [[ -z "${net}" ]]
+then
+    echo "ERROR: <network> is not set"
+    usage
+    exit 1
+fi
+
+# use main instead of legacy prod
+if [[ "${net}" == "prod" ]]
+then
+    echo "Detected \"prod\" legacy network setting. Using \"main\" instead."
+    net=main
+fi
+
+# Grab current location and source the shared functions.
+location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+# shellcheck source=/dev/null
+source "${location}/.shared-functions.sh"
+
+case "${net}" in
+    test)
+        export MC_FOG_REPORT_URL="fog://fog.test.mobilecoin.com"
+        export MC_WALLET_FILE=${MC_WALLET_FILE:-${GIT_BASE}/.mob/testnet_secret_mnemonic.json}
+        export MC_FOG_AUTHORITY_SPKI="MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cCAwEAAQ=="
+        funding_account_id="2e181bc5ec273f2385439eecfacf967525c9d61003cc7c178ba4eaad84d1ac72"
+        funding_fs_port="9091"
+        port_forward_cmd="kubectl -n dev-wallet-testnet port-forward svc/full-service 9091:9090"
+    ;;
+    main)
+        export MC_FOG_REPORT_URL="fog://fog.prod.mobilecoinww.com"
+        export MC_WALLET_FILE=${MC_WALLET_FILE:-${GIT_BASE}/.mob/mainnet_secret_mnemonic.json}
+        export MC_FOG_AUTHORITY_SPKI="MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyr/99fvxi104MLgDgvWPVt01TuTJ+rN4qcNBUbF5i3EMM5zDZlugFHKPYPv7flCh5yDDYyLQHfWkxPQqCBAqlhSrCakvQH3HqDSpbM5FJg7pt0k5w+UQGWvP079iSEO5fMRhjE/lORkvk3/UKr2yIXjZ19iEgP8hlhk9xkI42DSg0iIhk59k3wEYPMGSkVarqlPoKBzx2+11CieXnbCkRvoNwLvdzLceY8QNoLc6h2/nht4bcjDCdB0MKNSKFLVp6XNHkVF66jC7QWTZRA/d4pgI5xa+GmkQ90zDZC2sBc+xfquVIVtk0nEvqSkUDZjv7AcJaq/VdPu4uj773ojrZz094PI4Q6sdbg7mfWrcq3ZQG8t9RDXD+6cgugCTFx2Cq/vJhDAPbQHmCEaMoXv2sRSfOhRjtMP1KmKUw5zXmAZa7s88+e7UXRQC+SS77V8s3hinE/I5Gqa/lzl73smhXx8l4CwGnXzlQ5h1lgEHnYLRFnIenNw/mdMGKlWH5HwHLX3hIujERCPAnGLDt+4MjcUiU0spDH3hC9mjPVA3ltaA3+Mk2lDw0kLrZ4Gv3/Ik9WPlYetOuWteMkR1fz6VOc13+WoTJPz0dVrJsK2bUz+YvdBsoHQBbUpCkmnQ5Ok+yiuWa5vYikEJ24SEr8wUiZ4Oe12KVEcjyDIxp6QoE8kCAwEAAQ=="
+        funding_account_id="ea7d2628e31ff7f546b193258e4b99f026521a99c2a5fdb76ac45258405f5b12"
+        funding_fs_port="9092"
+        port_forward_cmd="kubectl -n dev-wallet-mainnet port-forward svc/full-service 9092:9090"
+    ;;
+    *)
+        echo "ERROR: <network> must be main or test"
+        usage
+        exit 1
+    ;;
+esac
+
+# Override the URL and account_id for the funding full-service if you want to use a different one
+# Parse to get the host and port
+TARGET_FS_URL=${TARGET_FS_URL:-"http://localhost:9090/wallet/v2"}
+declare -A TARGET_FS_URL_PARSED
+parse_url "${TARGET_FS_URL}" TARGET_FS_URL_PARSED
+
+# Set funding url and parse hostname/port
+FUNDING_FS_URL=${FUNDING_FS_URL:-"http://localhost:${funding_fs_port}/wallet/v2"}
+declare -A FUNDING_FS_URL_PARSED
+parse_url "${FUNDING_FS_URL}" FUNDING_FS_URL_PARSED
+
+FUNDING_ACCOUNT_ID=${FUNDING_ACCOUNT_ID:-${funding_account_id}}
+test_success=0
+
+funding_mob()
+{
+    MC_FULL_SERVICE_PORT=${FUNDING_FS_URL_PARSED[port]} MC_FULL_SERVICE_HOST="${FUNDING_FS_URL_PARSED[proto]}${FUNDING_FS_URL_PARSED[host]}" mob "$@"
+}
+
+target_mob()
+{
+    MC_FULL_SERVICE_PORT=${TARGET_FS_URL_PARSED[port]} MC_FULL_SERVICE_HOST="${TARGET_FS_URL_PARSED[proto]}${TARGET_FS_URL_PARSED[host]}" mob "$@"
+}
+
+# Check to see if local full-service is running
+if ! curl --connect-timeout 2 -s -f "${TARGET_FS_URL}" >/dev/null
+then
+    echo "ERROR: Full-Service is not running on ${TARGET_FS_URL}"
+    echo "      Please ensure the service is running and accessible."
+    exit 1
+else
+    echo "INFO: Connected successfully to local Full-Service at ${TARGET_FS_URL}"
+fi
+
+# Check if the Funding Full-Service is running and accessible
+read -r -d '' get_account_status_request <<EOF || true
+{
+    "method": "get_account_status",
+    "params": {
+        "account_id": "${FUNDING_ACCOUNT_ID}"
+    },
+    "jsonrpc": "2.0",
+    "id": 1
+}
+EOF
+
+if ! response=$(curl --connect-timeout 2 -s -f --header 'Content-Type: application/json' "${FUNDING_FS_URL}" -d "${get_account_status_request}")
+then
+    echo "ERROR: Unable to connect to the Funding Full-Service at ${FUNDING_FS_URL}"
+    echo "      with account_id: ${FUNDING_ACCOUNT_ID}"
+    echo "      Please ensure the service is running and accessible."
+    echo "      If you are running this test locally, you can port-forward to the service:"
+    echo "      Connect to the development cluster and run:"
+    echo "      ${port_forward_cmd}"
+    echo "      OR"
+    echo "      Set the FUNDING_ACCOUNT_ID and FUNDING_FS_URL environment variable to the full-service instance you want to use."
+    exit 1
+fi
+
+if [[ "${response}" =~ "AccountNotFound" ]]
+then
+    echo "ERROR: Unable to get account status for account_id: ${FUNDING_ACCOUNT_ID}"
+    echo "      Please ensure the account_id is correct."
+    exit 1
+fi
+
+echo "INFO: Connected to the Funding Full-Service at ${FUNDING_FS_URL}"
+
+echo "INFO: check for existing wallet file"
+if [[ -e ${MC_WALLET_FILE} ]]
+then
+    echo "ERROR: existing wallet file found: ${MC_WALLET_FILE}"
+    echo "      Please drain funds and remove the file before running this script."
+    exit 1
+fi
+mkdir -p "$(dirname "${MC_WALLET_FILE}")"
+
+echo "INFO: check for poetry"
+if ! command -v poetry >/dev/null
+then
+    echo "INFO: poetry not found, installing..."
+    pip install poetry
+fi
+
+pushd "${GIT_BASE:?}/python" > /dev/null
+
+echo "INFO: Install mob(lecoin) package"
+if ! command -v mob >/dev/null
+then
+    echo "INFO: mob not found, installing..."
+    export PATH="${HOME}/.local/bin:${PATH}"
+    pip install .
+fi
+
+echo "INFO: install test dependencies"
+poetry install
+
+echo "INFO: Create wallet"
+if target_mob list | grep test-wallet
+then
+    echo: "ERROR: test-wallet already exists"
+    exit 1
+fi
+target_mob -y create --name test-wallet
+
+echo "INFO: Get wallet address"
+local_address=$(target_mob address list test-wallet -i 0)
+echo "INFO: ${local_address}"
+
+echo "INFO: fund test wallet with 0.02 MOB"
+funding_mob -y send "${funding_account_id}" 0.02 MOB "${local_address}"
+
+echo "INFO: wait for funds to arrive"
+local_balance=$(target_mob balance test-wallet | cut -d' ' -f2)
+while [[ "${local_balance}" == "0" ]]
+do
+    local_balance=$(target_mob balance test-wallet | cut -d' ' -f2)
+    echo "INFO: balance: ${local_balance}"
+    sleep 2
+done
+
+echo "INFO: get funding account return address"
+funding_account_address=$(funding_mob address list "${funding_account_id}" -i 0)
+echo "INFO: ${funding_account_address}"
+
+echo "INFO: export wallet"
+target_mob -y export test-wallet --file "${MC_WALLET_FILE}"
+
+echo "INFO: remove wallet so we can test import from file"
+target_mob -y remove test-wallet
+
+echo "INFO: run tests"
+if MC_FULL_SERVICE_PORT=${TARGET_FS_URL_PARSED[port]} MC_FULL_SERVICE_HOST="${TARGET_FS_URL_PARSED[proto]}${TARGET_FS_URL_PARSED[host]}" poetry run pytest -v
+then
+    echo "INFO: tests passed"
+    test_success=1
+else
+    # this is a bit silly, but we want to catch failure and finish the script to drain any remaining funds
+    # we could trap exits, but there are lots of places where we could exit but not have things set up to
+    # drain funds
+    echo "ERROR: tests failed"
+fi
+
+echo "INFO: look for leftover funds"
+balances=$(target_mob balance)
+while read -r b
+do
+    # split out ammount from address and token type
+    counter=0
+    account=$(echo "${b}" | cut -d' ' -f1)
+    amount=$(echo "${b}" | cut -d' ' -f2)
+    token=$(echo "${b}" | cut -d' ' -f3)
+    amount_minus_fee=$(awk "BEGIN{print ${amount} - 0.0004}")
+    if (( $(echo "${amount_minus_fee} 0" | awk '{print ($1 > $2)}') ))
+    then
+        echo "INFO: found leftover funds: ${b}"
+        echo "INFO: drain funds to ${funding_account_address:0:5}...${funding_account_address: -5}"
+        echo "mob -y send ${account} ${amount_minus_fee} ${token} ..."
+        # I think there can be a timing issue when sending funds. If full-service has not yet polled the network, it
+        # might think its in sync, but might have transactions pending.  As a work around, we will retry sending.
+        while ! target_mob -y send "${account}" "${amount_minus_fee}" "${token}" "${funding_account_address}"
+        do
+            sleep 5
+            echo "INFO: retrying send"
+            counter=$((counter+1))
+            if ((counter > 5))
+            then
+                echo "ERROR: out of retries - failed to send leftover funds back to funding account"
+                exit 1
+            fi
+        done
+    fi
+done <<< "${balances}"
+
+echo "INFO: remove wallet file"
+rm "${MC_WALLET_FILE}"
+
+popd > /dev/null
+
+if ((test_success == 0))
+then
+    echo "ERROR: tests failed"
+    exit 1
+fi


### PR DESCRIPTION
### Motivation

Create a wrapper around the python integration tests to make funding running tests easier.

- ./tools/test-python-integration.sh - wrapper to setup, fund, run and return leftover funds.
- Improve some outputs for the mob full-service cli tool.
  - 'balance' command for easier to parse balance output
  - 'export' command now accepts a flag for file name and path to save export json.
  - 'list' accepts optional flag to output a single account
- Reduce funds required for test runs.
  - Test runs now transfer 0.001 MOB
  - Funding request is 0.02.  reduces the amount of lost mob if something goes wrong and clean up steps cannot complete.
- Create and fund new wallets for each test runs.  The old saved wallets took over 30s to sync.  Tests would timeout and fail while waiting for sync to complete.
- Fund wallet from "FUNDING" full-service running in private network of the dev cluster.  These wallets have minimal funding. Contact Ops for refills. 
- update .devcontainer to use host network so we can share localhost with port-forwarding or other full-service instances for funding. 

### Local Testing

Integration tests can be run locally with the `tools/test-python-integration.sh` script.  This script is configured with a _funding_ full-service instance with a _funding_ account id and a _target_ full-service instance.  The intention is to port-forward the funding instances of `dev-wallet-testnet` and `dev-wallet-mainnet` instances to localhost.

The test script will 
1. Check that both _target_ and _funding_ full-service instances are available and environment is sane. 
2. create a new account on the _target_ 
3. fund that new account from _funding_
4. export and delete account on _target_
5. run python tests
6. look for leftover funds and return all funds to _funding_ account.
7. remove exported account file

**Warning:** Since the python tests create random accounts, the test script will scan the _target_ full-service and attempt to send the remaining funds from any accounts still configured on the test full-service to the _funding_ account.

**Usage**
```
tools/test-python-integration.sh <network>
    <network> - main|prod|test
Environment Variables:
    FUNDING_FS_URL - optional: URL of the funding full-service
    FUNDING_ACCOUNT_ID - optional: account_id of the funding account
    TARGET_FS_URL - optional: URL of the full-service we want to test
```

- `FUNDING_FS_URL` defaults to `http://localhost:9091/wallet/v2` for Testnet and `http://localhost:9092/wallet/v2`
- `FUNDING_ACCOUNT_ID` - see script. These accounts are configured in the dev cluster and funded with a small amount of MOB for testing. 
- `TARGET_FS_URL`  defaults to `http://localhost:9090/wallet/v2` - this is FS instance you want to test

### Automated Testing
 
For automated tests we launch Testnet and Mainnet copies of the current container build in the `development` cluster.  These instances clone their ledger volume and database from existing volumes that are kept up to date by a nightly cronjob.  This saves 10+ minuets on each run over copying the ledger in from scratch or a blob storage backup.