### PR TITLE
Fix transaction logs incorrectly marked successful

### DIFF
--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -777,16 +777,16 @@ impl TransactionLogModel for TransactionLog {
     }
 
     fn update_pending_associated_with_txo_to_succeeded(
-        txo_id_hex: &str,
+        txo_out_id_hex: &str,
         finalized_block_index: u64,
         conn: Conn,
     ) -> Result<(), WalletDbError> {
-        use crate::db::schema::{transaction_input_txos, transaction_logs};
+        use crate::db::schema::{transaction_logs, transaction_output_txos};
         // Find all submitted transaction logs associated with this txo that have not
         // yet been finalized (there should only ever be one).
         let transaction_log_ids: Vec<String> = transaction_logs::table
-            .inner_join(transaction_input_txos::table)
-            .filter(transaction_input_txos::txo_id.eq(txo_id_hex))
+            .inner_join(transaction_output_txos::table)
+            .filter(transaction_output_txos::txo_id.eq(txo_out_id_hex))
             .filter(transaction_logs::submitted_block_index.is_not_null()) // we actually sent this transaction
             .filter(transaction_logs::failed.eq(false)) // non-failed transactions
             .filter(transaction_logs::finalized_block_index.is_null()) // non-completed transactions

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -777,7 +777,7 @@ impl TransactionLogModel for TransactionLog {
     }
 
     fn update_pending_associated_with_txo_to_succeeded(
-        txo_out_id_hex: &str,
+        transaction_output_txo_id_hex: &str,
         finalized_block_index: u64,
         conn: Conn,
     ) -> Result<(), WalletDbError> {
@@ -786,7 +786,7 @@ impl TransactionLogModel for TransactionLog {
         // yet been finalized (there should only ever be one).
         let transaction_log_ids: Vec<String> = transaction_logs::table
             .inner_join(transaction_output_txos::table)
-            .filter(transaction_output_txos::txo_id.eq(txo_out_id_hex))
+            .filter(transaction_output_txos::txo_id.eq(transaction_output_txo_id_hex))
             .filter(transaction_logs::submitted_block_index.is_not_null()) // we actually sent this transaction
             .filter(transaction_logs::failed.eq(false)) // non-failed transactions
             .filter(transaction_logs::finalized_block_index.is_null()) // non-completed transactions


### PR DESCRIPTION
Previously `transaction_log`s were marked successful if the input TXO(s)
were spent according to the block chain. This was problematic when
multiple `transaction_log`s were created that utilized the same input
TXOs. These `transaction_log`s using the same input TXOs could happen
when two clients were talking to the same Full-Service instance and
those clients were using two step build and submit:

1. Client_a sends `build_transaction`, input TXO_n is used
2. Client_b sends `build_transaction`, input TXO_n is also used
3. Client_a `submit_transaction`
4. Client_b `submit_transaction` before the block chain knows that the
   Client_a transaction exists and will consume `TXO_n`. The blockchain
   will still reject this transaction eventually.
5. Previously, Full-Service would see that input TXO_n has been consumed
   and will mark **all** submitted `transaction_log`s that used TXO_n as
   successful.

Now `transaction_log`s are marked successful based on if their output
TXO(s) land on the blockchain. This ensures that only the transaction
log that the blockchain accepted will be marked as successful.
