### PR TITLE
Improved wallet sync performance

### DIFF
--- a/full-service/migrations/2025-01-06-033047_add_index_for_account_id_and_spent_block_index_to_txos/down.sql
+++ b/full-service/migrations/2025-01-06-033047_add_index_for_account_id_and_spent_block_index_to_txos/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX idx_txos__account_id_spent_block_index;

--- a/full-service/migrations/2025-01-06-033047_add_index_for_account_id_and_spent_block_index_to_txos/up.sql
+++ b/full-service/migrations/2025-01-06-033047_add_index_for_account_id_and_spent_block_index_to_txos/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+CREATE INDEX idx_txos__account_id_spent_block_index on txos (account_id,spent_block_index);

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -2336,12 +2336,18 @@ mod tests {
 
         assert_eq!(ledger_db.num_blocks().unwrap(), 18);
 
+        // make sure the tests were set up correctly
+        assert_ne!(
+            first_account_first_tx_log.submitted_block_index,
+            first_account_second_tx_log.submitted_block_index
+        );
         assert_ne!(
             first_account_first_tx_log.submitted_block_index,
             second_account_tx_log.submitted_block_index
         );
         assert_ne!(first_account_id.to_string(), second_account_id.to_string());
 
+        // chceck that the results are as expected prior to syncing
         assert_eq!(
             TransactionLog::lowest_pending_block_index(&first_account_id, conn).unwrap(),
             Some(first_account_first_tx_log.submitted_block_index.unwrap() as u64)
@@ -2351,9 +2357,11 @@ mod tests {
             Some(second_account_tx_log.submitted_block_index.unwrap() as u64)
         );
 
+        // sync the accounts
         let _sync = manually_sync_account(&ledger_db, &wallet_db, &first_account_id, &logger);
         let _sync = manually_sync_account(&ledger_db, &wallet_db, &second_account_id, &logger);
 
+        // check that the results are as expected after syncing
         assert_eq!(
             TransactionLog::lowest_pending_block_index(&first_account_id, conn).unwrap(),
             None
@@ -2362,7 +2370,6 @@ mod tests {
             TransactionLog::lowest_pending_block_index(&second_account_id, conn).unwrap(),
             None
         );
-
         let updated_tx_log =
             TransactionLog::get(&TransactionId::from(&first_account_first_tx_log), conn).unwrap();
         assert_eq!(updated_tx_log.status(), TxStatus::Succeeded);

--- a/full-service/src/db/transaction_log.rs
+++ b/full-service/src/db/transaction_log.rs
@@ -342,6 +342,22 @@ pub trait TransactionLogModel {
         conn: Conn,
     ) -> Result<(), WalletDbError>;
 
+    /// Return the lowest block_index associated with an account's pending transactions, as tracked in this wallet db.
+    /// 
+    /// # Arguments
+    ///
+    ///| Name                   | Purpose                                                 | Notes                               |
+    ///|------------------------|---------------------------------------------------------|-------------------------------------|
+    ///| `account_id`           | The account id to scan for transaction logs.            | Account must exist in the database. |
+    ///| `conn`                 | An reference to the pool connection of wallet database  |                                     |
+    /// 
+    /// # Returns
+    /// * None if no pending transactions from account_id, or
+    ///   Some<u64> that is the submitted_block_index of the oldest pending tx.
+    fn lowest_pending_block_index(
+        account_id: &AccountID,
+        conn: Conn,
+    ) -> Result<Option<u64>, WalletDbError>;
 
     /// Update all transaction logs that have an input transaction corresponding to
     /// `transaction_input_txo_id_hex` to failed.
@@ -776,6 +792,27 @@ impl TransactionLogModel for TransactionLog {
         .execute(conn)?;
 
         Ok(())
+    }
+
+    fn lowest_pending_block_index(
+        account_id: &AccountID,
+        conn: Conn,
+    ) -> Result<Option<u64>, WalletDbError> {
+        let lowest_pending_submitted_block_index: Vec<Option<i64>> = transaction_logs::table
+            .filter(transaction_logs::account_id.eq(&account_id.0))
+            .filter(transaction_logs::submitted_block_index.is_not_null())
+            .filter(transaction_logs::failed.eq(false)) // non-failed transactions
+            .filter(transaction_logs::finalized_block_index.is_null())
+            .select(diesel::dsl::min(transaction_logs::submitted_block_index))
+            .load(conn)?;
+
+        if lowest_pending_submitted_block_index.len() == 0
+            || lowest_pending_submitted_block_index[0].is_none()
+        {
+            Ok(None)
+        } else {
+            Ok(Some(lowest_pending_submitted_block_index[0].unwrap() as u64))
+        }
     }
 
     fn update_pending_associated_with_txo_to_succeeded(
@@ -2122,5 +2159,220 @@ mod tests {
         for tx_log in &updated_transaction_logs[1..] {
             assert_eq!(tx_log.status(), TxStatus::Pending);
         }
+    }
+
+    #[async_test_with_logger]
+    async fn test_lowest_pending_block_index(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
+
+        let db_test_context = WalletDbTestContext::default();
+        let wallet_db = db_test_context.get_db_instance(logger.clone());
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let first_account_key = random_account_with_seed_values(
+            &wallet_db,
+            &mut ledger_db,
+            &[70 * MOB, 75 * MOB],
+            &mut rng,
+            &logger,
+        );
+        let first_account_id = AccountID::from(&first_account_key);
+
+        let second_account_key = random_account_with_seed_values(
+            &wallet_db,
+            &mut ledger_db,
+            &[80 * MOB],
+            &mut rng,
+            &logger,
+        );
+        let second_account_id = AccountID::from(&second_account_key);
+
+        // Build a first transaction from first_account
+        let mut pooled_conn = wallet_db.get_pooled_conn().unwrap();
+        let conn = pooled_conn.deref_mut();
+
+        let account = Account::get(&first_account_id, conn).unwrap();
+
+        let (recipient, mut builder) =
+            builder_for_random_recipient(&first_account_key, &ledger_db, &mut rng);
+        builder
+            .add_recipient(recipient.clone(), 50 * MOB, Mob::ID)
+            .unwrap();
+        builder.set_tombstone(0).unwrap();
+        builder.select_txos(conn, None).unwrap();
+        let unsigned_tx_proposal = builder
+            .build(
+                TransactionMemo::RTH {
+                    subaddress_index: None,
+                },
+                conn,
+            )
+            .unwrap();
+        let tx_proposal = unsigned_tx_proposal.clone().sign(&account).await.unwrap();
+
+        // Log submitted transaction from tx_proposal
+        let first_account_first_tx_log = TransactionLog::log_submitted(
+            &tx_proposal,
+            ledger_db.num_blocks().unwrap(),
+            "".to_string(),
+            &first_account_id.to_string(),
+            conn,
+        )
+        .unwrap();
+
+        let key_images: Vec<KeyImage> = tx_proposal
+            .input_txos
+            .iter()
+            .map(|txo| txo.key_image)
+            .collect();
+
+        // Note: This block doesn't contain the fee output.
+        add_block_with_tx_outs(
+            &mut ledger_db,
+            &[
+                tx_proposal.change_txos[0].tx_out.clone(),
+                tx_proposal.payload_txos[0].tx_out.clone(),
+            ],
+            &key_images,
+            &mut rng,
+        );
+
+        assert_eq!(ledger_db.num_blocks().unwrap(), 16);
+
+        // Build a second transaction from first_account
+        let (recipient, mut builder) =
+            builder_for_random_recipient(&first_account_key, &ledger_db, &mut rng);
+        builder
+            .add_recipient(recipient.clone(), 45 * MOB, Mob::ID)
+            .unwrap();
+        builder.set_tombstone(0).unwrap();
+        builder.select_txos(conn, None).unwrap();
+        let unsigned_tx_proposal = builder
+            .build(
+                TransactionMemo::RTH {
+                    subaddress_index: None,
+                },
+                conn,
+            )
+            .unwrap();
+        let tx_proposal = unsigned_tx_proposal.clone().sign(&account).await.unwrap();
+
+        // Log submitted transaction from tx_proposal
+        let first_account_second_tx_log = TransactionLog::log_submitted(
+            &tx_proposal,
+            ledger_db.num_blocks().unwrap(),
+            "".to_string(),
+            &first_account_id.to_string(),
+            conn,
+        )
+        .unwrap();
+
+        let key_images: Vec<KeyImage> = tx_proposal
+            .input_txos
+            .iter()
+            .map(|txo| txo.key_image)
+            .collect();
+
+        // Note: This block doesn't contain the fee output.
+        add_block_with_tx_outs(
+            &mut ledger_db,
+            &[
+                tx_proposal.change_txos[0].tx_out.clone(),
+                tx_proposal.payload_txos[0].tx_out.clone(),
+            ],
+            &key_images,
+            &mut rng,
+        );
+
+        assert_eq!(ledger_db.num_blocks().unwrap(), 17);
+
+        // build a transaction from second_account
+        let account = Account::get(&second_account_id, conn).unwrap();
+
+        let (recipient, mut builder) =
+            builder_for_random_recipient(&second_account_key, &ledger_db, &mut rng);
+        builder
+            .add_recipient(recipient.clone(), 55 * MOB, Mob::ID)
+            .unwrap();
+        builder.set_tombstone(0).unwrap();
+        builder.select_txos(conn, None).unwrap();
+        let unsigned_tx_proposal = builder
+            .build(
+                TransactionMemo::RTH {
+                    subaddress_index: None,
+                },
+                conn,
+            )
+            .unwrap();
+        let tx_proposal = unsigned_tx_proposal.clone().sign(&account).await.unwrap();
+
+        // Log submitted transaction from tx_proposal
+        let second_account_tx_log = TransactionLog::log_submitted(
+            &tx_proposal,
+            ledger_db.num_blocks().unwrap(),
+            "".to_string(),
+            &second_account_id.to_string(),
+            conn,
+        )
+        .unwrap();
+
+        let key_images: Vec<KeyImage> = tx_proposal
+            .input_txos
+            .iter()
+            .map(|txo| txo.key_image)
+            .collect();
+
+        // Note: This block doesn't contain the fee output.
+        add_block_with_tx_outs(
+            &mut ledger_db,
+            &[
+                tx_proposal.change_txos[0].tx_out.clone(),
+                tx_proposal.payload_txos[0].tx_out.clone(),
+            ],
+            &key_images,
+            &mut rng,
+        );
+
+        assert_eq!(ledger_db.num_blocks().unwrap(), 18);
+
+        assert_ne!(
+            first_account_first_tx_log.submitted_block_index,
+            second_account_tx_log.submitted_block_index
+        );
+        assert_ne!(first_account_id.to_string(), second_account_id.to_string());
+
+        assert_eq!(
+            TransactionLog::lowest_pending_block_index(&first_account_id, conn).unwrap(),
+            Some(first_account_first_tx_log.submitted_block_index.unwrap() as u64)
+        );
+        assert_eq!(
+            TransactionLog::lowest_pending_block_index(&second_account_id, conn).unwrap(),
+            Some(second_account_tx_log.submitted_block_index.unwrap() as u64)
+        );
+
+        let _sync = manually_sync_account(&ledger_db, &wallet_db, &first_account_id, &logger);
+        let _sync = manually_sync_account(&ledger_db, &wallet_db, &second_account_id, &logger);
+
+        assert_eq!(
+            TransactionLog::lowest_pending_block_index(&first_account_id, conn).unwrap(),
+            None
+        );
+        assert_eq!(
+            TransactionLog::lowest_pending_block_index(&second_account_id, conn).unwrap(),
+            None
+        );
+
+        let updated_tx_log =
+            TransactionLog::get(&TransactionId::from(&first_account_first_tx_log), conn).unwrap();
+        assert_eq!(updated_tx_log.status(), TxStatus::Succeeded);
+
+        let updated_tx_log =
+            TransactionLog::get(&TransactionId::from(&first_account_second_tx_log), conn).unwrap();
+        assert_eq!(updated_tx_log.status(), TxStatus::Succeeded);
+
+        let updated_tx_log =
+            TransactionLog::get(&TransactionId::from(&second_account_tx_log), conn).unwrap();
+        assert_eq!(updated_tx_log.status(), TxStatus::Succeeded);
     }
 }

--- a/full-service/src/service/receipt.rs
+++ b/full-service/src/service/receipt.rs
@@ -319,6 +319,7 @@ mod tests {
     use mc_account_keys::{AccountKey, PublicAddress};
     use mc_common::logger::{async_test_with_logger, Logger};
     use mc_crypto_keys::{ReprBytes, RistrettoPrivate, RistrettoPublic};
+    use mc_ledger_db::Ledger;
     use mc_rand::RngCore;
     use mc_transaction_core::{ring_signature::KeyImage, tokens::Mob, tx::TxOut, Amount, Token};
     use mc_transaction_types::BlockVersion;
@@ -591,7 +592,7 @@ mod tests {
         // Land the Txo in the ledger - only sync for the sender
         TransactionLog::log_submitted(
             &tx_proposal,
-            14,
+            ledger_db.num_blocks().unwrap(),
             "".to_string(),
             &alice.id,
             service.get_pooled_conn().unwrap().deref_mut(),
@@ -711,7 +712,7 @@ mod tests {
         // Land the Txo in the ledger - only sync for the sender
         TransactionLog::log_submitted(
             &tx_proposal0,
-            14,
+            ledger_db.num_blocks().unwrap(),
             "".to_string(),
             &alice.id,
             service.get_pooled_conn().unwrap().deref_mut(),
@@ -859,7 +860,7 @@ mod tests {
         // Land the Txo in the ledger - only sync for the sender
         TransactionLog::log_submitted(
             &tx_proposal0,
-            14,
+            ledger_db.num_blocks().unwrap(),
             "".to_string(),
             &alice.id,
             service.get_pooled_conn().unwrap().deref_mut(),

--- a/full-service/src/service/sync.rs
+++ b/full-service/src/service/sync.rs
@@ -9,7 +9,7 @@ use crate::{
         exclusive_transaction,
         models::{Account, AssignedSubaddress, TransactionLog, Txo},
         transaction_log::TransactionLogModel,
-        txo::TxoModel,
+        txo::{TxoID, TxoModel},
         Conn, WalletDb,
     },
     error::SyncError,
@@ -230,17 +230,28 @@ pub fn sync_account_next_chunk(
             (*account_key.view_private_key(), Some(account_key))
         };
 
-        tx_outs.iter().try_for_each(|(block_index, tx_out)| {
-            let txos = Txo::select_by_public_key(&[&tx_out.public_key], conn).unwrap();
-            txos.iter().try_for_each(|txo| {
+        let setup_time = Instant::now();
+
+        let lowest_pending_block_index =
+            TransactionLog::lowest_pending_block_index(&account_id, conn)?;
+        if lowest_pending_block_index.is_some()
+            && start_block_index <= lowest_pending_block_index.unwrap()
+        {
+            // log::debug!(logger, "marking landed txs as succeeded");
+            tx_outs.iter().try_for_each(|(block_index, tx_out)| {
                 TransactionLog::update_pending_associated_with_txo_to_succeeded(
-                    &txo.id,
+                    &TxoID::from(tx_out).to_string(),
                     *block_index,
                     conn,
                 )
-            })
-        })?;
+            })?;
+        } else {
+            // log::debug!(logger, "skipping tlog success update",);
+        };
 
+        let succeeded_time = Instant::now();
+
+        let num_scanned_txos = tx_outs.len();
         // Attempt to decode each transaction as received by this account.
         let received_txos: Vec<_> = tx_outs
             .into_par_iter()
@@ -270,6 +281,8 @@ pub fn sync_account_next_chunk(
 
         let num_received_txos = received_txos_with_subaddresses_and_key_images.len();
 
+        let view_key_scanned_time = Instant::now();
+
         // Write received transactions to the database.
         for (block_index, tx_out, amount, subaddress_index, key_image) in
             received_txos_with_subaddresses_and_key_images
@@ -285,9 +298,16 @@ pub fn sync_account_next_chunk(
             )?;
         }
 
+        let received_txos_to_db_time = Instant::now();
+
         // Match key images to mark existing unspent transactions as spent.
+        // Note: on a wallet_db with many txos, importing an additional account, this is
+        // the most expensive part of the sync. 
         let unspent_key_images: MCHashMap<KeyImage, String> =
             Txo::list_unspent_or_pending_key_images(account_id_hex, None, conn)?;
+        
+        let looked_up_key_images_time = Instant::now();
+
         let spent_txos: Vec<(u64, String)> = key_images
             .into_par_iter()
             .filter_map(|(block_index, key_image)| {
@@ -297,6 +317,8 @@ pub fn sync_account_next_chunk(
             })
             .collect();
 
+        let matched_key_images_time = Instant::now();
+
         for (block_index, txo_id_hex) in &spent_txos {
             Txo::update_spent_block_index(txo_id_hex, *block_index, conn)?;
             // NB: This needs to be done after calling
@@ -305,11 +327,15 @@ pub fn sync_account_next_chunk(
             TransactionLog::update_consumed_txo_to_failed(txo_id_hex, conn)?;
         }
 
+        let marked_spent_time = Instant::now();
+        
         TransactionLog::update_pending_exceeding_tombstone_block_index_to_failed(
             &account_id,
             end_block_index + 1,
             conn,
         )?;
+
+        let marked_failed_time = Instant::now();
 
         // Done syncing this chunk. Mark these blocks as synced for this account.
         account.update_next_block_index(end_block_index + 1, conn)?;
@@ -320,15 +346,30 @@ pub fn sync_account_next_chunk(
 
         log::debug!(
             logger,
-            "Synced {} blocks ({}-{}) for account {} in {:?}. {} txos received, {}/{} txos spent.",
+            "Synced {} blocks ({}-{}) for account {} in {:?}. {}/{} txos received, {}/{} txos spent.",
             num_blocks_synced,
             start_block_index,
             end_block_index,
             account_id_hex.chars().take(6).collect::<String>(),
             duration,
             num_received_txos,
+            num_scanned_txos,
             spent_txos.len(),
             unspent_key_images.len()
+        );
+
+        log::debug!(
+            logger,
+            "total {:?}, setup {:?}, succeeded {:?}, view_key_scanned {:?}, received_txos_to_db {:?}, looked_up_key_images {:?}, matched_key_images {:?}, marked_spent {:?}, marked_failed {:?}",
+            start_time.elapsed(),
+            setup_time-start_time,
+            succeeded_time-setup_time,
+            view_key_scanned_time-succeeded_time,
+            received_txos_to_db_time-view_key_scanned_time,
+            looked_up_key_images_time-received_txos_to_db_time,
+            matched_key_images_time-looked_up_key_images_time,
+            marked_spent_time-matched_key_images_time,
+            marked_failed_time-marked_spent_time,
         );
 
         Ok(num_received_txos)


### PR DESCRIPTION
### Motivation

Since PR #1027, a performance issue has been noted when syncing a wallet-db that has a large number of `txos` tracked within. This is due to looking up the `txo_id` of each txo as it is synced from the ledger via the `txos` table using the `public_key` column, which is not indexed.

### In this PR
* when scanning the `transaction_logs` to see if a `txo` appearing in the ledger means a corresponding `transaction_log` entry should be transitioned from `pending` to `succeeded`, calculate the `txo_id` (which is a digest of the `txo` data that appeared in the ledger, rather than looking it up in the `txos` table by `public_key`. This significantly relieved the performance issue, lowering sync times by several orders of magnitude.
* to further increase sync throughput for imported (and re-syncing) accounts, a check was added to only do the above part of the sync when the account has pending transactions in `transaction_log`, and at least one of those transactions was submitted prior to the chunk of the ledger being synced was "mined."
* during debugging, it was also noted that a good deal of time was being spent in the part of the sync loop where unspent `txos` were being checked against incoming `key_images` to see if they should be marked as spent.  Further exploration indicated that an index of (`account_id`, `spent_block_index`) would greatly speed up the SQL query that returned all of the unspent `key_images` for an account, and this PR adds that index via a migration.

