### PR TITLE
Cleanup validate_proof_of_reserve_sci result

### DIFF
--- a/full-service/src/json_rpc/v2/api/response.rs
+++ b/full-service/src/json_rpc/v2/api/response.rs
@@ -218,6 +218,7 @@ pub enum JsonCommandResponse {
         validated: bool,
     },
     validate_proof_of_reserve_sci {
+        #[serde(flatten)]
         result: ValidateProofOfReserveSciResult,
     },
     verify_address {

--- a/full-service/src/json_rpc/v2/models/signed_contingent_input.rs
+++ b/full-service/src/json_rpc/v2/models/signed_contingent_input.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// A result of a call to the validate_proof_of_reserve_sci JSON-RPC method.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-#[serde(tag = "result")]
+#[serde(tag = "status", rename_all = "snake_case")]
 pub enum ValidateProofOfReserveSciResult {
     /// The signed contingent input is valid.
     Valid {


### PR DESCRIPTION
### Motivation

@nick-mobilecoin reminded me that I can use `#[serde(flatten)]` to simplify the result returned from the `validate_proof_of_reserve_sci` API call.
After this change, the response looks like this:
```
{
  "method": "validate_proof_of_reserve_sci",
  "result": {
    "status": "valid",
    "tx_out_public_key": "d6c9f4eeb819db2d6e5f28098fd9a2ceda42a06efe6c4707c761ff8a57e10508",
    "key_image": "6e1e88d267ab9914faa9ff7ff838eef4d9ac5a00727e67ebf69c64e0deac6367",
    "amount": {
      "value": "5555155555555",
      "token_id": "0"
    }
  },
  "jsonrpc": "2.0",
  "id": 1
}
```

Which i nicer.

### In this PR
Small changes to the response type for the `validate_proof_of_reserve_sci` method.
