### PR TITLE
(SENTZ-3883) fix get_account_status to calculate secreted balance per-token_id

### DIFF
--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -77,3 +77,7 @@ runs:
       echo "AUTH_KEY_PATH=${AUTH_KEY_PATH}" >> "${GITHUB_ENV}"
       echo "CERTIFICATE_PATH=${CERTIFICATE_PATH}" >> "${GITHUB_ENV}"
       echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
+
+      # debugging -- list a fragment of code signing identities
+      security find-identity -v -p codesigning | head -1 | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'
+      

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -79,5 +79,5 @@ runs:
       echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
 
       # debugging -- list a fragment of code signing identities
-      security find-identity -v -p codesigning | head -1 | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'
-      
+      echo "-- debug code signing identities"
+      security find-identity -v -p codesigning | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -25,6 +25,12 @@ runs:
       rm -rf "$(brew --prefix)/var/homebrew/locks"
       brew bundle --quiet
 
+      echo "-- install cmake"
+      curl -LO https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-macos-universal.tar.gz
+      tar -xzf cmake-3.31.7-macos-universal.tar.gz
+      sudo mv cmake-3.31.7-macos-universal /opt/cmake-3.31.7
+      echo "/opt/cmake-3.31.7/bin" >> "${GITHUB_PATH}"
+
       echo "-- install rust toolchain"
       rm -rf /Users/runner/.cargo
       rm -rf /Users/runner/.rustup

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -80,4 +80,5 @@ runs:
 
       # debugging -- list a fragment of code signing identities
       echo "-- debug code signing identities"
+      security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
       security find-identity -v -p codesigning "${KEYCHAIN_PATH}" | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -77,8 +77,3 @@ runs:
       echo "AUTH_KEY_PATH=${AUTH_KEY_PATH}" >> "${GITHUB_ENV}"
       echo "CERTIFICATE_PATH=${CERTIFICATE_PATH}" >> "${GITHUB_ENV}"
       echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
-
-      # debugging -- list a fragment of code signing identities
-      echo "-- debug code signing identities"
-      security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
-      security find-identity -v -p codesigning "${KEYCHAIN_PATH}" | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -80,4 +80,4 @@ runs:
 
       # debugging -- list a fragment of code signing identities
       echo "-- debug code signing identities"
-      security find-identity -v -p codesigning | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'
+      security find-identity -v -p codesigning "${KEYCHAIN_PATH}" | awk '{print substr($2, 1, 4) "..." substr($2, length($2)-3)}'

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -97,7 +97,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        cargo install cargo-sort --force
+        # pin cargo sort to version 1.0.9 because v2.x require newer rustc than we use
+        cargo install cargo-sort --version 1.0.9 --force
         cargo sort --workspace --grouped --check
 
     - name: Cargo fmt

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 # Build dependencies
-brew 'cmake'
 brew 'go'
 brew 'llvm'
 brew 'protobuf'

--- a/full-service/src/service/balance.rs
+++ b/full-service/src/service/balance.rs
@@ -410,7 +410,7 @@ where
             conn,
         )?);
 
-        let secreted = sum_query_result(Txo::list_secreted(account_id_hex, conn)?);
+        let secreted = sum_query_result(Txo::list_secreted(account_id_hex, Some(*token_id), conn)?);
 
         let orphaned = if public_address_b58.is_some() {
             0


### PR DESCRIPTION
### Motivation

The get_account_status method is
1. adding together the secreted txo balances across token_ids
2. reporting that same, blended balance repeatedly under each token_id’s block in the response

Instead, it should report a separate secreted total amount for each token_id as that token_id’s secreted balance.

It especially doesn’t make sense to sum this quantity across token_ids as the amounts are in native units for each token_id, which differs from token_id to token_id.

### In this PR
* add optional `token_id` parameter to `list_secreted` txo lookup
* pass through the `token_id` from functions calling `list_secreted` as appropriate
* update `test_received_txo_lifecycle` detect regression

### Test Plan

1. updated `db::txo::tests::test_received_txo_lifecycle` test as per above
2. did test on prod build on account with both MOB and eUSD
   * previously combined secreted balances and showed same secreted value for both tokens
   * now shows different, correct, secreted balances for each
   * still returns all secreted txos via` get_txos` method

### Other
Updated MacOS CI to:
* pin cargo sort to 1.0.9 because newer versions require update to rustc
* pin cmake to 3.31.7 for compatibility with mbedtls crates