### PR TITLE
fix migration of pre-v2 db subaddress spend_public_key storage format

### DIFF
--- a/full-service/src/db/wallet_db.rs
+++ b/full-service/src/db/wallet_db.rs
@@ -235,9 +235,12 @@ impl WalletDb {
                 &assigned_subaddress.spend_public_key,
             ) {
                 Ok(spend_public_key) => spend_public_key.to_bytes().to_vec(),
-                Err(_) => {
-                    global_log::debug!(
-                        "Assigned subaddress proto conversion already done, skipping..."
+                Err(e) => {
+                    global_log::error!(
+                        "Assigned subaddress_index {} of account_id {} proto conversion failed: {:?}, discontinuing scan", 
+                        assigned_subaddress.subaddress_index,
+                        assigned_subaddress.account_id,
+                        e
                     );
                     return;
                 }


### PR DESCRIPTION
### Motivation

From v1.x to v2.x, full-service changed how it stores subaddress` spend_public_keys` in the `wallet-db`, used for subaddress matching to remove an unnecessary protobuf data type prefix.

On start-up full-service starts converting this column in the `assigned_subaddresses` table, unless it detects that the conversion is unnecessary.

However, the check currently in full-service relies on the protobuf parser throwing an err to decide that the conversion is not needed. This is insufficient as raw `spend_public_keys` can randomly pass protobuf parsing simple due to their byte values.

### In this PR

This PR updates the converter to explicitly check for a length of 34 bytes and a prefix of 0x0a20 before converting a key, as this is the specific length and prefix on all entries in a pre-v2.0.0 `assigned_subaddresses.spend_public_key` column. As of v2.0.0 the length of the stored data will be 32 bytes but could still start with 0x0a20 or some other valid protobuf field designation. Thus the length check is absolutely essential to preventing converting a valid post-v2.0.0 raw `spend_public_key` into an incorrect value, causing that subaddresses txos to be orphaned.
