### PR TITLE
pin enclave measurements download version

### DIFF
--- a/.github/actions/build-rust/action.yaml
+++ b/.github/actions/build-rust/action.yaml
@@ -8,6 +8,9 @@ inputs:
   version:
     description: "version of the build"
     required: true
+  enclave_release_tag:
+    description: "tag of the enclave release to download sigstruct for"
+    required: true
   target:
     description: "cargo target to build for"
     required: false
@@ -72,6 +75,7 @@ runs:
     with:
       sigstruct: consensus
       network: ${{ inputs.network }}
+      enclave_release_tag: ${{ inputs.enclave_release_tag }}
       download_path: ${{ env.CONSENSUS_ENCLAVE_CSS }}
 
   - name: Ingest SigStruct
@@ -79,6 +83,7 @@ runs:
     with:
       sigstruct: ingest
       network: ${{ inputs.network }}
+      enclave_release_tag: ${{ inputs.enclave_release_tag }}
       download_path: ${{ env.INGEST_ENCLAVE_CSS }}
 
   - name: Cache Rust Binaries

--- a/.github/actions/download-sigstruct/action.yaml
+++ b/.github/actions/download-sigstruct/action.yaml
@@ -5,6 +5,9 @@ inputs:
   sigstruct:
     description: "name of sigstruct consensus|ingest|view|ledger"
     required: true
+  enclave_release_tag:
+    description: "tag of the enclave release to download sigstruct for"
+    required: true
   network:
     description: "network to download sigstruct from main|test"
     required: true
@@ -29,6 +32,7 @@ runs:
       NETWORK="${{ inputs.network }}"
       SIGSTRUCT_NAME="${{ inputs.sigstruct }}"
       DOWNLOAD_PATH="${{ inputs.download_path }}"
+      ENCLAVE_RELEASE_TAG="${{ inputs.enclave_release_tag }}"
 
       # set network to prod if main
       if [[ "${NETWORK}" == "main" ]]; then
@@ -36,7 +40,7 @@ runs:
       fi
 
       CSS_BASE_URL="https://enclave-distribution.${NETWORK}.mobilecoin.com"
-      SIGSTRUCT_URI=$(curl -fsSL "${CSS_BASE_URL}/production.json" | jq -r ".${SIGSTRUCT_NAME}.sigstruct")
+      SIGSTRUCT_URI=$(curl -fsSL "${CSS_BASE_URL}/production-${ENCLAVE_RELEASE_TAG}.json" | jq -r ".${SIGSTRUCT_NAME}.sigstruct")
 
       mkdir -p "$(dirname "${DOWNLOAD_PATH}")"
       curl -fL --retry 3 "${CSS_BASE_URL}/${SIGSTRUCT_URI}" -o "${DOWNLOAD_PATH}"

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -23,6 +23,7 @@ env:
   RUST_BIN_PATH: placeholder
   CONSENSUS_ENCLAVE_CSS: /var/tmp/consensus-enclave.css
   INGEST_ENCLAVE_CSS: /var/tmp/ingest-enclave.css
+  ENCLAVE_RELEASE_TAG: v6.0.0
 
 jobs:
   meta:
@@ -74,6 +75,7 @@ jobs:
       with:
         sigstruct: consensus
         network: test
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         download_path: ${{ env.CONSENSUS_ENCLAVE_CSS }}
 
     - name: Ingest SigStruct
@@ -81,6 +83,7 @@ jobs:
       with:
         sigstruct: ingest
         network: test
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         download_path: ${{ env.INGEST_ENCLAVE_CSS }}
 
     # we don't need to cache the results, we just want an indication of test success
@@ -131,6 +134,7 @@ jobs:
       with:
         sigstruct: consensus
         network: test
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         download_path: ${{ env.CONSENSUS_ENCLAVE_CSS }}
 
     - name: Ingest SigStruct
@@ -138,6 +142,7 @@ jobs:
       with:
         sigstruct: ingest
         network: test
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         download_path: ${{ env.INGEST_ENCLAVE_CSS }}
 
     # we don't need to cache the results, we just want an indication of test success
@@ -187,6 +192,7 @@ jobs:
       with:
         network: ${{ matrix.network }}
         version: ${{ needs.meta.outputs.version }}
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         cache_buster: ${{ vars.CACHE_BUSTER }}
 
   build-rust-macos:
@@ -220,6 +226,7 @@ jobs:
         target: ${{ matrix.target }}
         network: ${{ matrix.network }}
         version: ${{ needs.meta.outputs.version }}
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         cache_buster: ${{ vars.CACHE_BUSTER }}
         codesign_identity: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         codesign_prefix: ${{ secrets.APPLE_CODESIGN_PREFIX }}

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  ENCLAVE_RELEASE_TAG: v6.0.0
+
 jobs:
   build-rust-linux:
     strategy:
@@ -31,6 +34,7 @@ jobs:
       with:
         network: ${{ matrix.network }}
         version: ${{ github.ref_name }}
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         cache_buster: ${{ vars.CACHE_BUSTER }}
 
   build-rust-macos:
@@ -62,6 +66,7 @@ jobs:
         target: ${{ matrix.target }}
         network: ${{ matrix.network }}
         version: ${{ github.ref_name }}
+        enclave_release_tag: ${{ env.ENCLAVE_RELEASE_TAG }}
         cache_buster: ${{ vars.CACHE_BUSTER }}
         codesign_identity: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         codesign_prefix: ${{ secrets.APPLE_CODESIGN_PREFIX }}

--- a/tools/.shared-functions.sh
+++ b/tools/.shared-functions.sh
@@ -2,6 +2,7 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 # Set of shared functions for full-service build, test and run tools.
 
+ENCLAVE_RELEASE_TAG=${ENCLAVE_RELEASE_TAG:-"v6.0.0"}
 GIT_BASE=$(git rev-parse --show-toplevel)
 AM_I_IN_MOB_PROMPT="no"
 
@@ -87,15 +88,18 @@ debug()
 }
 
 # get_css_file - download a specified enclave measurement css file
-#  1: css file name - consensus-enclave.css, ingest-enclave.css
+#  1: network
+#  2: enclave release tag
+#  3: css file name - consensus-enclave.css, ingest-enclave.css
 get_css_file()
 {
     net="${1}"
-    css_file="${2}"
+    enclave_tag="${2}"
+    css_file="${3}"
 
     # Default Variables - you can override these with environment var settings.
     CSS_BASE_URL=${CSS_BASE_URL:-"https://enclave-distribution.${net}.mobilecoin.com"}
-    CSS_JSON_FILE=${CSS_JSON_FILE:-"production.json"}
+    CSS_JSON_FILE=${CSS_JSON_FILE:-"production-${enclave_tag}.json"}
 
     # Get remote css
     debug "  Pulling index file from ${CSS_BASE_URL}/${CSS_JSON_FILE}"

--- a/tools/build-fs.sh
+++ b/tools/build-fs.sh
@@ -68,14 +68,14 @@ case ${net} in
     test)
         echo "Setting '${net}' SGX and enclave values"
         SGX_MODE=HW
-        CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/consensus-enclave.css")
-        INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/ingest-enclave.css")
+        CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/consensus-enclave.css")
+        INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/ingest-enclave.css")
         ;;
     main)
         echo "Setting '${net}' SGX and enclave values"
         SGX_MODE=HW
-        CONSENSUS_ENCLAVE_CSS=$(get_css_file prod "${RELEASE_DIR}/consensus-enclave.css")
-        INGEST_ENCLAVE_CSS=$(get_css_file prod "${RELEASE_DIR}/ingest-enclave.css")
+        CONSENSUS_ENCLAVE_CSS=$(get_css_file prod "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/consensus-enclave.css")
+        INGEST_ENCLAVE_CSS=$(get_css_file prod "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/ingest-enclave.css")
         ;;
     alpha)
         echo "Setting '${net}' SGX and enclave values"


### PR DESCRIPTION
### Motivation

Full-service relies on the `production.json` file for location of enclave measurements it should use as part of its build. We should use and pint to the versioned production file instead of assuming that latest is correct.

### In this PR
* Add logic to download the versioned copy of the enclave measurements.
* fix tools/build-fs.sh
* fix gha workflows



