### PR TITLE
update tools/test.sh to use version pinned enclave measurements

### DIFF
--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -30,7 +30,7 @@ runs:
       curl -LO https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-macos-universal.tar.gz
       tar -xzf cmake-3.31.7-macos-universal.tar.gz
       sudo mv cmake-3.31.7-macos-universal /opt/cmake-3.31.7
-      echo "/opt/cmake-3.31.7/bin" >> "${GITHUB_PATH}"
+      echo "/opt/cmake-3.31.7/CMake.app/Contents/bin" >> "${GITHUB_PATH}"
 
       echo "-- install rust toolchain"
       rm -rf /Users/runner/.cargo

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -26,6 +26,7 @@ runs:
       brew bundle --quiet
 
       echo "-- install cmake"
+      brew uninstall cmake || true
       curl -LO https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-macos-universal.tar.gz
       tar -xzf cmake-3.31.7-macos-universal.tar.gz
       sudo mv cmake-3.31.7-macos-universal /opt/cmake-3.31.7

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -44,6 +44,11 @@ runs:
       echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       echo "$(dirname "${rustup_cargo}")" >> "${GITHUB_PATH}"
 
+  - name: Select Xcode
+    uses: maxim-lobanov/setup-xcode@v1
+    with:
+      xcode-version: '15.4'
+
   - name: Setup ENV for signing and notarization
     env:
       BUILD_CERTIFICATE_BASE64: ${{ inputs.build_certificate_base64 }}

--- a/.github/actions/bootstrap-macos/action.yaml
+++ b/.github/actions/bootstrap-macos/action.yaml
@@ -44,11 +44,6 @@ runs:
       echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       echo "$(dirname "${rustup_cargo}")" >> "${GITHUB_PATH}"
 
-  - name: Select Xcode
-    uses: maxim-lobanov/setup-xcode@v1
-    with:
-      xcode-version: '15.4'
-
   - name: Setup ENV for signing and notarization
     env:
       BUILD_CERTIFICATE_BASE64: ${{ inputs.build_certificate_base64 }}

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -207,7 +207,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -207,7 +207,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -207,7 +207,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -47,7 +47,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -47,7 +47,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -47,7 +47,7 @@ jobs:
         network:
         - main
         - test
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -17,8 +17,8 @@ mkdir -p "${RELEASE_DIR:?}"
 debug "RELEASE_DIR: ${RELEASE_DIR}"
 
 SGX_MODE=HW
-CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/consensus-enclave.css")
-INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${RELEASE_DIR}/ingest-enclave.css")
+CONSENSUS_ENCLAVE_CSS=$(get_css_file "${net}" "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/consensus-enclave.css")
+INGEST_ENCLAVE_CSS=$(get_css_file "${net}" "${ENCLAVE_RELEASE_TAG}" "${RELEASE_DIR}/ingest-enclave.css")
 export SGX_MODE CONSENSUS_ENCLAVE_CSS INGEST_ENCLAVE_CSS
 
 echo "CONSENSUS_ENCLAVE_CSS: ${CONSENSUS_ENCLAVE_CSS}"


### PR DESCRIPTION
### Motivation

tools/test.sh, the script for locally running unit and integration tests, needs an update to work with the current tools/.shared-functions.sh, providing it the version of the measurements that are to be downloaded.

### In this PR
* update tools/test.sh to pass the version number of enclave measurements to download back to .shared-functions.sh's `get_css_file`. .shared-functions.sh now reads the version string to use out of the environment variable ENCLAVE_RELEASE_TAG and falls back to a hard-coded default version, currently v6.0.0, and this needs to be explicitly passed to `get_css_file`

This is a companion to merged PR #1049 