### PR TITLE
Rework TransactionMemo to support various types of credentials

### DIFF
--- a/full-service/src/service/transaction_builder.rs
+++ b/full-service/src/service/transaction_builder.rs
@@ -19,20 +19,19 @@ use crate::{
     },
     error::WalletTransactionBuilderError,
     service::models::{
-        transaction_memo::TransactionMemo,
+        transaction_memo::{TransactionMemo, TransactionMemoSignerCredentials},
         tx_blueprint_proposal::{TxBlueprintProposal, TxBlueprintProposalTxoContext},
         tx_proposal::{OutputTxo, UnsignedInputTxo, UnsignedTxProposal},
     },
     util::b58::b58_encode_public_address,
 };
-use mc_account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX};
+use mc_account_keys::{PublicAddress, DEFAULT_SUBADDRESS_INDEX};
 use mc_common::{logger::global_log, HashSet};
 use mc_crypto_ring_signature_signer::OneTimeKeyDeriveData;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_builder::{
-    DefaultTxOutputsOrdering, EmptyMemoBuilder, InputCredentials, ReservedSubaddresses,
-    TransactionBuilder,
+    DefaultTxOutputsOrdering, InputCredentials, ReservedSubaddresses, TransactionBuilder,
 };
 use mc_transaction_core::{
     constants::RING_SIZE,
@@ -42,7 +41,7 @@ use mc_transaction_core::{
 };
 use mc_util_uri::FogUri;
 use rand::Rng;
-use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+use std::{collections::BTreeMap, convert::TryInto, str::FromStr, sync::Arc};
 
 /// Default number of blocks used for calculating transaction tombstone block
 /// number.
@@ -590,10 +589,7 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
             &AccountID(tx_blueprint_proposal.account_id_hex.clone()),
             conn,
         )?;
-        build_unsigned_tx_from_blueprint_proposal(
-            &tx_blueprint_proposal,
-            &account.account_key().ok(),
-        )
+        build_unsigned_tx_from_blueprint_proposal(&tx_blueprint_proposal, &(&account).try_into()?)
     }
 
     /// Get rings.
@@ -662,12 +658,11 @@ impl<FPR: FogPubkeyResolver + 'static> WalletTransactionBuilder<FPR> {
 /// over.
 pub fn build_unsigned_tx_from_blueprint_proposal(
     tx_blueprint_proposal: &TxBlueprintProposal,
-    account_key: &Option<AccountKey>,
+    memo_builder_signer_credentials: &TransactionMemoSignerCredentials,
 ) -> Result<UnsignedTxProposal, WalletTransactionBuilderError> {
-    let memo_builder = match account_key {
-        Some(account_key) => tx_blueprint_proposal.memo.memo_builder(account_key),
-        None => Box::<EmptyMemoBuilder>::default(),
-    };
+    let memo_builder = tx_blueprint_proposal
+        .memo
+        .memo_builder(memo_builder_signer_credentials)?;
 
     let unsigned_tx = tx_blueprint_proposal
         .tx_blueprint

--- a/full-service/src/test_utils.rs
+++ b/full-service/src/test_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     error::SyncError,
     service::{
         models::{
-            transaction_memo::TransactionMemo,
+            transaction_memo::{TransactionMemo, TransactionMemoSignerCredentials},
             tx_proposal::{TxProposal, UnsignedTxProposal},
         },
         sync::sync_account_next_chunk,
@@ -411,7 +411,11 @@ pub fn create_test_txo_for_recipient_with_memo(
     let tx_private_key = RistrettoPrivate::from_random(rng);
     let hint = EncryptedFogHint::fake_onetime_hint(rng);
 
-    let mut memo_builder = memo.memo_builder(recipient_account_key);
+    let mut memo_builder = memo
+        .memo_builder(&TransactionMemoSignerCredentials::Local(
+            recipient_account_key.clone(),
+        ))
+        .unwrap();
 
     let tx_out = TxOut::new_with_memo(
         BlockVersion::MAX,


### PR DESCRIPTION
The purpose of this PR is to break the dependency`TransactionMemo` currently have on `AccountKey`, and instead replace it with a generic credentials enum (`TransactionMemoSignerCredentials`).
The main reason to do this is that it enables us to add a hardware wallet as the signer, which we do in a followup PR.