### PR TITLE
Rename some functions in preparation for a JSON tx blueprint API

### DIFF
--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -23,7 +23,9 @@ use crate::{
                 public_address::PublicAddress,
                 receiver_receipt::ReceiverReceipt,
                 transaction_log::TransactionLog,
-                tx_proposal::{TxProposal as TxProposalJSON, UnsignedTxProposal},
+                tx_proposal::{
+                    TxProposal as TxProposalJSON, UnsignedTxProposal as UnsignedTxProposalJSON,
+                },
                 txo::Txo,
                 wallet_status::WalletStatus,
             },
@@ -395,8 +397,8 @@ where
                 None => None,
             };
 
-            let unsigned_tx_proposal: UnsignedTxProposal = (&service
-                .build_transaction(
+            let unsigned_tx_proposal: UnsignedTxProposalJSON = (&service
+                .build_unsigned_transaction(
                     &account_id,
                     &[(
                         b58_encode_public_address(&burn_address()).map_err(format_error)?,
@@ -446,8 +448,8 @@ where
                 None => None,
             };
 
-            let unsigned_tx_proposal: UnsignedTxProposal = (&service
-                .build_transaction(
+            let unsigned_tx_proposal: UnsignedTxProposalJSON = (&service
+                .build_unsigned_transaction(
                     &account_id,
                     &addresses_and_amounts,
                     input_txo_ids.as_ref(),

--- a/full-service/src/service/gift_code.rs
+++ b/full-service/src/service/gift_code.rs
@@ -526,7 +526,7 @@ where
 
         let fee_value = fee.map(|f| f.to_string());
 
-        let unsigned_tx_proposal = self.build_transaction(
+        let unsigned_tx_proposal = self.build_unsigned_transaction(
             &from_account.id,
             &[(
                 gift_code_account_main_subaddress_b58,

--- a/full-service/src/service/models/tx_proposal.rs
+++ b/full-service/src/service/models/tx_proposal.rs
@@ -531,7 +531,7 @@ mod tests {
             .unwrap();
 
         let unsigned_tx_proposal = service
-            .build_transaction(
+            .build_unsigned_transaction(
                 &alice.id,
                 &[(
                     bob_address_from_alice.public_address_b58,

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -327,7 +327,7 @@ where
             ))
         }
 
-        let unsigned_transaction = self.build_transaction(
+        let unsigned_transaction = self.build_unsigned_transaction(
             &account_id_hex,
             &addresses_and_amounts,
             Some(&[txo_id.to_string()].to_vec()),


### PR DESCRIPTION
People using full-service with a hardware wallet might want to have an offline signing flow for sending transactions that include memos.

Currently, the offline signing flow is done by calling `build_unsigned_transaction` which builds an `UnsignedTxProposal` that is then signed using the standalone signer service (https://github.com/mobilecoinofficial/full-service/blob/main/signer/src/service/api/request.rs#L39). Memos are generated by `build_unsigned_transaction`, which means they do not have access to the account key when a hardware wallet is used.

Using the new `TxBlueprint`, we are able to provide full-service users with an API that produces a `TxBlueprint`, which they will then be able to hand off to the standalone signer service, at which point an `UnsignedTxProposal` followed by a signed `Tx` can be produced.

This PR is the first step in enabling that flow - it contains changes to the `TransactionService` that is used by the JSON API implementation to add support for working with `TxBlueprint`s. This gets used in follow-up PRs.