### PR TITLE
get_txo takes public key

### DIFF
--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -4154,8 +4154,7 @@ mod tests {
         let prefixed_hex = hex::encode(&db_txo.public_key);
         let bad_prefix = format!("0b20{}", &prefixed_hex[4..]);
 
-        let result =
-            Txo::get_by_public_key(&bad_prefix, &mut wallet_db.get_pooled_conn().unwrap());
+        let result = Txo::get_by_public_key(&bad_prefix, &mut wallet_db.get_pooled_conn().unwrap());
         assert_matches!(result, Err(WalletDbError::InvalidArgument(_)));
     }
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -1803,7 +1803,7 @@ impl TxoModel for Txo {
         // compatibility need to accept either format from the API's clients.
         let pubkey = match txo_pubkey.len() {
             68 => {
-                if !txo_pubkey.starts_with("0a20") {
+                if !txo_pubkey.to_ascii_lowercase().starts_with("0a20") {
                     return Err(WalletDbError::InvalidArgument(format!(
                         "public key {txo_pubkey} is not in a valid public key format"
                     )));
@@ -2006,7 +2006,7 @@ impl TxoModel for Txo {
         let mut total: u128 = 0;
         loop {
             if total >= target_value {
-                global_log::debug!("total is greater than target value");
+                global_log::debug!("total {} is greater than target_value {}", total, target_value);
                 break;
             }
 
@@ -4108,14 +4108,19 @@ mod tests {
         let db_txo = Txo::get(&txo_id, &mut wallet_db.get_pooled_conn().unwrap()).unwrap();
         let prefixed_hex = hex::encode(&db_txo.public_key);
         let raw_hex = hex::encode(db_txo.public_key().unwrap().as_bytes());
+        let prefixed_uppercase_hex = prefixed_hex.to_ascii_uppercase();
 
         let by_prefixed =
             Txo::get_by_public_key(&prefixed_hex, &mut wallet_db.get_pooled_conn().unwrap())
                 .unwrap();
+        let by_prefixed_uppercase =
+            Txo::get_by_public_key(&prefixed_uppercase_hex, &mut wallet_db.get_pooled_conn().unwrap())
+            .unwrap();
         let by_raw =
             Txo::get_by_public_key(&raw_hex, &mut wallet_db.get_pooled_conn().unwrap()).unwrap();
 
         assert_eq!(by_prefixed, db_txo);
+        assert_eq!(by_prefixed_uppercase, db_txo);
         assert_eq!(by_raw, db_txo);
     }
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -169,7 +169,7 @@ pub trait TxoModel {
     ///| `amount`               | The value in this TxOut                                                         | Unit in picoMob |
     ///| `received_block_index` | The index of the block at which this TxOut was received.                        |                 |
     ///| `account_id_hex`       | The account ID for the account which received this TxOut                        |                 |
-    ///| `conn`                 | An reference to the pool connection of wallet database                          |                 |
+    ///| `conn`                 | A reference to the pool connection of wallet database                           |                 |
     ///
     /// # Returns
     /// * txo_id_hex
@@ -193,7 +193,7 @@ pub trait TxoModel {
     ///| `output_txo`     | This is the transaction output TxOut that will be insert to database                  | Either a change or payload transaction output TxOut |
     ///| `is_change`      | A boolean value to indicate if this transaction output TxOut is a change or a payload | Assign if known                                     |
     ///| `transaction_id` | The transaction id at which the transaction output TxOut associates with              |                                                     |
-    ///| `conn`           | An reference to the pool connection of wallet database                                |                                                     |
+    ///| `conn`           | A reference to the pool connection of wallet database                                 |                                                     |
     ///
     /// # Returns
     /// * unit
@@ -220,7 +220,7 @@ pub trait TxoModel {
     ///| `public_key`         | The per output tx public key                                                                                    |                 |
     ///| `e_fog_hint`         | The encrypted fog hint for the fog ingest server.                                                               |                 |
     ///| `shared_secret`      | A cryptographic key shared between the sender and recipient that is used to decrypt the TxOut's amount and memo |                 |
-    ///| `conn`               | An reference to the pool connection of wallet database                                                          |                 |
+    ///| `conn`               | A reference to the pool connection of wallet database                                                           |                 |
     ///
     /// # Returns
     /// * unit
@@ -248,7 +248,7 @@ pub trait TxoModel {
     ///|---------------------|--------------------------------------------------------|-------|
     ///| `txo_id_hex`        | The id of the TxOut object that will be updated        |       |
     ///| `spent_block_index` | The index of block where the TxOut was spent           |       |
-    ///| `conn`              | An reference to the pool connection of wallet database |       |
+    ///| `conn`              | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns
     /// * unit
@@ -267,7 +267,7 @@ pub trait TxoModel {
     ///| `txo_id_hex`        | The id of the TxOut object that will be updated        |       |
     ///| `key_image`         | The fingerprint of the TxOut                           |       |
     ///| `spent_block_index` | The index of block where the TxOut was spent           |       |
-    ///| `conn`              | An reference to the pool connection of wallet database |       |
+    ///| `conn`              | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns
     /// * unit
@@ -298,7 +298,7 @@ pub trait TxoModel {
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.                                                                 |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                                                                                |
     ///| `token_id`                 | The id of a supported type of token to filter on              |                                                                                          |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                                                                          |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                                                                          |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -325,7 +325,7 @@ pub trait TxoModel {
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.                                                                 |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                                                                                |
     ///| `token_id`                 | The id of a supported type of token to filter on              |                                                                                          |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                                                                          |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                                                                          |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -354,7 +354,7 @@ pub trait TxoModel {
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.                                                                 |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                                                                                |
     ///| `token_id`                 | The id of a supported type of token to filter on              |                                                                                          |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                                                                          |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                                                                          |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -378,7 +378,7 @@ pub trait TxoModel {
     ///|------------------|--------------------------------------------------------|-------------------------------------|
     ///| `account_id_hex` | The account id where the key images and Txos from      | Account must exist in the database. |
     ///| `token_id`       | The id of a supported type of token to filter on       |                                     |
-    ///| `conn`           | An reference to the pool connection of wallet database |                                     |
+    ///| `conn`           | A reference to the pool connection of wallet database  |                                     |
     ///
     /// # Returns
     /// * A hashmap of a KeyImage key and a TxOut id string
@@ -401,7 +401,7 @@ pub trait TxoModel {
     ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive |                                                                                          |
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.                                                                 |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                                                                                |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                                                                          |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                                                                          |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -430,7 +430,7 @@ pub trait TxoModel {
     ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive |                                      |
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.             |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                            |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                      |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                      |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -458,7 +458,7 @@ pub trait TxoModel {
     ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive |                                      |
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.             |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                            |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                      |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                      |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -485,7 +485,7 @@ pub trait TxoModel {
     ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive |                                      |
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.             |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                            |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                      |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                      |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -514,7 +514,7 @@ pub trait TxoModel {
     ///| `max_received_block_index` | The maximum block index to query for received txos, inclusive |                                      |
     ///| `offset`                   | The pagination offset. Results start at the offset index.     | Optional. Defaults to 0.             |
     ///| `limit`                    | Limit for the number of results.                              | Optional.                            |
-    ///| `conn`                     | An reference to the pool connection of wallet database        |                                      |
+    ///| `conn`                     | A reference to the pool connection of wallet database         |                                      |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -541,7 +541,7 @@ pub trait TxoModel {
     ///| `max_spendable_value`     | The upper limit for the spendable TxOut value to filter on |                                     |
     ///| `assigned_subaddress_b58` | The subaddress at which the list of Txos from              |                                     |
     ///| `token_id`                | The id of a supported type of token to filter on           |                                     |
-    ///| `conn`                    | An reference to the pool connection of wallet database     |                                     |
+    ///| `conn`                    | A reference to the pool connection of wallet database      |                                     |
     ///
     ///
     /// # Returns
@@ -563,7 +563,7 @@ pub trait TxoModel {
     ///| Name             | Purpose                                                | Notes                               |
     ///|------------------|--------------------------------------------------------|-------------------------------------|
     ///| `account_id_hex` | The account id where the Txos from                     | Account must exist in the database. |
-    ///| `conn`           | An reference to the pool connection of wallet database |                                     |
+    ///| `conn`           | A reference to the pool connection of wallet database  |                                     |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -577,7 +577,7 @@ pub trait TxoModel {
     ///|------------------|--------------------------------------------------------|-------------------------------------|
     ///| `account_id_hex` | The account id where the Txos from                     | Account must exist in the database. |
     ///| `token_id`       | The id of a supported type of token to filter on       |                                     |
-    ///| `conn`           | An reference to the pool connection of wallet database |                                     |
+    ///| `conn`           | A reference to the pool connection of wallet database  |                                     |
     ///
     /// # Returns
     /// * Vector of TxoOut
@@ -590,7 +590,7 @@ pub trait TxoModel {
     ///| Name         | Purpose                                                | Notes |
     ///|--------------|--------------------------------------------------------|-------|
     ///| `txo_id_hex` | The TxOut id from which to retrieve a TxOut            |       |
-    ///| `conn`       | An reference to the pool connection of wallet database |       |
+    ///| `conn`       | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns:
     /// * TxOut
@@ -603,7 +603,7 @@ pub trait TxoModel {
     ///| Name         | Purpose                                                | Notes |
     ///|--------------|--------------------------------------------------------|-------|
     ///| `txo_pubkey` | The TxOut public key from which to retrieve a TxOut    |       |
-    ///| `conn`       | An reference to the pool connection of wallet database |       |
+    ///| `conn`       | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns:
     /// * TxOut
@@ -616,7 +616,7 @@ pub trait TxoModel {
     ///| Name          | Purpose                                                | Notes |
     ///|---------------|--------------------------------------------------------|-------|
     ///| `public_keys` | The public key where to retrieve Txos from             |       |
-    ///| `conn`        | An reference to the pool connection of wallet database |       |
+    ///| `conn`        | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns:
     /// * Vector of TxoOut
@@ -632,7 +632,7 @@ pub trait TxoModel {
     ///| Name      | Purpose                                                | Notes |
     ///|-----------|--------------------------------------------------------|-------|
     ///| `txo_ids` | The list of TxOut IDs from which to retrieve Txos      |       |
-    ///| `conn`    | An reference to the pool connection of wallet database |       |
+    ///| `conn`    | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns:
     /// * Vector of TxoOut
@@ -650,7 +650,7 @@ pub trait TxoModel {
     ///| `assigned_subaddress_b58`  | The subaddress where the spendable Txos can be sourced from |                                      |
     ///| `token_id`            | The id of a supported type of token to filter on           |                                     |
     ///| `default_token_fee`   | The default transaction fee in Mob network                 |                                     |
-    ///| `conn`                | An reference to the pool connection of wallet database     |                                     |
+    ///| `conn`                | A reference to the pool connection of wallet database      |                                     |
     ///
     /// # Returns:
     /// * Vector of TxoOut
@@ -673,7 +673,7 @@ pub trait TxoModel {
     ///| `account_id`   | The account id used to retrieve the account key                | Account must exist in the database. |
     ///| `txo_id_hex`   | The TxOut id used to retrieve the TxOut public_key             |                                     |
     ///| `confirmation` | The confirmation to valid the TxOut public_key and account key |                                     |
-    ///| `conn`         | An reference to the pool connection of wallet database         |                                     |
+    ///| `conn`         | A reference to the pool connection of wallet database          |                                     |
     ///
     /// # Returns:
     /// * Bool - true if verified
@@ -691,7 +691,7 @@ pub trait TxoModel {
     ///| Name         | Purpose                                                                               | Notes |
     ///|--------------|---------------------------------------------------------------------------------------|-------|
     ///| `account_id` | The account id needs to be removed from all Txos at which the account associates to   |       |
-    ///| `conn`       | An reference to the pool connection of wallet database                                |       |
+    ///| `conn`       | A reference to the pool connection of wallet database                                 |       |
     ///
     /// # Returns
     /// * unit
@@ -703,7 +703,7 @@ pub trait TxoModel {
     ///
     ///| Name   | Purpose                                                | Notes |
     ///|--------|--------------------------------------------------------|-------|
-    ///| `conn` | An reference to the pool connection of wallet database |       |
+    ///| `conn` | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns
     /// * unit
@@ -715,7 +715,7 @@ pub trait TxoModel {
     ///
     ///| Name   | Purpose                                                | Notes |
     ///|--------|--------------------------------------------------------|-------|
-    ///| `conn` | An reference to the pool connection of wallet database |       |
+    ///| `conn` | A reference to the pool connection of wallet database  |       |
     ///
     /// # Returns
     /// * TxoStatus
@@ -740,12 +740,12 @@ pub trait TxoModel {
     ///
     /// # Arguments
     ///
-    ///| Name        | Purpose                                                   | Notes                                     |
-    ///|-------------|-----------------------------------------------------------|-------------------------------------------|
-    ///| `public_key` | The compressed ristretto public to use to search for the txo. | |
-    ///| `key_image` | The Key Image to add to the txo. | |
-    ///| `spent_block_index` | The spent block index to update for the txo. |  |
-    ///| `conn` | A reference to the connection of wallet database |  |
+    ///| Name                | Purpose                                                       | Notes |
+    ///|---------------------|---------------------------------------------------------------|-------|
+    ///| `public_key`        | The compressed ristretto public to use to search for the txo. |       |
+    ///| `key_image`         | The Key Image to add to the txo.                              |       |
+    ///| `spent_block_index` | The spent block index to update for the txo.                  |       |
+    ///| `conn`              | A reference to the connection of wallet database              |       |
     ///
     /// # Returns
     /// * unit
@@ -2006,7 +2006,11 @@ impl TxoModel for Txo {
         let mut total: u128 = 0;
         loop {
             if total >= target_value {
-                global_log::debug!("total {} is greater than target_value {}", total, target_value);
+                global_log::debug!(
+                    "total {} is greater than target_value {}",
+                    total,
+                    target_value
+                );
                 break;
             }
 
@@ -4113,9 +4117,11 @@ mod tests {
         let by_prefixed =
             Txo::get_by_public_key(&prefixed_hex, &mut wallet_db.get_pooled_conn().unwrap())
                 .unwrap();
-        let by_prefixed_uppercase =
-            Txo::get_by_public_key(&prefixed_uppercase_hex, &mut wallet_db.get_pooled_conn().unwrap())
-            .unwrap();
+        let by_prefixed_uppercase = Txo::get_by_public_key(
+            &prefixed_uppercase_hex,
+            &mut wallet_db.get_pooled_conn().unwrap(),
+        )
+        .unwrap();
         let by_raw =
             Txo::get_by_public_key(&raw_hex, &mut wallet_db.get_pooled_conn().unwrap()).unwrap();
 

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -602,7 +602,7 @@ pub trait TxoModel {
     ///
     ///| Name         | Purpose                                                | Notes |
     ///|--------------|--------------------------------------------------------|-------|
-    ///| `txo_pubkey` | The TxOut publicKey from which to retrieve a TxOut     |       |
+    ///| `txo_pubkey` | The TxOut public key from which to retrieve a TxOut    |       |
     ///| `conn`       | An reference to the pool connection of wallet database |       |
     ///
     /// # Returns:

--- a/full-service/src/db/txo.rs
+++ b/full-service/src/db/txo.rs
@@ -596,6 +596,18 @@ pub trait TxoModel {
     /// * TxOut
     fn get(txo_id_hex: &str, conn: Conn) -> Result<Txo, WalletDbError>;
 
+    /// Get the details for a specific Txo using its public_key.
+    ///
+    /// # Arguments
+    ///
+    ///| Name         | Purpose                                                | Notes |
+    ///|--------------|--------------------------------------------------------|-------|
+    ///| `txo_pubkey` | The TxOut publicKey from which to retrieve a TxOut     |       |
+    ///| `conn`       | An reference to the pool connection of wallet database |       |
+    ///
+    /// # Returns:
+    /// * TxOut
+    fn get_by_public_key(txo_pubkey: &str, conn: Conn) -> Result<Txo, WalletDbError>;
 
     /// Get several Txos by Txo public_keys
     ///
@@ -1773,6 +1785,47 @@ impl TxoModel for Txo {
             Ok(t) => t,
             Err(diesel::result::Error::NotFound) => {
                 return Err(WalletDbError::TxoNotFound(txo_id_hex.to_string()));
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+
+        Ok(txo)
+    }
+
+    fn get_by_public_key(txo_pubkey: &str, conn: Conn) -> Result<Txo, WalletDbError> {
+        use crate::db::schema::txos;
+
+        // txo public_keys are 256 bits, but as *currently* stored in the db have a protobuf prefix
+        // of 0a20 prepended. We are in transition to unwrapping the protobuf notation wherever we
+        // can but for back/forward compatibility need to accept either format from the
+        // API's clients.
+        let pubkey = match txo_pubkey.len() {
+            68 => {
+                if !txo_pubkey.starts_with("0a20") {
+                    return Err(WalletDbError::InvalidArgument(format!("public key {txo_pubkey} is not in a valid public key format")))
+                }
+                txo_pubkey.to_string()
+            },
+            64 => {
+                format!("0a20{}", txo_pubkey)
+            },
+            _ => {
+                return Err(WalletDbError::InvalidArgument(format!("public key {txo_pubkey} is the wrong length")))
+            }
+        };
+
+        let public_key_blob: Vec<u8> = hex::decode(pubkey)
+        .map_err(|e| WalletDbError::InvalidArgument(format!("Invalid hex encoded public key: {txo_pubkey}: {e}")))?;
+
+        let txo = match txos::table
+            .filter(txos::public_key.eq(public_key_blob))
+            .get_result::<Txo>(conn)
+        {
+            Ok(t) => t,
+            Err(diesel::result::Error::NotFound) => {
+                return Err(WalletDbError::TxoNotFound(txo_pubkey.to_string()));
             }
             Err(e) => {
                 return Err(e.into());

--- a/full-service/src/json_rpc/v1/api/wallet.rs
+++ b/full-service/src/json_rpc/v1/api/wallet.rs
@@ -799,8 +799,8 @@ where
         JsonCommandRequest::get_transaction_log { transaction_log_id } => {
             // Check whether the transaction_log_id actually refers to the txo_id of a
             // received transaction.
-            let txo_id = TxoID(transaction_log_id.clone());
-            let json_tx_log = if let Ok(txo_info) = service.get_txo(&txo_id) {
+            let txo_id = transaction_log_id.clone();
+            let json_tx_log = if let Ok(txo_info) = service.get_txo(Some(txo_id), None) {
                 // A txo was found, determine which address it was received at, if any.
                 let subaddress_b58 =
                     match (&txo_info.txo.subaddress_index, &txo_info.txo.account_id) {
@@ -931,7 +931,7 @@ where
             }
         }
         JsonCommandRequest::get_txo { txo_id } => {
-            let txo_info = service.get_txo(&TxoID(txo_id)).map_err(format_error)?;
+            let txo_info = service.get_txo(Some(txo_id), None).map_err(format_error)?;
             JsonCommandResponse::get_txo {
                 txo: Txo::from(&txo_info),
             }

--- a/full-service/src/json_rpc/v2/api/request.rs
+++ b/full-service/src/json_rpc/v2/api/request.rs
@@ -228,7 +228,8 @@ pub enum JsonCommandRequest {
         outputs: Vec<JsonTxOut>,
     },
     get_txo {
-        txo_id: String,
+        txo_id: Option<String>,
+        txo_public_key: Option<String>,
     },
     get_txos {
         account_id: Option<String>,

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1105,8 +1105,8 @@ where
                 transaction_log_map,
             }
         }
-        JsonCommandRequest::get_txo { txo_id } => {
-            let txo_info = service.get_txo(&TxoID(txo_id)).map_err(format_error)?;
+        JsonCommandRequest::get_txo { txo_id, txo_public_key } => {
+            let txo_info = service.get_txo(txo_id, txo_public_key).map_err(format_error)?;
             JsonCommandResponse::get_txo {
                 txo: (&txo_info).into(),
             }

--- a/full-service/src/json_rpc/v2/api/wallet.rs
+++ b/full-service/src/json_rpc/v2/api/wallet.rs
@@ -1105,8 +1105,13 @@ where
                 transaction_log_map,
             }
         }
-        JsonCommandRequest::get_txo { txo_id, txo_public_key } => {
-            let txo_info = service.get_txo(txo_id, txo_public_key).map_err(format_error)?;
+        JsonCommandRequest::get_txo {
+            txo_id,
+            txo_public_key,
+        } => {
+            let txo_info = service
+                .get_txo(txo_id, txo_public_key)
+                .map_err(format_error)?;
             JsonCommandResponse::get_txo {
                 txo: (&txo_info).into(),
             }

--- a/full-service/src/service/confirmation_number.rs
+++ b/full-service/src/service/confirmation_number.rs
@@ -152,7 +152,7 @@ where
 
         let mut results = Vec::new();
         for (associated_txo, _) in associated_txos.outputs {
-            let txo_info = self.get_txo(&TxoID(associated_txo.id.clone()))?;
+            let txo_info = self.get_txo(Some(associated_txo.id.clone()), None)?;
             if let Some(confirmation) = txo_info.txo.confirmation {
                 let confirmation: TxOutConfirmationNumber = mc_util_serial::decode(&confirmation)?;
                 let pubkey: CompressedRistrettoPublic =

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -294,13 +294,24 @@ where
         Ok(txo_infos)
     }
 
-    fn get_txo(&self, txo_id: Option<String>, txo_public_key: Option<String>) -> Result<TxoInfo, TxoServiceError> {
+    fn get_txo(
+        &self,
+        txo_id: Option<String>,
+        txo_public_key: Option<String>,
+    ) -> Result<TxoInfo, TxoServiceError> {
         let mut pooled_conn = self.get_pooled_conn()?;
         let conn = pooled_conn.deref_mut();
 
         let txo = match (txo_id.as_deref(), txo_public_key.as_deref()) {
-            (None, None) => return Err(TxoServiceError::InvalidQuery("missing parameter: must include one of txo_id or txo_public_key".to_string())),
-            (Some(_), Some(_)) => return Err(TxoServiceError::InvalidQuery("mutually exclusive parameters: can include only one of txo_id and txo_public_key".to_string())),
+            (None, None) => {
+                return Err(TxoServiceError::InvalidQuery(
+                    "missing parameter: must include one of txo_id or txo_public_key".to_string(),
+                ))
+            }
+            (Some(_), Some(_)) => return Err(TxoServiceError::InvalidQuery(
+                "mutually exclusive parameters: can include only one of txo_id and txo_public_key"
+                    .to_string(),
+            )),
             (None, Some(public_key)) => Txo::get_by_public_key(public_key, conn)?,
             (Some(id), None) => Txo::get(id, conn)?,
         };

--- a/full-service/src/service/txo.rs
+++ b/full-service/src/service/txo.rs
@@ -526,4 +526,78 @@ mod tests {
         assert_eq!(balance_pmob.spent, 0);
         assert_eq!(balance_pmob.orphaned, 0);
     }
+
+    #[async_test_with_logger]
+    async fn test_get_txo_by_id_and_public_key(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([21u8; 32]);
+
+        let known_recipients: Vec<PublicAddress> = Vec::new();
+        let mut ledger_db = get_test_ledger(5, &known_recipients, 12, &mut rng);
+
+        let service = setup_wallet_service(ledger_db.clone(), None, logger.clone());
+        let alice = service
+            .create_account(
+                Some("Alice's Main Account".to_string()),
+                "".to_string(),
+                "".to_string(),
+                false,
+            )
+            .unwrap();
+
+        let alice_account_key: AccountKey = mc_util_serial::decode(&alice.account_key).unwrap();
+        let alice_account_id = AccountID::from(&alice_account_key);
+        let alice_public_address = alice_account_key.default_subaddress();
+        add_block_to_ledger_db(
+            &mut ledger_db,
+            &vec![alice_public_address],
+            100 * MOB,
+            &[KeyImage::from(rng.next_u64())],
+            &mut rng,
+        );
+
+        manually_sync_account(
+            &ledger_db,
+            service.wallet_db.as_ref().unwrap(),
+            &alice_account_id,
+            &logger,
+        );
+
+        let txos = service
+            .list_txos(
+                Some(alice_account_id.to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(txos.len(), 1);
+        let txo_id = txos[0].txo.id.clone();
+        let txo_public_key = hex::encode(&txos[0].txo.public_key);
+
+        let by_id = service.get_txo(Some(txo_id.clone()), None).unwrap();
+        assert_eq!(by_id.txo.id, txo_id);
+
+        let by_public_key = service.get_txo(None, Some(txo_public_key.clone())).unwrap();
+        assert_eq!(by_public_key.txo.id, txo_id);
+
+        match service.get_txo(None, None) {
+            Err(TxoServiceError::InvalidQuery(msg)) => assert_eq!(
+                msg,
+                "missing parameter: must include one of txo_id or txo_public_key"
+            ),
+            other => panic!("Expected InvalidQuery error, got: {:?}", other),
+        }
+
+        match service.get_txo(Some(txo_id), Some(txo_public_key)) {
+            Err(TxoServiceError::InvalidQuery(msg)) => assert_eq!(
+                msg,
+                "mutually exclusive parameters: can include only one of txo_id and txo_public_key"
+            ),
+            other => panic!("Expected InvalidQuery error, got: {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

The full-service API is currently limited to retrieve txos from the wallet via `txo_id`.  As `txo_id` is a full-service internal identifier, it currently requires downloading all wallet txos and iterating over them to find if there is a txo in the wallet that is know by the more universal `txo_public_key` unique identifier.
### In this PR
* enhances the `get_txo` method to accept either a `txo_id` param, or a `txo_public_key` param.
* `txo_public_key` is passed as a hex string and can include the 0a20 protobuf prefix as `txo_public_keys `are returned this way as part of some full-service api responses, but can also be a prefixless 64 character hex `txo_public_key` as displayed by the block explorer.

### Test Plan

* unit tests added to ensure exactly one of `txo_id` or `txo_public_key` are accepted by the API, and if neither or both are provided an error is returned as the api response.
* unit tests added to  ensure both `txo_id` and `txo_public_key` varients perform as expected, and the `public_key` can either have, or not have the 0a20 prefix.