### PR TITLE
increase startup wait time  to allow for large/slow ledger downloads

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -97,6 +97,10 @@ jobs:
         additional_keys: -lintrust
         path: .dummy
 
+    - name: Install 1.85.0 toolchain (for cargo-sort only)
+      run: |
+        rustup toolchain install 1.85.0 --no-self-update --profile minimal
+
     - name: Cargo sort
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -101,8 +101,8 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        # pin cargo sort to version 1.0.9 because v2.x require newer rustc than we use
-        cargo install cargo-sort --version 1.0.9 --force
+        # the latest cargo-sort and clap_lex require at rust 1.85.0, which we aren't ready to use for building
+        cargo +1.85.0 install cargo-sort
         cargo sort --workspace --grouped --check
 
     - name: Cargo fmt

--- a/.internal-ci/helm/full-service/templates/full-service-statefulSet.yaml
+++ b/.internal-ci/helm/full-service/templates/full-service-statefulSet.yaml
@@ -56,23 +56,23 @@ spec:
           httpGet:
             path: /health
             port: full-service
-          failureThreshold: 300
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          failureThreshold: {{ .Values.fullService.startupProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.fullService.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.fullService.startupProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             path: /health
             port: full-service
-          failureThreshold: 2
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          failureThreshold: {{ .Values.fullService.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.fullService.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.fullService.readinessProbe.periodSeconds }}
         livenessProbe:
           httpGet:
             path: /health
             port: full-service
-          failureThreshold: 10
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          failureThreshold: {{ .Values.fullService.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.fullService.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.fullService.livenessProbe.periodSeconds }}
         volumeMounts:
         - name: data
           mountPath: /data

--- a/.internal-ci/helm/full-service/values.yaml
+++ b/.internal-ci/helm/full-service/values.yaml
@@ -64,6 +64,18 @@ fullService:
   secret:
     name: full-service
     stringData: {}
+  startupProbe:
+    failureThreshold: 1440 # 4 hours with a 10 second period
+    initialDelaySeconds: 10
+    periodSeconds: 10
+  readinessProbe:
+    failureThreshold: 2
+    initialDelaySeconds: 5
+    periodSeconds: 5
+  livenessProbe:
+    failureThreshold: 10
+    initialDelaySeconds: 5
+    periodSeconds: 5
 
 backupsSidecar:
   enabled: false

--- a/full-service/Cargo.toml
+++ b/full-service/Cargo.toml
@@ -105,6 +105,17 @@ strum_macros = "0.25.1"
 tiny-bip39 = "1.0"
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 
+[build-dependencies]
+anyhow = "1.0"
+vergen = { version = "8.2.6", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+    "si",
+] }
+
 [dev-dependencies]
 mc-blockchain-test-utils = { path = "../mobilecoin/blockchain/test-utils" }
 mc-connection-test-utils = { path = "../mobilecoin/connection/test-utils" }
@@ -122,14 +133,3 @@ tempdir = "0.3"
 tokio = "1.27"
 url = "2.3"
 yare = "3"
-
-[build-dependencies]
-anyhow = "1.0"
-vergen = { version = "8.2.6", features = [
-    "build",
-    "cargo",
-    "git",
-    "gitcl",
-    "rustc",
-    "si",
-] }

--- a/mirror/Cargo.toml
+++ b/mirror/Cargo.toml
@@ -42,10 +42,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
 
-[dev-dependencies]
-rand_core = { version = "0.6", default-features = false }
-rand_hc = "0.3"
-
 [build-dependencies]
 mc-util-build-grpc = { path = "../mobilecoin/util/build/grpc" }
 mc-util-build-script = { path = "../mobilecoin/util/build/script" }
@@ -57,3 +53,7 @@ serde = { version = "1", default-features = false, features = [
     "alloc",
     "derive",
 ] }
+
+[dev-dependencies]
+rand_core = { version = "0.6", default-features = false }
+rand_hc = "0.3"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/hardware_service/bin/main.rs"
 [dependencies]
 mc-account-keys = { path = "../mobilecoin/account-keys" }
 mc-common = { path = "../mobilecoin/common", default-features = false, features = ["loggers"] }
-mc-core = { path = "../mobilecoin/core", features = [ "serde" ] }
-mc-core-types = { path = "../mobilecoin/core/types", features = [ "serde" ] }
+mc-core = { path = "../mobilecoin/core", features = ["serde"] }
+mc-core-types = { path = "../mobilecoin/core/types", features = ["serde"] }
 mc-crypto-keys = { path = "../mobilecoin/crypto/keys", default-features = false }
 mc-crypto-ring-signature = { path = "../mobilecoin/crypto/ring-signature" }
 mc-crypto-ring-signature-signer = { path = "../mobilecoin/crypto/ring-signature/signer" }
@@ -38,7 +38,7 @@ ledger-mob = { path = "../ledger-mob/lib" }
 
 anyhow = "1.0.75"
 base64 = "0.21.5"
-clap = { version = "4.4", features = [ "derive" ] }
+clap = { version = "4.4", features = ["derive"] }
 displaydoc = { version = "0.2", default-features = false }
 hex = { version = "0.4", default-features = false }
 log = "0.4.19"


### PR DESCRIPTION

### Motivation

Set 4 hour time out for large initial ledger mdb file archive downloads.  This usually takes 20-30 minuets, but times can vary.  Make these timeouts configurable. 


### In this PR
* make k8s pod probes configurable with helm values.
* set default startup probe for up to 4 hours.  



